### PR TITLE
02 World: Adventure/Expedition 월드 루프 안정화

### DIFF
--- a/src/GuardianExpeditionOverlay.tsx
+++ b/src/GuardianExpeditionOverlay.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { currentAdvancedTalents, masteryLevel, type ExpeditionActionCounts, type ExpeditionCraftingRecipeId, type ExpeditionRelicId, type ExpeditionStageId, type GameState } from './game';
 import { applyExpeditionAction, finishExpeditionBattle, startExpeditionBattle, type ExpeditionActionKind, type ExpeditionBattleState } from './expedition-combat';
-import { craftingRecipes } from './expedition-crafting';
+import { canCraft, craftingRecipes } from './expedition-crafting';
 import { expeditionDiscoveryDefinitions } from './expedition-discoveries';
 import { expeditionRegionDefinitions, expeditionStageDefinitions, isExpeditionStageCleared, isExpeditionStageUnlocked, nextExpeditionStage } from './expedition-regions';
 import { expeditionRelicDefinitions, relicModifiers } from './expedition-relics';
@@ -95,7 +95,7 @@ export default function GuardianExpeditionOverlay({ state, open, onOpen, onClose
   const [view, setView] = useState<View>('map');
   const [activeStage, setActiveStage] = useState<ExpeditionStageId>(() => nextExpeditionStage(state.expeditionRecords) ?? 'forest_path');
   const cleared = expeditionStageDefinitions.filter(stage => isExpeditionStageCleared(state.expeditionRecords[stage.id])).length;
-  const bosses = ['forest_guardian', 'city_core', 'lake_tempest'].filter(id => state.rewardedExpeditionStages.includes(id as ExpeditionStageId)).length;
+  const bosses = expeditionStageDefinitions.filter(stage => stage.boss && isExpeditionStageCleared(state.expeditionRecords[stage.id])).length;
   const recommended = nextExpeditionStage(state.expeditionRecords);
   const world = worldUiSummary(state);
 
@@ -127,17 +127,17 @@ export default function GuardianExpeditionOverlay({ state, open, onOpen, onClose
       <img className="expedition-result-burst" src="/assets/effects/success_burst.png" alt=""/>
       <small>EXPEDITION RECORD</small><h2>{stage.name}</h2>
       <strong className={`expedition-grade grade-${result?.grade ?? 'C'}`}>{result?.grade ?? '...'}</strong>
-      <p>{result ? `최고 기록이 원정 연대기에 저장됐어요.` : '원정 기록을 정리하고 있어요.'}</p>
+      <p>{result ? result.cleared ? '최고 기록이 원정 연대기에 저장됐어요.' : `목표 ${stage.target}점에 못 미쳤어요. 기록을 보완해 다시 도전하세요.` : '원정 기록을 정리하고 있어요.'}</p>
       {result && <div className="expedition-result-grid">
-        <span><b>첫 클리어</b>{result.firstClear ? '달성' : '재도전'}</span>
+        <span><b>클리어</b>{!result.cleared ? '실패' : result.firstClear ? '첫 달성' : '재도전 성공'}</span>
         <span><b>재료</b>+{result.materialReward}</span>
-        <span><b>스토리</b>{result.storyUnlocked ? '새 장면' : '기록됨'}</span>
+        <span><b>스토리</b>{!result.cleared ? '-' : result.storyUnlocked ? '새 장면' : '기록됨'}</span>
         <span><b>발견</b>{discovery?.label ?? '없음'}</span>
         <span><b>보스 휘장</b>{result.bossBadge ? '획득' : '-'}</span>
         <span><b>유물</b>{result.relicsUnlocked.length ? result.relicsUnlocked.length + '개' : '-'}</span>
         {calling && <span><b>Calling</b>{calling.label} · Lv.{mastery}</span>}
       </div>}
-      {worldResult && <div className="expedition-world-result">
+      {result?.cleared && worldResult && <div className="expedition-world-result">
         <small>WORLD PROGRESS</small>
         <div><b>{worldResult.regionLabel} 명성</b><span>{worldResult.renownLabel}</span></div>
         <div><b>계절 원정</b><span>{worldResult.seasonLabel}</span></div>
@@ -170,7 +170,17 @@ export default function GuardianExpeditionOverlay({ state, open, onOpen, onClose
         const equipped = state.equippedExpeditionRelics.includes(relic.id);
         return <button key={relic.id} disabled={!owned} onClick={() => equipped ? onUnequip(relic.id) : onEquip(relic.id)}><b>{owned ? relic.label : '미발견 유물'}<small>{relic.description}</small></b><i>{equipped ? '해제' : owned ? '장착' : '잠김'}</i></button>;
       })}</article>
-      <article><h3>원정 제작소</h3>{craftingRecipes.map(recipe => <button key={recipe.id} onClick={() => onCraft(recipe.id)}><b>{recipe.label}<small>{Object.entries(recipe.costs).map(([id, value]) => `${materialLabels[id as keyof typeof materialLabels]} ${value}`).join(' · ')}</small></b><i>제작</i></button>)}</article>
+      <article><h3>원정 제작소</h3>{craftingRecipes.map(recipe => {
+        const completed = Boolean(recipe.relic && (
+          state.ownedExpeditionRelics.includes(recipe.relic)
+          || state.craftingMilestones.includes(recipe.milestone)
+        ));
+        const craftable = canCraft(recipe.id, state.expeditionMaterials, {
+          craftingMilestones:state.craftingMilestones,
+          ownedRelics:state.ownedExpeditionRelics,
+        });
+        return <button key={recipe.id} disabled={!craftable} onClick={() => onCraft(recipe.id)}><b>{recipe.label}<small>{Object.entries(recipe.costs).map(([id, value]) => `${materialLabels[id as keyof typeof materialLabels]} ${value}`).join(' · ')}</small></b><i>{completed ? '제작 완료' : craftable ? '제작' : '재료 부족'}</i></button>;
+      })}</article>
     </div>
     <footer><span>스토리 {state.expeditionStoryEntries.length}/9</span><span>발견 {state.expeditionDiscoveries.length}/9</span><span>유물 {state.ownedExpeditionRelics.length}/6</span></footer>
   </section></div>;

--- a/src/adventure-expedition-loop.test.ts
+++ b/src/adventure-expedition-loop.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { pickExplorationOutcome } from './adventure';
+import { effectivePathfinderExplorationXp, specialistMasteryCalling } from './calling-depth-effects';
+import { resolveExpeditionFinish } from './expedition-rewards';
+import { emptyExpeditionPersistentState } from './expedition-state';
+import { regionalRenownLevel, renownGainForExpedition } from './regional-renown';
+import { worldEvent, worldEventExpeditionBonus } from './world-event';
+
+const base = () => ({
+  ...emptyExpeditionPersistentState(),
+  gold:0,
+  gems:0,
+  affection:0,
+  inventory:{ star_cookie:0, herb_tea:0, fox_charm:0 },
+});
+
+describe('adventure → exploration → guardian expedition loop', () => {
+  it('keeps exploration, boss mastery, replay rewards and featured event progress aligned', () => {
+    expect(pickExplorationOutcome('forest',0,[],0.5).discovery).toBeNull();
+    const acceleratedXp = effectivePathfinderExplorationXp(0,'pathfinder',['pathfinder_eye']);
+    expect(acceleratedXp).toBe(3);
+    expect(pickExplorationOutcome('forest',acceleratedXp,[],0.5).discovery).toBe('moon_feather');
+
+    let state = base();
+    const path = resolveExpeditionFinish(state,'forest_path',700);
+    expect(path.summary.firstClear).toBe(true);
+    state = path.state;
+    const glade = resolveExpeditionFinish(state,'forest_glade',850);
+    expect(glade.summary.firstClear).toBe(true);
+    state = glade.state;
+
+    const boss = resolveExpeditionFinish(state,'forest_guardian',840);
+    expect(boss.summary.grade).toBe('B');
+    expect(boss.summary.cleared).toBe(true);
+    expect(boss.summary.regionCompleted).toBe('starlight_forest');
+    expect(specialistMasteryCalling(
+      'pathfinder',
+      { attack:1, dodge:1, charge:1 },
+      boss.summary,
+    )).toBe('pathfinder');
+
+    const renown = renownGainForExpedition(path.summary.grade,false)
+      + renownGainForExpedition(glade.summary.grade,false)
+      + renownGainForExpedition(boss.summary.grade,true);
+    expect(renown).toBe(7);
+    expect(regionalRenownLevel(renown)).toBe(2);
+
+    const event = worldEvent(1,4);
+    expect(event.region).toBe('starlight_forest');
+    expect(worldEventExpeditionBonus(event,'starlight_forest',boss.summary.grade)).toEqual({ seasonPoints:5, materialBonus:0 });
+
+    const replay = resolveExpeditionFinish(boss.state,'forest_guardian',840);
+    expect(replay.summary.cleared).toBe(true);
+    expect(replay.summary.firstClear).toBe(false);
+    expect(replay.state.gold).toBe(boss.state.gold);
+    expect(replay.state.gems).toBe(boss.state.gems);
+    expect(specialistMasteryCalling(
+      'pathfinder',
+      { attack:1, dodge:1, charge:1 },
+      replay.summary,
+    )).toBe('pathfinder');
+  });
+});

--- a/src/calling-depth-effects.test.ts
+++ b/src/calling-depth-effects.test.ts
@@ -17,11 +17,24 @@ describe('Calling depth effects', () => {
   });
 
   it('detects specialist Calling mastery from expedition actions', () => {
-    expect(specialistMasteryCalling('vanguard', { attack:2, dodge:0, charge:0 }, { grade:'A', discovery:null, materialReward:1 })).toBe('vanguard');
-    expect(specialistMasteryCalling('arcanist', { attack:0, dodge:0, charge:1 }, { grade:'S', discovery:null, materialReward:2 })).toBe('arcanist');
-    expect(specialistMasteryCalling('caretaker', { attack:0, dodge:1, charge:0 }, { grade:'B', discovery:null, materialReward:1 })).toBe('caretaker');
-    expect(specialistMasteryCalling('pathfinder', { attack:1, dodge:0, charge:0 }, { grade:'A', discovery:'forest_echo', materialReward:0 })).toBe('pathfinder');
-    expect(specialistMasteryCalling('vanguard', { attack:0, dodge:2, charge:0 }, { grade:'A', discovery:null, materialReward:1 })).toBeNull();
+    expect(specialistMasteryCalling('vanguard', { attack:2, dodge:0, charge:0 }, { stageId:'forest_path', grade:'A', discovery:null, materialReward:1 })).toBe('vanguard');
+    expect(specialistMasteryCalling('arcanist', { attack:0, dodge:0, charge:1 }, { stageId:'forest_path', grade:'S', discovery:null, materialReward:2 })).toBe('arcanist');
+    expect(specialistMasteryCalling('caretaker', { attack:0, dodge:1, charge:0 }, { stageId:'forest_path', grade:'B', discovery:null, materialReward:1 })).toBe('caretaker');
+    expect(specialistMasteryCalling('pathfinder', { attack:1, dodge:0, charge:0 }, { stageId:'forest_path', grade:'A', discovery:'forest_echo', materialReward:0 })).toBe('pathfinder');
+    expect(specialistMasteryCalling('vanguard', { attack:0, dodge:2, charge:0 }, { stageId:'forest_path', grade:'A', discovery:null, materialReward:1 })).toBeNull();
+  });
+
+  it('lets Pathfinder mastery progress on successful boss clears and re-clears', () => {
+    expect(specialistMasteryCalling(
+      'pathfinder',
+      { attack:1, dodge:1, charge:1 },
+      { stageId:'forest_guardian', grade:'B', discovery:null, materialReward:0 },
+    )).toBe('pathfinder');
+    expect(specialistMasteryCalling(
+      'pathfinder',
+      { attack:1, dodge:1, charge:1 },
+      { stageId:'forest_guardian', grade:'C', discovery:null, materialReward:0 },
+    )).toBeNull();
   });
 
   it('applies Pathfinder signature rewards without duplicating the existing supply trait', () => {

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -1,5 +1,6 @@
 import type { CallingSignatureId } from './calling-signatures';
 import type { ExpeditionActionCounts } from './expedition-combat';
+import { isBossStage } from './expedition-bosses';
 import type { ExpeditionGrade, ExpeditionRegionId, ExpeditionStageId } from './expedition-regions';
 import type { GuardianCallingId } from './guardian-callings';
 import type { GrowthTraitId } from './growth-traits';
@@ -19,13 +20,15 @@ export function effectivePathfinderExplorationXp(
 export function specialistMasteryCalling(
   calling:GuardianCallingId | null,
   actions:ExpeditionActionCounts,
-  summary:{ grade:ExpeditionGrade; discovery:string | null; materialReward:number },
+  summary:{ stageId:ExpeditionStageId; grade:ExpeditionGrade; discovery:string | null; materialReward:number },
 ): GuardianCallingId | null {
   if (!calling || summary.grade === 'C') return null;
   if (calling === 'vanguard') return actions.attack > 0 ? calling : null;
   if (calling === 'arcanist') return actions.charge > 0 ? calling : null;
   if (calling === 'caretaker') return actions.dodge > 0 ? calling : null;
-  return (actions.attack + actions.dodge + actions.charge > 0) && (summary.discovery !== null || summary.materialReward > 0) ? calling : null;
+  const acted = actions.attack + actions.dodge + actions.charge > 0;
+  const explored = summary.discovery !== null || summary.materialReward > 0 || isBossStage(summary.stageId);
+  return acted && explored ? calling : null;
 }
 
 export type ExpeditionCallingRewardInput = {

--- a/src/expedition-crafting.test.ts
+++ b/src/expedition-crafting.test.ts
@@ -28,4 +28,23 @@ describe('expedition crafting', () => {
     expect(result.relic).toBe('guardian_thread');
     expect(result.milestone).toBe('crafted_guardian_thread');
   });
+
+  it('does not consume materials when the one-time guardian thread was already crafted', () => {
+    const materials = { star_bark: 3, arcane_shard: 3, wind_pearl: 3 };
+    const result = applyCrafting('guardian_thread_recipe', materials, {
+      craftingMilestones:['crafted_guardian_thread'],
+      ownedRelics:['guardian_thread'],
+    });
+    expect(result.crafted).toBe(false);
+    expect(result.materials).toEqual(materials);
+    expect(canCraft('guardian_thread_recipe', materials, {
+      craftingMilestones:['crafted_guardian_thread'],
+      ownedRelics:['guardian_thread'],
+    })).toBe(false);
+  });
+
+  it('keeps gift recipes repeatable after their milestone was recorded', () => {
+    const materials = { star_bark: 4, arcane_shard: 0, wind_pearl: 0 };
+    expect(canCraft('star_cookie_recipe', materials, { craftingMilestones:['crafted_star_cookie'] })).toBe(true);
+  });
 });

--- a/src/expedition-crafting.ts
+++ b/src/expedition-crafting.ts
@@ -18,6 +18,11 @@ export type ExpeditionCraftingRecipe = {
   milestone: CraftingMilestoneId;
 };
 
+export type ExpeditionCraftingProgress = {
+  craftingMilestones?: readonly CraftingMilestoneId[];
+  ownedRelics?: readonly ExpeditionRelicId[];
+};
+
 export const craftingRecipes: ExpeditionCraftingRecipe[] = [
   { id: 'star_cookie_recipe', label: '별빛 쿠키 제작', costs: { star_bark: 2 }, gift: 'star_cookie', relic: null, milestone: 'crafted_star_cookie' },
   { id: 'fox_charm_recipe', label: '여우 부적 제작', costs: { arcane_shard: 2 }, gift: 'fox_charm', relic: null, milestone: 'crafted_fox_charm' },
@@ -29,15 +34,30 @@ export function emptyExpeditionMaterials(): ExpeditionMaterials {
   return { star_bark: 0, arcane_shard: 0, wind_pearl: 0 };
 }
 
-export function canCraft(recipeId: ExpeditionCraftingRecipeId, materials: ExpeditionMaterials): boolean {
+function isOneTimeRecipeCompleted(recipe: ExpeditionCraftingRecipe, progress: ExpeditionCraftingProgress): boolean {
+  return Boolean(recipe.relic && (
+    (progress.craftingMilestones ?? []).includes(recipe.milestone)
+    || (progress.ownedRelics ?? []).includes(recipe.relic)
+  ));
+}
+
+export function canCraft(
+  recipeId: ExpeditionCraftingRecipeId,
+  materials: ExpeditionMaterials,
+  progress: ExpeditionCraftingProgress = {},
+): boolean {
   const recipe = craftingRecipes.find(item => item.id === recipeId);
-  if (!recipe) return false;
+  if (!recipe || isOneTimeRecipeCompleted(recipe, progress)) return false;
   return expeditionMaterialIds.every(id => materials[id] >= (recipe.costs[id] ?? 0));
 }
 
-export function applyCrafting(recipeId: ExpeditionCraftingRecipeId, materials: ExpeditionMaterials) {
+export function applyCrafting(
+  recipeId: ExpeditionCraftingRecipeId,
+  materials: ExpeditionMaterials,
+  progress: ExpeditionCraftingProgress = {},
+) {
   const recipe = craftingRecipes.find(item => item.id === recipeId);
-  if (!recipe || !canCraft(recipeId, materials)) return { crafted: false as const, materials, gift: null, relic: null, milestone: null };
+  if (!recipe || !canCraft(recipeId, materials, progress)) return { crafted: false as const, materials, gift: null, relic: null, milestone: null };
   const next = { ...materials };
   for (const id of expeditionMaterialIds) next[id] = Math.max(0, next[id] - (recipe.costs[id] ?? 0));
   return { crafted: true as const, materials: next, gift: recipe.gift, relic: recipe.relic, milestone: recipe.milestone };

--- a/src/expedition-rewards.test.ts
+++ b/src/expedition-rewards.test.ts
@@ -103,6 +103,17 @@ describe('expedition finish reward pipeline', () => {
     expect(worldReplay.state.ownedExpeditionRelics).toContain('explorer_compass');
   });
 
+  it('does not repair the world-completion relic on a failed replay', () => {
+    const worldState = base();
+    for (const id of Object.keys(worldState.expeditionRecords) as Array<keyof typeof worldState.expeditionRecords>) {
+      worldState.expeditionRecords[id] = { bestScore:9999, bestGrade:'A', cleared:true };
+    }
+    const failedReplay = resolveExpeditionFinish(worldState, 'lake_tempest', 100);
+    expect(failedReplay.summary.cleared).toBe(false);
+    expect(failedReplay.summary.relicsUnlocked).toEqual([]);
+    expect(failedReplay.state.ownedExpeditionRelics).not.toContain('explorer_compass');
+  });
+
   it('separates an accepted C-grade attempt from a successful clear', () => {
     const result = resolveExpeditionFinish(base(), 'forest_path', 100);
     expect(result.summary.accepted).toBe(true);

--- a/src/expedition-rewards.test.ts
+++ b/src/expedition-rewards.test.ts
@@ -18,12 +18,14 @@ describe('expedition finish reward pipeline', () => {
     expect(result.state.expeditionStoryEntries).toContain('forest_path');
     expect(result.state.expeditionDiscoveries).toContain('forest_path_discovery');
     expect(result.summary.firstClear).toBe(true);
+    expect(result.summary.cleared).toBe(true);
     expect(result.summary.grade).toBe('A');
   });
 
   it('does not award discovery on B but does on later A replay', () => {
     const first = resolveExpeditionFinish(base(), 'forest_path', 560);
     expect(first.summary.grade).toBe('B');
+    expect(first.summary.cleared).toBe(true);
     expect(first.state.expeditionDiscoveries).not.toContain('forest_path_discovery');
     const replay = resolveExpeditionFinish(first.state, 'forest_path', 700);
     expect(replay.summary.firstClear).toBe(false);
@@ -50,6 +52,8 @@ describe('expedition finish reward pipeline', () => {
     const replay = resolveExpeditionFinish(first.state, 'forest_guardian', 1260);
     expect(replay.state.gold).toBe(first.state.gold);
     expect(replay.state.gems).toBe(first.state.gems);
+    expect(replay.summary.firstClear).toBe(false);
+    expect(replay.summary.cleared).toBe(true);
   });
 
   it('grants region relics and forest boss also makes bond locket obtainable', () => {
@@ -65,6 +69,46 @@ describe('expedition finish reward pipeline', () => {
   it('rejects attempts to finish a locked stage', () => {
     const result = resolveExpeditionFinish(base(), 'city_square', 5000);
     expect(result.summary.accepted).toBe(false);
+    expect(result.summary.cleared).toBe(false);
     expect(result.state).toEqual(base());
+  });
+
+  it('does not replay first-clear currency when a cleared record is missing its reward marker', () => {
+    const state = base();
+    state.expeditionRecords.forest_path = { bestScore:700, bestGrade:'A', cleared:true };
+    const replay = resolveExpeditionFinish(state, 'forest_path', 700);
+    expect(replay.summary.firstClear).toBe(false);
+    expect(replay.state.gold).toBe(state.gold);
+    expect(replay.state.rewardedExpeditionStages).toContain('forest_path');
+    expect(replay.state.expeditionStoryEntries).toContain('forest_path');
+  });
+
+  it('repairs missing region and world relics without replaying completion transitions', () => {
+    const regionState = base();
+    for (const id of ['forest_path','forest_glade','forest_guardian'] as const) {
+      regionState.expeditionRecords[id] = { bestScore:2000, bestGrade:'A', cleared:true };
+    }
+    const regionReplay = resolveExpeditionFinish(regionState, 'forest_guardian', 1050);
+    expect(regionReplay.summary.regionCompleted).toBeNull();
+    expect(regionReplay.state.ownedExpeditionRelics).toContain('moonfang_charm');
+    expect(regionReplay.state.ownedExpeditionRelics).toContain('bond_locket');
+
+    const worldState = base();
+    for (const id of Object.keys(worldState.expeditionRecords) as Array<keyof typeof worldState.expeditionRecords>) {
+      worldState.expeditionRecords[id] = { bestScore:9999, bestGrade:'A', cleared:true };
+    }
+    const worldReplay = resolveExpeditionFinish(worldState, 'lake_tempest', 1750);
+    expect(worldReplay.summary.fullCompleted).toBe(false);
+    expect(worldReplay.state.gems).toBe(worldState.gems);
+    expect(worldReplay.state.ownedExpeditionRelics).toContain('explorer_compass');
+  });
+
+  it('separates an accepted C-grade attempt from a successful clear', () => {
+    const result = resolveExpeditionFinish(base(), 'forest_path', 100);
+    expect(result.summary.accepted).toBe(true);
+    expect(result.summary.cleared).toBe(false);
+    expect(result.summary.firstClear).toBe(false);
+    expect(result.summary.materialReward).toBe(0);
+    expect(result.state.expeditionRecords.forest_path.cleared).toBe(false);
   });
 });

--- a/src/expedition-rewards.ts
+++ b/src/expedition-rewards.ts
@@ -1,5 +1,5 @@
 import type { GiftItemId } from './adventure';
-import { bossReward, isBossStage } from './expedition-bosses';
+import { bossReward } from './expedition-bosses';
 import type { ExpeditionMaterialId } from './expedition-crafting';
 import { eligibleExpeditionDiscovery } from './expedition-discoveries';
 import {
@@ -25,6 +25,7 @@ export type ExpeditionRewardState = ExpeditionPersistentState & {
 
 export type ExpeditionFinishSummary = {
   accepted: boolean;
+  cleared: boolean;
   stageId: ExpeditionStageId;
   grade: ExpeditionGrade;
   firstClear: boolean;
@@ -74,6 +75,7 @@ export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: E
   const accepted = isExpeditionStageUnlocked(stageId, state.expeditionRecords);
   const rejectedSummary: ExpeditionFinishSummary = {
     accepted: false,
+    cleared: false,
     stageId,
     grade,
     firstClear: false,
@@ -88,7 +90,11 @@ export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: E
   if (!accepted) return { state, summary: rejectedSummary };
 
   const clearedNow = grade !== 'C';
-  const firstClear = clearedNow && !state.rewardedExpeditionStages.includes(stageId);
+  const wasCleared = isExpeditionStageCleared(state.expeditionRecords[stageId]);
+  const wasStageRewarded = state.rewardedExpeditionStages.includes(stageId);
+  const regionWasComplete = regionNowComplete(stage.region, state.expeditionRecords);
+  const fullWasComplete = allStagesCleared(state.expeditionRecords);
+  const firstClear = clearedNow && !wasCleared && !wasStageRewarded;
   const expeditionRecords = updateExpeditionRecord(state.expeditionRecords, stageId, score, stage.target);
   let next: ExpeditionRewardState = { ...state, expeditionRecords };
   const relicsUnlocked: ExpeditionRelicId[] = [];
@@ -109,19 +115,26 @@ export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: E
 
   let storyUnlocked = false;
   let bossBadge = false;
-  if (firstClear) {
+  if (clearedNow) {
     storyUnlocked = !next.expeditionStoryEntries.includes(stageId);
-    const firstReward = stage.boss ? bossReward(stageId) : { gold: 150, gems: 0 };
-    const affectionBonus = relicModifiers(state.equippedExpeditionRelics).firstClearAffection;
     next = {
       ...next,
-      gold: next.gold + firstReward.gold,
-      gems: next.gems + firstReward.gems,
-      affection: Math.min(100, next.affection + affectionBonus),
       rewardedExpeditionStages: addUnique(next.rewardedExpeditionStages, stageId),
       expeditionStoryEntries: addUnique(next.expeditionStoryEntries, stageId),
     };
-    bossBadge = stage.boss;
+
+    if (firstClear) {
+      const firstReward = stage.boss ? bossReward(stageId) : { gold: 150, gems: 0 };
+      const affectionBonus = relicModifiers(state.equippedExpeditionRelics).firstClearAffection;
+      next = {
+        ...next,
+        gold: next.gold + firstReward.gold,
+        gems: next.gems + firstReward.gems,
+        affection: Math.min(100, next.affection + affectionBonus),
+      };
+      bossBadge = stage.boss;
+    }
+
     if (stageId === 'forest_guardian' && !next.ownedExpeditionRelics.includes('bond_locket')) {
       next = { ...next, ownedExpeditionRelics: [...next.ownedExpeditionRelics, 'bond_locket'] };
       relicsUnlocked.push('bond_locket');
@@ -132,24 +145,26 @@ export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: E
   if (discovery) next = { ...next, expeditionDiscoveries: [...next.expeditionDiscoveries, discovery] };
 
   let regionCompleted: ExpeditionRegionId | null = null;
-  if (clearedNow && regionNowComplete(stage.region, next.expeditionRecords) && !next.rewardedExpeditionRegions.includes(stage.region)) {
-    regionCompleted = stage.region;
+  const regionIsComplete = regionNowComplete(stage.region, next.expeditionRecords);
+  if (clearedNow && regionIsComplete) {
+    const regionWasRewarded = state.rewardedExpeditionRegions.includes(stage.region);
+    if (!regionWasComplete && !regionWasRewarded) regionCompleted = stage.region;
     const relic = regionRelic[stage.region];
     const owned = next.ownedExpeditionRelics.includes(relic) ? next.ownedExpeditionRelics : [...next.ownedExpeditionRelics, relic];
     if (!next.ownedExpeditionRelics.includes(relic)) relicsUnlocked.push(relic);
     next = {
       ...next,
       ownedExpeditionRelics: owned,
-      rewardedExpeditionRegions: [...next.rewardedExpeditionRegions, stage.region],
+      rewardedExpeditionRegions: addUnique(next.rewardedExpeditionRegions, stage.region),
     };
   }
 
   let fullCompleted = false;
   if (allStagesCleared(next.expeditionRecords) && !next.ownedExpeditionRelics.includes('explorer_compass')) {
-    fullCompleted = true;
+    fullCompleted = clearedNow && !fullWasComplete;
     next = {
       ...next,
-      gems: next.gems + 5,
+      gems: next.gems + (fullCompleted ? 5 : 0),
       ownedExpeditionRelics: [...next.ownedExpeditionRelics, 'explorer_compass'],
     };
     relicsUnlocked.push('explorer_compass');
@@ -159,6 +174,7 @@ export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: E
     state: next,
     summary: {
       accepted: true,
+      cleared: clearedNow,
       stageId,
       grade,
       firstClear,

--- a/src/expedition-rewards.ts
+++ b/src/expedition-rewards.ts
@@ -160,8 +160,8 @@ export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: E
   }
 
   let fullCompleted = false;
-  if (allStagesCleared(next.expeditionRecords) && !next.ownedExpeditionRelics.includes('explorer_compass')) {
-    fullCompleted = clearedNow && !fullWasComplete;
+  if (clearedNow && allStagesCleared(next.expeditionRecords) && !next.ownedExpeditionRelics.includes('explorer_compass')) {
+    fullCompleted = !fullWasComplete;
     next = {
       ...next,
       gems: next.gems + (fullCompleted ? 5 : 0),

--- a/src/expedition-state.test.ts
+++ b/src/expedition-state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { hydrateExpeditionPersistentState } from './expedition-state';
+
+describe('expedition persistent state repair', () => {
+  it('restores guardian thread ownership when its crafting milestone exists', () => {
+    const state = hydrateExpeditionPersistentState({
+      craftingMilestones:['crafted_guardian_thread'],
+      ownedExpeditionRelics:[],
+    });
+    expect(state.craftingMilestones).toContain('crafted_guardian_thread');
+    expect(state.ownedExpeditionRelics).toContain('guardian_thread');
+  });
+
+  it('keeps only owned relics equipped after hydration', () => {
+    const state = hydrateExpeditionPersistentState({
+      ownedExpeditionRelics:['moonfang_charm'],
+      equippedExpeditionRelics:['moonfang_charm','mana_prism'],
+    });
+    expect(state.equippedExpeditionRelics).toEqual(['moonfang_charm']);
+  });
+});

--- a/src/expedition-state.ts
+++ b/src/expedition-state.ts
@@ -66,7 +66,11 @@ function hydrateMaterials(raw: unknown): ExpeditionMaterials {
 
 export function hydrateExpeditionPersistentState(raw: unknown): ExpeditionPersistentState {
   const source = isRecord(raw) ? raw : {};
-  const owned = uniqueAllowed(source.ownedExpeditionRelics, expeditionRelicIds);
+  const milestones = uniqueAllowed(source.craftingMilestones, craftingMilestoneIds);
+  const storedOwned = uniqueAllowed(source.ownedExpeditionRelics, expeditionRelicIds);
+  const owned: ExpeditionRelicId[] = milestones.includes('crafted_guardian_thread') && !storedOwned.includes('guardian_thread')
+    ? [...storedOwned, 'guardian_thread']
+    : storedOwned;
   const equipped = uniqueAllowed(source.equippedExpeditionRelics, expeditionRelicIds).filter(id => owned.includes(id)).slice(0, 3);
   return {
     expeditionRecords: hydrateRecords(source.expeditionRecords),
@@ -77,7 +81,7 @@ export function hydrateExpeditionPersistentState(raw: unknown): ExpeditionPersis
     rewardedExpeditionRegions: uniqueAllowed(source.rewardedExpeditionRegions, regionIds),
     expeditionDiscoveries: uniqueAllowed(source.expeditionDiscoveries, expeditionDiscoveryIds),
     expeditionStoryEntries: uniqueAllowed(source.expeditionStoryEntries, stageIds),
-    craftingMilestones: uniqueAllowed(source.craftingMilestones, craftingMilestoneIds),
+    craftingMilestones: milestones,
   };
 }
 

--- a/src/expedition-world-loop.test.ts
+++ b/src/expedition-world-loop.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { applyCrafting } from './expedition-crafting';
+import { resolveExpeditionFinish } from './expedition-rewards';
+import { expeditionStageDefinitions } from './expedition-regions';
+import { emptyExpeditionPersistentState } from './expedition-state';
+import { emptyRegionalRenown, regionalRenownLevel, renownGainForExpedition } from './regional-renown';
+import { advanceWorldContracts, emptyWorldContractProgress } from './world-contracts';
+import { worldEvent, worldEventExpeditionBonus } from './world-event';
+
+const base = () => ({
+  ...emptyExpeditionPersistentState(),
+  gold:0,
+  gems:0,
+  affection:0,
+  inventory:{ star_cookie:0, herb_tea:0, fox_charm:0 },
+});
+
+describe('guardian expedition full world loop', () => {
+  it('runs stage → boss → rewards → relic/crafting/discovery → renown → contract/event without a blocker', () => {
+    let state = base();
+    let renown = emptyRegionalRenown();
+    let contractProgress = emptyWorldContractProgress();
+    let rewardedKeys:string[] = [];
+    let contractGold = 0;
+    let contractGems = 0;
+    let eventPoints = 0;
+    const event = worldEvent(1,1);
+
+    for (const stage of expeditionStageDefinitions) {
+      const result = resolveExpeditionFinish(state,stage.id,stage.target);
+      expect(result.summary.accepted).toBe(true);
+      expect(result.summary.cleared).toBe(true);
+      expect(result.summary.firstClear).toBe(true);
+      state = result.state;
+
+      renown = {
+        ...renown,
+        [stage.region]:renown[stage.region] + renownGainForExpedition(result.summary.grade,stage.boss && result.summary.firstClear),
+      };
+      const contracts = advanceWorldContracts({
+        year:1,
+        month:1,
+        event,
+        progress:contractProgress,
+        rewardedKeys,
+        region:stage.region,
+        grade:result.summary.grade,
+      });
+      contractProgress = contracts.progress;
+      rewardedKeys = contracts.rewardedKeys;
+      contractGold += contracts.reward.gold;
+      contractGems += contracts.reward.gems;
+      eventPoints += worldEventExpeditionBonus(event,stage.region,result.summary.grade).seasonPoints;
+    }
+
+    expect(state.expeditionStoryEntries).toHaveLength(9);
+    expect(state.expeditionDiscoveries).toHaveLength(9);
+    expect(state.expeditionMaterials).toEqual({ star_bark:2, arcane_shard:2, wind_pearl:2 });
+    expect(state.ownedExpeditionRelics).toEqual(expect.arrayContaining([
+      'moonfang_charm','mana_prism','wind_feather','bond_locket','explorer_compass',
+    ]));
+    expect(regionalRenownLevel(renown.starlight_forest)).toBe(2);
+    expect(regionalRenownLevel(renown.ancient_city)).toBe(2);
+    expect(regionalRenownLevel(renown.wind_lakes)).toBe(2);
+    expect({ gold:contractGold, gems:contractGems }).toEqual({ gold:250, gems:1 });
+    expect(rewardedKeys).toHaveLength(3);
+    expect(eventPoints).toBe(15);
+
+    for (const [stageId,target] of [['forest_path',700],['city_square',950],['lake_channel',1200]] as const) {
+      state = resolveExpeditionFinish(state,stageId,target).state;
+    }
+    expect(state.expeditionMaterials).toEqual({ star_bark:3, arcane_shard:3, wind_pearl:3 });
+
+    const craft = applyCrafting('guardian_thread_recipe',state.expeditionMaterials,{
+      craftingMilestones:state.craftingMilestones,
+      ownedRelics:state.ownedExpeditionRelics,
+    });
+    expect(craft.crafted).toBe(true);
+    expect(craft.relic).toBe('guardian_thread');
+
+    const repeatContract = advanceWorldContracts({
+      year:1,
+      month:1,
+      event,
+      progress:contractProgress,
+      rewardedKeys,
+      region:'starlight_forest',
+      grade:'S',
+    });
+    expect(repeatContract.reward).toEqual({ gold:0, gems:0 });
+    expect(repeatContract.progress).toEqual({ expedition_clear:3, high_grade:2, featured_region:2 });
+    expect(worldEventExpeditionBonus(event,'starlight_forest','S')).toEqual({ seasonPoints:5, materialBonus:1 });
+  });
+});

--- a/src/world-contracts.test.ts
+++ b/src/world-contracts.test.ts
@@ -35,7 +35,21 @@ describe('world contracts', () => {
     expect(result.reward).toEqual({ gold:0, gems:0 });
   });
 
-  it('auto-pays newly completed contracts once', () => {
+  it('does not advance failed C-grade attempts', () => {
+    const result = advanceWorldContracts({
+      year:1,
+      month:1,
+      event:worldEvent(1, 1),
+      progress:{ expedition_clear:1, high_grade:1, featured_region:1 },
+      rewardedKeys:[],
+      region:'starlight_forest',
+      grade:'C',
+    });
+    expect(result.progress).toEqual({ expedition_clear:1, high_grade:1, featured_region:1 });
+    expect(result.reward).toEqual({ gold:0, gems:0 });
+  });
+
+  it('auto-pays newly completed contracts once and caps completed counters', () => {
     const result = advanceWorldContracts({
       year:1,
       month:1,
@@ -62,6 +76,7 @@ describe('world contracts', () => {
       grade:'S',
     });
     expect(repeat.reward).toEqual({ gold:0, gems:0 });
+    expect(repeat.progress).toEqual({ expedition_clear:3, high_grade:2, featured_region:2 });
   });
 
   it('creates stable monthly reward keys', () => {

--- a/src/world-contracts.ts
+++ b/src/world-contracts.ts
@@ -52,17 +52,19 @@ export function advanceWorldContracts(input:AdvanceInput): {
     return { progress:{ ...input.progress }, rewardedKeys:[...input.rewardedKeys], reward:{ gold:0, gems:0 }, newlyCompleted:[] };
   }
 
+  const contracts = monthlyWorldContracts(input.year, input.month, input.event);
+  const targetFor = (id:WorldContractId) => contracts.find(contract => contract.id === id)?.target ?? Number.MAX_SAFE_INTEGER;
   const progress:WorldContractProgress = {
-    expedition_clear:input.progress.expedition_clear + 1,
-    high_grade:input.progress.high_grade + (input.grade === 'A' || input.grade === 'S' ? 1 : 0),
-    featured_region:input.progress.featured_region + (input.region === input.event.region ? 1 : 0),
+    expedition_clear:Math.min(targetFor('expedition_clear'),input.progress.expedition_clear + 1),
+    high_grade:Math.min(targetFor('high_grade'),input.progress.high_grade + (input.grade === 'A' || input.grade === 'S' ? 1 : 0)),
+    featured_region:Math.min(targetFor('featured_region'),input.progress.featured_region + (input.region === input.event.region ? 1 : 0)),
   };
   const rewardedKeys = [...input.rewardedKeys];
   const newlyCompleted:WorldContractId[] = [];
   let gold = 0;
   let gems = 0;
 
-  for (const contract of monthlyWorldContracts(input.year, input.month, input.event)) {
+  for (const contract of contracts) {
     const key = worldContractRewardKey(input.year, input.month, contract.id);
     if (progress[contract.id] < contract.target || rewardedKeys.includes(key)) continue;
     rewardedKeys.push(key);

--- a/src/world-ui.test.ts
+++ b/src/world-ui.test.ts
@@ -57,11 +57,11 @@ describe('world UI summaries', () => {
     expect(summary.season.tiers.map(item => item.status)).toEqual(['claimed','claimed','locked','locked']);
   });
 
-  it('clamps maxed regional renown and marks a completed contract', () => {
+  it('clamps maxed regional renown and completed contract counters', () => {
     const state: GameState = {
       ...initialState,
       regionalRenown:{ starlight_forest:99, ancient_city:5, wind_lakes:0 },
-      worldContractProgress:{ expedition_clear:3, high_grade:1, featured_region:0 },
+      worldContractProgress:{ expedition_clear:99, high_grade:1, featured_region:0 },
       rewardedWorldContracts:['1-4:expedition_clear'],
     };
     const summary = worldUiSummary(state);
@@ -97,5 +97,22 @@ describe('world UI summaries', () => {
       seasonRewardLabel:'시즌 보상 1·2단계 자동 수령',
       contractLabel:'빛나는 기록 · 월드 이벤트 지원 완료',
     });
+  });
+
+  it('hides no-op world progress from a failed expedition attempt', () => {
+    const state: GameState = {
+      ...initialState,
+      lastWorldProgress:{
+        region:'starlight_forest',
+        renownGain:0,
+        renownLevel:1,
+        seasonPoints:0,
+        eventSeasonPoints:0,
+        eventMaterialBonus:0,
+        seasonTiersClaimed:[],
+        completedContracts:[],
+      },
+    };
+    expect(worldResultSummary(state)).toBeNull();
   });
 });

--- a/src/world-ui.ts
+++ b/src/world-ui.ts
@@ -93,7 +93,7 @@ export function worldUiSummary(state:GameState): WorldUiSummary {
   });
 
   const contracts = monthlyWorldContracts(state.year, state.month, event).map(contract => {
-    const progress = Math.max(0, Math.floor(state.worldContractProgress[contract.id] ?? 0));
+    const progress = Math.min(contract.target, Math.max(0, Math.floor(state.worldContractProgress[contract.id] ?? 0)));
     const rewardKey = worldContractRewardKey(state.year, state.month, contract.id);
     const rewardLabel = [contract.reward.gold ? `${contract.reward.gold}G` : '', contract.reward.gems ? `보석 ${contract.reward.gems}` : ''].filter(Boolean).join(' · ');
     return {
@@ -154,6 +154,12 @@ export type WorldResultSummary = {
 export function worldResultSummary(state:GameState): WorldResultSummary|null {
   const progress = state.lastWorldProgress;
   if (!progress) return null;
+  const meaningful = progress.renownGain > 0
+    || progress.seasonPoints > 0
+    || progress.eventMaterialBonus > 0
+    || progress.seasonTiersClaimed.length > 0
+    || progress.completedContracts.length > 0;
+  if (!meaningful) return null;
   const contracts = monthlyWorldContracts(state.year, state.month, worldEvent(state.year, state.month));
   const completedLabels = progress.completedContracts
     .map(id => contracts.find(contract => contract.id === id)?.label)


### PR DESCRIPTION
## 상태
- 작업 브랜치: `work/world-expedition`
- Base: `integration/v2`
- 상태: **Draft / Integration Candidate / Feature Frozen**
- 직접 merge 금지
- 신규 지역/보스/월드 시스템 추가는 06 통합 전까지 중단

## 구현한 기능
- Adventure → Exploration → Guardian Expedition → Boss → Reward → Relic/Crafting/Discovery → Regional Renown → World Contract/Event 반복 플레이 루프 안정화
- 첫 클리어와 재클리어 보상 전이를 실제 진행 상태 기준으로 분리해 중복 화폐/보스 보상 방지
- 부분 손상/구버전 진행 상태에서 지역/완주 유물은 복구하되 완료 보상은 재지급하지 않도록 보강
- `accepted`(유효한 시도)와 `cleared`(B/A/S 성공)를 분리해 C등급 실패가 성공 진행으로 보이지 않도록 정리
- Guardian Thread 일회 제작 중복 소모 방지, 소비형 제작은 반복 가능 유지
- 제작 마일스톤은 있는데 Guardian Thread 소유 정보가 누락된 저장 상태 hydration 복구
- World Contract 진행도를 목표치에서 cap하고 C등급 실패는 진행에서 제외
- Pathfinder Calling Mastery가 성공한 보스 클리어/재클리어에서도 상승하고 C 실패에서는 상승하지 않도록 보강
- 월드 이벤트 지역 보너스와 원정 성공 상태 표시 정합성 보강
- Adventure/Exploration/Expedition 통합 회귀 테스트와 전체 9스테이지 월드 루프 테스트 추가

## 변경 파일
- `src/GuardianExpeditionOverlay.tsx`
- `src/adventure-expedition-loop.test.ts`
- `src/calling-depth-effects.test.ts`
- `src/calling-depth-effects.ts`
- `src/expedition-crafting.test.ts`
- `src/expedition-crafting.ts`
- `src/expedition-rewards.test.ts`
- `src/expedition-rewards.ts`
- `src/expedition-state.test.ts`
- `src/expedition-state.ts`
- `src/expedition-world-loop.test.ts`
- `src/world-contracts.test.ts`
- `src/world-contracts.ts`
- `src/world-ui.test.ts`
- `src/world-ui.ts`

공용 `src/game*.ts`, `src/App.tsx`, `src/Root.tsx`, save schema/resilience 파일은 수정하지 않음.

## 테스트 결과
Frozen HEAD 기준 world-only fresh verification:
- TypeScript compile: PASS
- 회귀 검증: `regression assertions passed`
- 전체 9스테이지 루프: `full world loop assertions passed`
- Adventure/Exploration/Expedition 통합 검증: `WORLD_LOOP_VERIFY_OK`

검증 범위:
- 첫 클리어/재클리어 화폐 및 보스 보상 중복 방지
- 부분 상태 유물 복구 시 완료 보상 재발동 방지
- C등급 실패 semantics
- Guardian Thread 일회 제작 차단 및 소비형 제작 반복 가능
- hydration 복구
- 9스테이지 순차 진행, 스토리 9/9, 발견 9/9
- 지역 재료 → Guardian Thread 제작 경로
- Regional Renown
- World Contract 목표치 cap 및 reward-once
- World Event 추천 지역 일치
- Pathfinder 보스 Mastery

Repository-wide CI는 기존 공용 Core API 불일치 때문에 base 계열에서도 red 상태였으므로 이 PR에서 공용 파일을 수정하지 않음.

## 공용 파일 연결 필요사항
06 통합에서만 처리:
1. 성공한 원정만 세는 공용 카운터/보너스는 `lastExpeditionResult.accepted`가 아니라 `lastExpeditionResult.cleared` 사용
   - C 실패 → 성공 카운트 증가 없음
   - B/A/S 성공 → 정상 증가
2. `game-base.ts`의 crafting dispatch에서 `applyCrafting` 호출 시 현재 진행 컨텍스트 전달
   - `craftingMilestones`
   - `ownedExpeditionRelics`
   - direct reducer dispatch에서도 Guardian Thread 재제작을 차단해야 함

## 다른 작업방과 충돌 가능성이 있는 파일
### `src/GuardianExpeditionOverlay.tsx`
05 Hub UI PR #9와 동시 수정 파일.

05에서 반드시 보존할 변경:
- `useRef` import
- `launcherRef`, `wasOpen`
- overlay 닫힘 후 launcher로 focus를 돌려주는 `useEffect`
- launcher button의 `ref={launcherRef}`

02 World에서 반드시 보존할 변경:
- `canCraft` import/판정
- 보스 완료 수를 `rewardedExpeditionStages`가 아니라 실제 boss stage clear 기록으로 계산
- `result.cleared` 기준 C 실패/실제 성공 구분
- 실패 시 story/world progress 성공 표시 숨김
- crafting milestone/owned relic/material에 맞춘 `제작 완료/제작/재료 부족` 상태 및 disabled 처리

**한쪽 파일을 통째로 선택하지 말고 합성 필요.**

## 저장 데이터 영향
- 새 save schema 필드 추가 없음
- 기존 필드 사용:
  - `expeditionRecords`
  - `rewardedExpeditionStages`
  - `rewardedExpeditionRegions`
  - `craftingMilestones`
  - `ownedExpeditionRelics`
  - `equippedExpeditionRelics`
  - `worldContractProgress`
- `crafted_guardian_thread` 마일스톤은 남아 있는데 relic ownership이 누락된 부분 저장 상태를 hydration에서 복구
- 기존 저장 호환을 깨는 migration 요구 없음

## 06 통합 시 주의사항
1. PR은 Draft 상태로 유지하고 직접 merge하지 말 것.
2. `GuardianExpeditionOverlay.tsx`는 **05 PR #9 버전을 기준**으로 포커스 복원 UX를 유지한 뒤, 본 PR의 월드 정합성 hunk만 합성할 것.
3. 본 PR 전체 파일로 05 UI 버전을 덮어쓰지 말 것.
4. 공용 성공 판정은 `accepted`와 `cleared` 의미를 혼동하지 말 것.
5. crafting 공용 dispatch 연결 후 C 실패/B 성공 및 Guardian Thread 재제작 회귀 테스트를 다시 실행할 것.
6. 통합 후 전체 save hydration + 월드 9스테이지 loop + World Contract/Event 회귀 테스트를 재실행할 것.
7. 현재 브랜치는 기능 동결 상태이며 통합 과정에서 발견된 월드 회귀 외 신규 기능은 추가하지 말 것.