### PR TITLE
01 Raising: stabilize raising → bond → story → career flow

### DIFF
--- a/src/career-records.test.ts
+++ b/src/career-records.test.ts
@@ -23,4 +23,21 @@ describe('career records and titles', () => {
       'steady_trainer', 'perfect_chaser', 'seasoned_explorer', 'warm_giver', 'story_witness', 'veteran_guardian',
     ]);
   });
+
+  it('uses raising-story progress for story witness when supplied instead of expedition-heavy total story count', () => {
+    const records = emptyCareerRecords();
+    expect(careerTitles({
+      records,
+      guardianRank: 'trainee',
+      openedStories: 9,
+      openedRaisingStories: 2,
+    })).not.toContain('story_witness');
+
+    expect(careerTitles({
+      records,
+      guardianRank: 'trainee',
+      openedStories: 9,
+      openedRaisingStories: 4,
+    })).toContain('story_witness');
+  });
 });

--- a/src/career-records.test.ts
+++ b/src/career-records.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { careerTitles, emptyCareerRecords, recordCareerAction } from './career-records';
+import { careerTitleDefinitions, careerTitles, emptyCareerRecords, recordCareerAction } from './career-records';
 
 describe('career records and titles', () => {
   it('starts with zero lifetime records', () => {
@@ -39,5 +39,9 @@ describe('career records and titles', () => {
       openedStories: 9,
       openedRaisingStories: 4,
     })).toContain('story_witness');
+  });
+
+  it('labels story witness as a raising-story achievement', () => {
+    expect(careerTitleDefinitions.find(title => title.id === 'story_witness')?.description).toContain('육성 스토리');
   });
 });

--- a/src/career-records.test.ts
+++ b/src/career-records.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { careerTitleDefinitions, careerTitles, emptyCareerRecords, recordCareerAction } from './career-records';
+import { careerTitleDefinitions, careerTitles, emptyCareerRecords, recordCareerAction, type CareerAction } from './career-records';
 
 describe('career records and titles', () => {
   it('starts with zero lifetime records', () => {
@@ -17,9 +17,38 @@ describe('career records and titles', () => {
     expect(records).toEqual({ trainings: 3, bestScore: 930, sGrades: 1, outings: 1, gifts: 1, monthsCompleted: 1 });
   });
 
+  it('produces the same career record for the same actions regardless of action order', () => {
+    const actions: CareerAction[] = [
+      { type:'training', score:720, grade:'A' },
+      { type:'training', score:930, grade:'S' },
+      { type:'outing' },
+      { type:'gift' },
+      { type:'month' },
+    ];
+    const forward = actions.reduce(recordCareerAction, emptyCareerRecords());
+    const reverse = [...actions].reverse().reduce(recordCareerAction, emptyCareerRecords());
+    expect(reverse).toEqual(forward);
+  });
+
+  it('ignores non-finite training scores instead of poisoning lifetime best score', () => {
+    const base = recordCareerAction(emptyCareerRecords(), { type:'training', score:850, grade:'A' });
+    const nan = recordCareerAction(base, { type:'training', score:Number.NaN, grade:'C' });
+    const infinite = recordCareerAction(nan, { type:'training', score:Number.POSITIVE_INFINITY, grade:'C' });
+    expect(nan.bestScore).toBe(850);
+    expect(infinite.bestScore).toBe(850);
+  });
+
   it('derives long-term titles from records and existing growth progress', () => {
     const records = { trainings: 12, bestScore: 930, sGrades: 3, outings: 10, gifts: 5, monthsCompleted: 6 };
     expect(careerTitles({ records, guardianRank: 'veteran', openedStories: 4 })).toEqual([
+      'steady_trainer', 'perfect_chaser', 'seasoned_explorer', 'warm_giver', 'story_witness', 'veteran_guardian',
+    ]);
+  });
+
+  it('keeps career title thresholds exact at their boundaries', () => {
+    const base = emptyCareerRecords();
+    expect(careerTitles({ records:{ ...base, trainings:9, bestScore:899, outings:9, gifts:4 }, guardianRank:'junior', openedStories:3, openedRaisingStories:3 })).toEqual([]);
+    expect(careerTitles({ records:{ ...base, trainings:10, bestScore:900, outings:10, gifts:5 }, guardianRank:'veteran', openedStories:4, openedRaisingStories:4 })).toEqual([
       'steady_trainer', 'perfect_chaser', 'seasoned_explorer', 'warm_giver', 'story_witness', 'veteran_guardian',
     ]);
   });
@@ -30,7 +59,7 @@ describe('career records and titles', () => {
       records,
       guardianRank: 'trainee',
       openedStories: 9,
-      openedRaisingStories: 2,
+      openedRaisingStories: 3,
     })).not.toContain('story_witness');
 
     expect(careerTitles({
@@ -39,6 +68,13 @@ describe('career records and titles', () => {
       openedStories: 9,
       openedRaisingStories: 4,
     })).toContain('story_witness');
+  });
+
+  it('keeps different raising records meaningfully distinct in career results', () => {
+    const base = emptyCareerRecords();
+    expect(careerTitles({ records:{ ...base, trainings:10 }, guardianRank:'trainee', openedStories:0, openedRaisingStories:0 })).toEqual(['steady_trainer']);
+    expect(careerTitles({ records:{ ...base, outings:10 }, guardianRank:'trainee', openedStories:0, openedRaisingStories:0 })).toEqual(['seasoned_explorer']);
+    expect(careerTitles({ records:{ ...base, gifts:5 }, guardianRank:'trainee', openedStories:0, openedRaisingStories:0 })).toEqual(['warm_giver']);
   });
 
   it('labels story witness as a raising-story achievement', () => {

--- a/src/career-records.ts
+++ b/src/career-records.ts
@@ -57,13 +57,21 @@ export function recordCareerAction(records: CareerRecords, action: CareerAction)
 
 const guardianOrder: GuardianRankId[] = ['trainee', 'junior', 'guardian', 'veteran', 'starlight'];
 
-export function careerTitles(input: { records: CareerRecords; guardianRank: GuardianRankId; openedStories: number }): CareerTitleId[] {
+export type CareerTitleProgress = {
+  records: CareerRecords;
+  guardianRank: GuardianRankId;
+  openedStories: number;
+  openedRaisingStories?: number;
+};
+
+export function careerTitles(input: CareerTitleProgress): CareerTitleId[] {
   const unlocked = new Set<CareerTitleId>();
+  const relevantStories = input.openedRaisingStories ?? input.openedStories;
   if (input.records.trainings >= 10) unlocked.add('steady_trainer');
   if (input.records.bestScore >= 900) unlocked.add('perfect_chaser');
   if (input.records.outings >= 10) unlocked.add('seasoned_explorer');
   if (input.records.gifts >= 5) unlocked.add('warm_giver');
-  if (input.openedStories >= 4) unlocked.add('story_witness');
+  if (relevantStories >= 4) unlocked.add('story_witness');
   if (guardianOrder.indexOf(input.guardianRank) >= guardianOrder.indexOf('veteran')) unlocked.add('veteran_guardian');
   return careerTitleDefinitions.map(item => item.id).filter(id => unlocked.has(id));
 }

--- a/src/career-records.ts
+++ b/src/career-records.ts
@@ -22,7 +22,7 @@ export const careerTitleDefinitions: Array<{ id: CareerTitleId; label: string; d
   { id: 'perfect_chaser', label: '완벽을 좇는 자', description: '최고 훈련 점수 900 이상.' },
   { id: 'seasoned_explorer', label: '노련한 탐험가', description: '누적 외출 10회 이상.' },
   { id: 'warm_giver', label: '따뜻한 선물가', description: '누적 선물 5회 이상.' },
-  { id: 'story_witness', label: '이야기의 목격자', description: '스토리 챕터 4개 이상 해금.' },
+  { id: 'story_witness', label: '이야기의 목격자', description: '육성 스토리 챕터 4개 이상 해금.' },
   { id: 'veteran_guardian', label: '숙련 수호자의 증표', description: '숙련 수호자 이상.' },
 ];
 

--- a/src/career-records.ts
+++ b/src/career-records.ts
@@ -43,10 +43,11 @@ export type CareerAction =
 
 export function recordCareerAction(records: CareerRecords, action: CareerAction): CareerRecords {
   if (action.type === 'training') {
+    const score = Number.isFinite(action.score) ? Math.max(0, Math.floor(action.score)) : 0;
     return {
       ...records,
       trainings: records.trainings + 1,
-      bestScore: Math.max(records.bestScore, Math.max(0, Math.floor(action.score))),
+      bestScore: Math.max(records.bestScore, score),
       sGrades: records.sGrades + (action.grade === 'S' ? 1 : 0),
     };
   }

--- a/src/raising-depth-rewards.test.ts
+++ b/src/raising-depth-rewards.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { initialState, reducer } from './game';
+import { reconcileBondSceneRewards } from './raising-depth-rewards';
 
 describe('raising depth rewards and bond progression', () => {
   it('unlocks a bond scene only when the current action crosses its condition and rewards it once', () => {
@@ -19,15 +20,33 @@ describe('raising depth rewards and bond progression', () => {
     expect(again.rewardedBondScenes.filter(id => id === 'first_trust')).toHaveLength(1);
   });
 
-  it('does not retroactively reward a scene that was already eligible before an unrelated action', () => {
-    const ready = {
-      ...initialState,
-      stats:{ ...initialState.stats, affection:55 },
+  it('catches up an eligible but missing bond scene and reward exactly once', () => {
+    const progress = {
+      affection:55,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+      unlocked:[],
+      rewarded:[],
+      gold:500,
+      gems:2,
     };
-    const next = reducer(ready, { type:'SET_MONTHLY_FOCUS', focus:'balanced' });
-    expect(next.unlockedBondScenes).toEqual([]);
-    expect(next.rewardedBondScenes).toEqual([]);
-    expect(next.gold).toBe(ready.gold);
+    const caughtUp = reconcileBondSceneRewards(progress, progress);
+    expect(caughtUp.changed).toBe(true);
+    expect(caughtUp.newlyUnlocked).toEqual(['first_trust']);
+    expect(caughtUp.unlocked).toEqual(['first_trust']);
+    expect(caughtUp.rewarded).toEqual(['first_trust']);
+    expect(caughtUp.gold).toBe(600);
+
+    const reconciled = reconcileBondSceneRewards(
+      { ...progress, unlocked:caughtUp.unlocked, rewarded:caughtUp.rewarded, gold:caughtUp.gold },
+      { ...progress, unlocked:caughtUp.unlocked, rewarded:caughtUp.rewarded, gold:caughtUp.gold },
+    );
+    expect(reconciled.changed).toBe(false);
+    expect(reconciled.gold).toBe(600);
   });
 
   it('grants one growth point every completed month and one extra for an S training month', () => {

--- a/src/raising-depth-rewards.test.ts
+++ b/src/raising-depth-rewards.test.ts
@@ -49,6 +49,34 @@ describe('raising depth rewards and bond progression', () => {
     expect(reconciled.gold).toBe(600);
   });
 
+  it('catches up a missing reward for an already unlocked eligible bond scene', () => {
+    const progress = {
+      affection:55,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+      unlocked:['first_trust' as const],
+      rewarded:[],
+      gold:500,
+      gems:2,
+    };
+    const caughtUp = reconcileBondSceneRewards(progress, progress);
+    expect(caughtUp.changed).toBe(true);
+    expect(caughtUp.newlyUnlocked).toEqual([]);
+    expect(caughtUp.rewarded).toEqual(['first_trust']);
+    expect(caughtUp.gold).toBe(600);
+
+    const reconciled = reconcileBondSceneRewards(
+      { ...progress, rewarded:caughtUp.rewarded, gold:caughtUp.gold },
+      { ...progress, rewarded:caughtUp.rewarded, gold:caughtUp.gold },
+    );
+    expect(reconciled.changed).toBe(false);
+    expect(reconciled.gold).toBe(600);
+  });
+
   it('grants one growth point every completed month and one extra for an S training month', () => {
     const normal = reducer({ ...initialState, growthPoints:0, trainingScore:650 }, { type:'NEXT_MONTH' });
     expect(normal.growthPoints).toBe(1);

--- a/src/raising-depth-rewards.test.ts
+++ b/src/raising-depth-rewards.test.ts
@@ -77,6 +77,27 @@ describe('raising depth rewards and bond progression', () => {
     expect(reconciled.gold).toBe(600);
   });
 
+  it('uses an existing unlock as proof for a missing reward even if the live condition later fell below the threshold', () => {
+    const progress = {
+      affection:0,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+      unlocked:['first_trust' as const],
+      rewarded:[],
+      gold:500,
+      gems:2,
+    };
+    const caughtUp = reconcileBondSceneRewards(progress, progress);
+    expect(caughtUp.changed).toBe(true);
+    expect(caughtUp.newlyUnlocked).toEqual([]);
+    expect(caughtUp.rewarded).toEqual(['first_trust']);
+    expect(caughtUp.gold).toBe(600);
+  });
+
   it('grants one growth point every completed month and one extra for an S training month', () => {
     const normal = reducer({ ...initialState, growthPoints:0, trainingScore:650 }, { type:'NEXT_MONTH' });
     expect(normal.growthPoints).toBe(1);

--- a/src/raising-depth-rewards.test.ts
+++ b/src/raising-depth-rewards.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { bondSceneIds } from './bond-scenes';
 import { initialState, reducer } from './game';
 import { reconcileBondSceneRewards } from './raising-depth-rewards';
 
@@ -18,6 +19,15 @@ describe('raising depth rewards and bond progression', () => {
     const again = reducer(first, { type:'SET_MONTHLY_FOCUS', focus:'balanced' });
     expect(again.gold).toBe(first.gold);
     expect(again.rewardedBondScenes.filter(id => id === 'first_trust')).toHaveLength(1);
+  });
+
+  it('keeps the first bond threshold exact', () => {
+    const base = {
+      outings:0, trainings:0, gifts:0, guardianRank:'trainee' as const,
+      bossClears:0, annualRecords:0, unlocked:[], rewarded:[], gold:500, gems:2,
+    };
+    expect(reconcileBondSceneRewards({ ...base, affection:54 }, { ...base, affection:54 }).changed).toBe(false);
+    expect(reconcileBondSceneRewards({ ...base, affection:55 }, { ...base, affection:55 }).newlyUnlocked).toEqual(['first_trust']);
   });
 
   it('catches up an eligible but missing bond scene and reward exactly once', () => {
@@ -96,6 +106,78 @@ describe('raising depth rewards and bond progression', () => {
     expect(caughtUp.newlyUnlocked).toEqual([]);
     expect(caughtUp.rewarded).toEqual(['first_trust']);
     expect(caughtUp.gold).toBe(600);
+  });
+
+  it('restores a missing unlock from an existing reward claim without paying twice', () => {
+    const progress = {
+      affection:0,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+      unlocked:[],
+      rewarded:['first_trust' as const],
+      gold:500,
+      gems:2,
+    };
+    const repaired = reconcileBondSceneRewards(progress, progress);
+    expect(repaired.changed).toBe(true);
+    expect(repaired.unlocked).toEqual(['first_trust']);
+    expect(repaired.rewarded).toEqual(['first_trust']);
+    expect(repaired.gold).toBe(500);
+    expect(repaired.gems).toBe(2);
+  });
+
+  it('canonicalizes duplicate bond state without duplicating rewards', () => {
+    const progress = {
+      affection:0,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+      unlocked:['first_trust' as const, 'first_trust' as const],
+      rewarded:['first_trust' as const, 'first_trust' as const],
+      gold:500,
+      gems:2,
+    };
+    const repaired = reconcileBondSceneRewards(progress, progress);
+    expect(repaired.changed).toBe(true);
+    expect(repaired.unlocked).toEqual(['first_trust']);
+    expect(repaired.rewarded).toEqual(['first_trust']);
+    expect(repaired.gold).toBe(500);
+  });
+
+  it('can catch up every reachable bond scene in one reconciliation regardless of prior action order', () => {
+    const progress = {
+      affection:95,
+      outings:1,
+      trainings:10,
+      gifts:5,
+      guardianRank:'guardian' as const,
+      bossClears:3,
+      annualRecords:1,
+      unlocked:[],
+      rewarded:[],
+      gold:500,
+      gems:2,
+    };
+    const caughtUp = reconcileBondSceneRewards(progress, progress);
+    expect(caughtUp.unlocked).toEqual(bondSceneIds);
+    expect(caughtUp.rewarded).toEqual(bondSceneIds);
+    expect(caughtUp.gold).toBe(1200);
+    expect(caughtUp.gems).toBe(7);
+
+    const stable = reconcileBondSceneRewards(
+      { ...progress, unlocked:caughtUp.unlocked, rewarded:caughtUp.rewarded, gold:caughtUp.gold, gems:caughtUp.gems },
+      { ...progress, unlocked:caughtUp.unlocked, rewarded:caughtUp.rewarded, gold:caughtUp.gold, gems:caughtUp.gems },
+    );
+    expect(stable.changed).toBe(false);
+    expect(stable.gold).toBe(1200);
+    expect(stable.gems).toBe(7);
   });
 
   it('grants one growth point every completed month and one extra for an S training month', () => {

--- a/src/raising-depth-rewards.ts
+++ b/src/raising-depth-rewards.ts
@@ -32,12 +32,22 @@ function eligible(progress: BondRewardProgress): BondSceneId[] {
   });
 }
 
+function sameIds(left: BondSceneId[], right: BondSceneId[]): boolean {
+  return left.length === right.length && left.every((id, index) => id === right[index]);
+}
+
 export function reconcileBondSceneRewards(_previous: BondRewardProgress, current: BondRewardProgress) {
-  const afterEligible = eligible(current);
-  const newlyUnlocked = afterEligible.filter(id => !current.unlocked.includes(id));
-  const unlocked = bondSceneIds.filter(id => current.unlocked.includes(id) || newlyUnlocked.includes(id));
-  const newlyRewarded = unlocked.filter(id => !current.rewarded.includes(id));
-  if (!newlyUnlocked.length && !newlyRewarded.length) return {
+  const claimedUnlocks = bondSceneIds.filter(id => current.unlocked.includes(id));
+  const claimedRewards = bondSceneIds.filter(id => current.rewarded.includes(id));
+  const provenUnlocks = bondSceneIds.filter(id => claimedUnlocks.includes(id) || claimedRewards.includes(id));
+  const afterEligible = eligible({ ...current, unlocked:provenUnlocks });
+  const unlocked = bondSceneIds.filter(id => provenUnlocks.includes(id) || afterEligible.includes(id));
+  const newlyUnlocked = unlocked.filter(id => !claimedUnlocks.includes(id));
+  const newlyRewarded = unlocked.filter(id => !claimedRewards.includes(id));
+  const rewarded = bondSceneIds.filter(id => claimedRewards.includes(id) || newlyRewarded.includes(id));
+  const canonicalized = !sameIds(current.unlocked, unlocked) || !sameIds(current.rewarded, rewarded);
+
+  if (!newlyUnlocked.length && !newlyRewarded.length && !canonicalized) return {
     changed:false,
     unlocked:current.unlocked,
     rewarded:current.rewarded,
@@ -56,7 +66,7 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
   return {
     changed:true,
     unlocked,
-    rewarded:bondSceneIds.filter(id => current.rewarded.includes(id) || newlyRewarded.includes(id)),
+    rewarded,
     gold,
     gems,
     newlyUnlocked,

--- a/src/raising-depth-rewards.ts
+++ b/src/raising-depth-rewards.ts
@@ -32,10 +32,9 @@ function eligible(progress: BondRewardProgress): BondSceneId[] {
   });
 }
 
-export function reconcileBondSceneRewards(previous: BondRewardProgress, current: BondRewardProgress) {
-  const beforeEligible = new Set(eligible(previous));
+export function reconcileBondSceneRewards(_previous: BondRewardProgress, current: BondRewardProgress) {
   const afterEligible = eligible(current);
-  const newlyUnlocked = afterEligible.filter(id => !beforeEligible.has(id) && !current.unlocked.includes(id));
+  const newlyUnlocked = afterEligible.filter(id => !current.unlocked.includes(id));
   if (!newlyUnlocked.length) return {
     changed:false,
     unlocked:current.unlocked,

--- a/src/raising-depth-rewards.ts
+++ b/src/raising-depth-rewards.ts
@@ -36,7 +36,7 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
   const afterEligible = eligible(current);
   const newlyUnlocked = afterEligible.filter(id => !current.unlocked.includes(id));
   const unlocked = bondSceneIds.filter(id => current.unlocked.includes(id) || newlyUnlocked.includes(id));
-  const newlyRewarded = afterEligible.filter(id => unlocked.includes(id) && !current.rewarded.includes(id));
+  const newlyRewarded = unlocked.filter(id => !current.rewarded.includes(id));
   if (!newlyUnlocked.length && !newlyRewarded.length) return {
     changed:false,
     unlocked:current.unlocked,

--- a/src/raising-depth-rewards.ts
+++ b/src/raising-depth-rewards.ts
@@ -35,7 +35,9 @@ function eligible(progress: BondRewardProgress): BondSceneId[] {
 export function reconcileBondSceneRewards(_previous: BondRewardProgress, current: BondRewardProgress) {
   const afterEligible = eligible(current);
   const newlyUnlocked = afterEligible.filter(id => !current.unlocked.includes(id));
-  if (!newlyUnlocked.length) return {
+  const unlocked = bondSceneIds.filter(id => current.unlocked.includes(id) || newlyUnlocked.includes(id));
+  const newlyRewarded = afterEligible.filter(id => unlocked.includes(id) && !current.rewarded.includes(id));
+  if (!newlyUnlocked.length && !newlyRewarded.length) return {
     changed:false,
     unlocked:current.unlocked,
     rewarded:current.rewarded,
@@ -44,8 +46,6 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
     newlyUnlocked:[] as BondSceneId[],
   };
 
-  const unlocked = bondSceneIds.filter(id => current.unlocked.includes(id) || newlyUnlocked.includes(id));
-  const newlyRewarded = newlyUnlocked.filter(id => !current.rewarded.includes(id));
   let gold = current.gold;
   let gems = current.gems;
   for (const id of newlyRewarded) {

--- a/src/raising-story-flow.test.ts
+++ b/src/raising-story-flow.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { careerTitles, emptyCareerRecords } from './career-records';
+import { coreStoryChapterIds, eligibleStoryChapters, type StoryChapterId } from './story-chapters';
+import { reconcileBondSceneRewards } from './raising-depth-rewards';
+import type { GuardianCallingId } from './guardian-callings';
+
+function resolveRaisingFlow(affection: number, activeCalling: GuardianCallingId | null) {
+  const bondProgress = {
+    affection,
+    outings:1,
+    trainings:1,
+    gifts:0,
+    guardianRank:'guardian' as const,
+    bossClears:0,
+    annualRecords:0,
+    unlocked:[],
+    rewarded:[],
+    gold:500,
+    gems:2,
+  };
+  const bond = reconcileBondSceneRewards(bondProgress, bondProgress);
+  const stories = eligibleStoryChapters({
+    memories:['first_training'],
+    visitedOutings:['forest','village','lakeside'],
+    affection,
+    guardianRank:'guardian',
+    discoveries:0,
+    expeditionStoryEntries:[],
+    unlockedBondScenes:bond.unlocked,
+    activeCalling,
+  });
+  const raisingStories = stories.filter((id): id is StoryChapterId => coreStoryChapterIds.includes(id as never)).length;
+  const records = { ...emptyCareerRecords(), trainings:1, outings:3 };
+  const titles = careerTitles({
+    records,
+    guardianRank:'guardian',
+    openedStories:stories.length,
+    openedRaisingStories:raisingStories,
+  });
+  return { bond, stories, titles };
+}
+
+describe('raising -> bond -> story -> career flow', () => {
+  it('turns the exact shared-secret bond threshold into a real story and career difference', () => {
+    const before = resolveRaisingFlow(74, 'caretaker');
+    const after = resolveRaisingFlow(75, 'caretaker');
+
+    expect(before.bond.unlocked).not.toContain('shared_secret');
+    expect(before.stories).toEqual(['first_step','wide_world']);
+    expect(before.titles).not.toContain('story_witness');
+
+    expect(after.bond.unlocked).toContain('shared_secret');
+    expect(after.stories).toEqual(['first_step','wide_world','trusted_bond','guardian_oath']);
+    expect(after.titles).toContain('story_witness');
+  });
+
+  it('makes the Calling choice meaningful after the same bond result', () => {
+    const uncalled = resolveRaisingFlow(75, null);
+    const called = resolveRaisingFlow(75, 'caretaker');
+
+    expect(uncalled.bond.unlocked).toEqual(called.bond.unlocked);
+    expect(uncalled.stories).toEqual(['first_step','wide_world','trusted_bond']);
+    expect(uncalled.titles).not.toContain('story_witness');
+    expect(called.stories).toEqual(['first_step','wide_world','trusted_bond','guardian_oath']);
+    expect(called.titles).toContain('story_witness');
+  });
+
+  it('keeps the core raising story list unique and ordered for downstream career counting', () => {
+    const resolved = resolveRaisingFlow(95, 'pathfinder');
+    const core = resolved.stories.filter(id => coreStoryChapterIds.includes(id as never));
+    expect(core).toEqual(['first_step','wide_world','trusted_bond','guardian_oath']);
+    expect(new Set(core).size).toBe(core.length);
+  });
+});

--- a/src/story-chapters.test.ts
+++ b/src/story-chapters.test.ts
@@ -26,6 +26,34 @@ describe('story chapter rules', () => {
     })).toEqual(['first_step', 'wide_world', 'trusted_bond', 'guardian_oath']);
   });
 
+  it('uses unlocked bond scenes as the trusted-bond source when relationship progress is supplied', () => {
+    const base = {
+      memories: [],
+      visitedOutings: [],
+      affection: 95,
+      guardianRank: 'trainee' as const,
+      discoveries: 0,
+      expeditionStoryEntries: [],
+      unlockedBondScenes: [] as const,
+    };
+    expect(eligibleStoryChapters(base)).not.toContain('trusted_bond');
+    expect(eligibleStoryChapters({ ...base, unlockedBondScenes:['shared_secret'] as const })).toContain('trusted_bond');
+  });
+
+  it('requires an actual Calling choice for guardian oath when Calling progress is supplied', () => {
+    const base = {
+      memories: [],
+      visitedOutings: [],
+      affection: 95,
+      guardianRank: 'guardian' as const,
+      discoveries: 0,
+      expeditionStoryEntries: [],
+      activeCalling: null,
+    };
+    expect(eligibleStoryChapters(base)).not.toContain('guardian_oath');
+    expect(eligibleStoryChapters({ ...base, activeCalling:'caretaker' as const })).toContain('guardian_oath');
+  });
+
   it('unlocks expedition chapters exactly from cleared expedition story entries', () => {
     const opened = eligibleStoryChapters({
       memories: [], visitedOutings: [], affection: 0, guardianRank: 'trainee', discoveries: 0,

--- a/src/story-chapters.test.ts
+++ b/src/story-chapters.test.ts
@@ -30,11 +30,11 @@ describe('story chapter rules', () => {
   it('does not let late-game conditions skip the earlier raising story, but catches up in one evaluation once the start exists', () => {
     const matureProgress = {
       memories: [] as string[],
-      visitedOutings: ['forest', 'village', 'lakeside'] as const,
+      visitedOutings: ['forest', 'village', 'lakeside'],
       affection: 100,
       guardianRank: 'veteran' as const,
       discoveries: 6,
-      expeditionStoryEntries: [] as const,
+      expeditionStoryEntries: [],
       unlockedBondScenes: ['shared_secret'] as const,
       activeCalling: 'caretaker' as const,
     };

--- a/src/story-chapters.test.ts
+++ b/src/story-chapters.test.ts
@@ -7,6 +7,7 @@ describe('story chapter rules', () => {
       'first_step', 'wide_world', 'trusted_bond', 'guardian_oath', 'starlight_road',
     ]);
     expect(storyChapterDefinitions).toHaveLength(14);
+    expect(new Set(storyChapterDefinitions.map(chapter => chapter.id)).size).toBe(storyChapterDefinitions.length);
     expect(storyChapterDefinitions.slice(5).map(chapter => chapter.id)).toEqual([
       'forest_path','forest_glade','forest_guardian','city_square','city_gallery','city_core','lake_channel','lake_cliff','lake_tempest',
     ]);
@@ -26,10 +27,26 @@ describe('story chapter rules', () => {
     })).toEqual(['first_step', 'wide_world', 'trusted_bond', 'guardian_oath']);
   });
 
+  it('does not let late-game conditions skip the earlier raising story, but catches up in one evaluation once the start exists', () => {
+    const matureProgress = {
+      memories: [] as string[],
+      visitedOutings: ['forest', 'village', 'lakeside'] as const,
+      affection: 100,
+      guardianRank: 'veteran' as const,
+      discoveries: 6,
+      expeditionStoryEntries: [] as const,
+      unlockedBondScenes: ['shared_secret'] as const,
+      activeCalling: 'caretaker' as const,
+    };
+
+    expect(eligibleStoryChapters(matureProgress)).toEqual([]);
+    expect(eligibleStoryChapters({ ...matureProgress, memories:['first_training'] })).toEqual(coreStoryChapterIds);
+  });
+
   it('uses unlocked bond scenes as the trusted-bond source when relationship progress is supplied', () => {
     const base = {
-      memories: [],
-      visitedOutings: [],
+      memories: ['first_training'],
+      visitedOutings: ['forest', 'village', 'lakeside'],
       affection: 95,
       guardianRank: 'trainee' as const,
       discoveries: 0,
@@ -40,14 +57,27 @@ describe('story chapter rules', () => {
     expect(eligibleStoryChapters({ ...base, unlockedBondScenes:['shared_secret'] as const })).toContain('trusted_bond');
   });
 
+  it('keeps the fallback bond threshold exact when relationship progress is not supplied', () => {
+    const base = {
+      memories: ['first_training'],
+      visitedOutings: ['forest', 'village', 'lakeside'],
+      guardianRank: 'trainee' as const,
+      discoveries: 0,
+      expeditionStoryEntries: [],
+    };
+    expect(eligibleStoryChapters({ ...base, affection:74 })).not.toContain('trusted_bond');
+    expect(eligibleStoryChapters({ ...base, affection:75 })).toContain('trusted_bond');
+  });
+
   it('requires an actual Calling choice for guardian oath when Calling progress is supplied', () => {
     const base = {
-      memories: [],
-      visitedOutings: [],
+      memories: ['first_training'],
+      visitedOutings: ['forest', 'village', 'lakeside'],
       affection: 95,
       guardianRank: 'guardian' as const,
       discoveries: 0,
       expeditionStoryEntries: [],
+      unlockedBondScenes: ['shared_secret'] as const,
       activeCalling: null,
     };
     expect(eligibleStoryChapters(base)).not.toContain('guardian_oath');
@@ -67,9 +97,15 @@ describe('story chapter rules', () => {
     expect(opened).toEqual(['forest_path','forest_glade']);
   });
 
-  it('requires veteran rank and four discoveries for the final raising chapter', () => {
+  it('requires veteran rank and exactly four discoveries for the final raising chapter', () => {
     const base = {
-      memories: ['first_training'], visitedOutings: ['forest', 'village', 'lakeside'], affection: 90, guardianRank: 'veteran' as const, expeditionStoryEntries: [],
+      memories: ['first_training'],
+      visitedOutings: ['forest', 'village', 'lakeside'],
+      affection: 90,
+      guardianRank: 'veteran' as const,
+      expeditionStoryEntries: [],
+      unlockedBondScenes: ['shared_secret'] as const,
+      activeCalling: 'pathfinder' as const,
     };
     expect(eligibleStoryChapters({ ...base, discoveries: 3 })).not.toContain('starlight_road');
     expect(eligibleStoryChapters({ ...base, discoveries: 4 })).toContain('starlight_road');

--- a/src/story-chapters.test.ts
+++ b/src/story-chapters.test.ts
@@ -54,6 +54,11 @@ describe('story chapter rules', () => {
     expect(eligibleStoryChapters({ ...base, activeCalling:'caretaker' as const })).toContain('guardian_oath');
   });
 
+  it('describes Calling-dependent story gates in the player-facing unlock hints', () => {
+    expect(storyChapterDefinitions.find(chapter => chapter.id === 'guardian_oath')?.unlockHint).toContain('Calling');
+    expect(storyChapterDefinitions.find(chapter => chapter.id === 'starlight_road')?.unlockHint).toContain('Calling');
+  });
+
   it('unlocks expedition chapters exactly from cleared expedition story entries', () => {
     const opened = eligibleStoryChapters({
       memories: [], visitedOutings: [], affection: 0, guardianRank: 'trainee', discoveries: 0,

--- a/src/story-chapters.ts
+++ b/src/story-chapters.ts
@@ -1,7 +1,9 @@
 import type { MemoryId } from './game-core';
 import type { OutingLocationId } from './adventure';
+import type { BondSceneId } from './bond-scenes';
 import { expeditionStoryDefinitions } from './expedition-story';
 import type { ExpeditionStageId } from './expedition-regions';
+import type { GuardianCallingId } from './guardian-callings';
 import type { GuardianRankId } from './guardian-rank';
 
 export type CoreStoryChapterId = 'first_step' | 'wide_world' | 'trusted_bond' | 'guardian_oath' | 'starlight_road';
@@ -22,6 +24,8 @@ export type StoryProgress = {
   guardianRank: GuardianRankId;
   discoveries: number;
   expeditionStoryEntries?: ExpeditionStageId[] | string[];
+  unlockedBondScenes?: readonly BondSceneId[];
+  activeCalling?: GuardianCallingId | null;
 };
 
 const coreStoryChapterDefinitions: StoryChapterDefinition[] = [
@@ -51,13 +55,22 @@ function rankAtLeast(rank: GuardianRankId, target: GuardianRankId): boolean {
   return guardianRankOrder.indexOf(rank) >= guardianRankOrder.indexOf(target);
 }
 
+function trustedBondReady(progress: StoryProgress): boolean {
+  if (progress.unlockedBondScenes === undefined) return progress.affection >= 75;
+  return progress.unlockedBondScenes.includes('shared_secret');
+}
+
+function callingChosen(progress: StoryProgress): boolean {
+  return progress.activeCalling === undefined || progress.activeCalling !== null;
+}
+
 export function eligibleStoryChapters(progress: StoryProgress): StoryChapterId[] {
   const unlocked = new Set<StoryChapterId>();
   if (progress.memories.includes('first_training')) unlocked.add('first_step');
   if (requiredOutings.every(id => progress.visitedOutings.includes(id))) unlocked.add('wide_world');
-  if (progress.affection >= 75) unlocked.add('trusted_bond');
-  if (rankAtLeast(progress.guardianRank, 'guardian')) unlocked.add('guardian_oath');
-  if (rankAtLeast(progress.guardianRank, 'veteran') && progress.discoveries >= 4) unlocked.add('starlight_road');
+  if (trustedBondReady(progress)) unlocked.add('trusted_bond');
+  if (rankAtLeast(progress.guardianRank, 'guardian') && callingChosen(progress)) unlocked.add('guardian_oath');
+  if (rankAtLeast(progress.guardianRank, 'veteran') && progress.discoveries >= 4 && callingChosen(progress)) unlocked.add('starlight_road');
   for (const id of progress.expeditionStoryEntries ?? []) {
     if (expeditionStoryDefinitions.some(entry => entry.stageId === id)) unlocked.add(id as ExpeditionStageId);
   }

--- a/src/story-chapters.ts
+++ b/src/story-chapters.ts
@@ -30,10 +30,10 @@ export type StoryProgress = {
 
 const coreStoryChapterDefinitions: StoryChapterDefinition[] = [
   { id: 'first_step', title: '첫 발걸음', summary: '루나는 처음으로 수호자 훈련을 마쳤다. 작은 한 걸음이 앞으로 이어질 긴 여정의 시작이 되었다.', unlockHint: '첫 훈련을 완료하면 열려요.', rewardGems: 0 },
-  { id: 'wide_world', title: '넓어진 세계', summary: '별빛 숲과 마법 마을, 바람 호숫가를 돌아본 루나는 집 밖의 세계가 생각보다 훨씬 넓다는 걸 알게 되었다.', unlockHint: '세 곳의 외출 장소를 모두 방문하면 열려요.', rewardGems: 1 },
-  { id: 'trusted_bond', title: '마음을 나누는 사이', summary: '함께 보낸 시간이 쌓이며 루나는 조심스럽게 마음속 이야기를 꺼내기 시작했다.', unlockHint: '루나와 가까운 친구가 되면 열려요.', rewardGems: 1 },
-  { id: 'guardian_oath', title: '수호자의 맹세', summary: '쌓아온 기억과 숙련은 이제 우연이 아니다. 루나는 정식 수호자로서 자신의 길을 선택한다.', unlockHint: '정식 수호자 등급에 도달하고 Calling을 선택하면 열려요.', rewardGems: 2 },
-  { id: 'starlight_road', title: '별빛으로 가는 길', summary: '숨겨진 흔적들이 하나의 방향을 가리킨다. 루나는 더 먼 곳에서 자신을 부르는 별빛을 느낀다.', unlockHint: 'Calling 선택 + 숙련 수호자 이상 + 숨겨진 발견물 4개가 필요해요.', rewardGems: 3 },
+  { id: 'wide_world', title: '넓어진 세계', summary: '별빛 숲과 마법 마을, 바람 호숫가를 돌아본 루나는 집 밖의 세계가 생각보다 훨씬 넓다는 걸 알게 되었다.', unlockHint: '첫 발걸음 이후 세 곳의 외출 장소를 모두 방문하면 열려요.', rewardGems: 1 },
+  { id: 'trusted_bond', title: '마음을 나누는 사이', summary: '함께 보낸 시간이 쌓이며 루나는 조심스럽게 마음속 이야기를 꺼내기 시작했다.', unlockHint: '넓어진 세계 이후 루나와 가까운 친구가 되면 열려요.', rewardGems: 1 },
+  { id: 'guardian_oath', title: '수호자의 맹세', summary: '쌓아온 기억과 숙련은 이제 우연이 아니다. 루나는 정식 수호자로서 자신의 길을 선택한다.', unlockHint: '마음을 나누는 사이 이후 정식 수호자 등급에 도달하고 Calling을 선택하면 열려요.', rewardGems: 2 },
+  { id: 'starlight_road', title: '별빛으로 가는 길', summary: '숨겨진 흔적들이 하나의 방향을 가리킨다. 루나는 더 먼 곳에서 자신을 부르는 별빛을 느낀다.', unlockHint: '수호자의 맹세 이후 Calling 선택 + 숙련 수호자 이상 + 숨겨진 발견물 4개가 필요해요.', rewardGems: 3 },
 ];
 
 export const coreStoryChapterIds = coreStoryChapterDefinitions.map(chapter => chapter.id as CoreStoryChapterId);
@@ -66,11 +66,28 @@ function callingChosen(progress: StoryProgress): boolean {
 
 export function eligibleStoryChapters(progress: StoryProgress): StoryChapterId[] {
   const unlocked = new Set<StoryChapterId>();
-  if (progress.memories.includes('first_training')) unlocked.add('first_step');
-  if (requiredOutings.every(id => progress.visitedOutings.includes(id))) unlocked.add('wide_world');
-  if (trustedBondReady(progress)) unlocked.add('trusted_bond');
-  if (rankAtLeast(progress.guardianRank, 'guardian') && callingChosen(progress)) unlocked.add('guardian_oath');
-  if (rankAtLeast(progress.guardianRank, 'veteran') && progress.discoveries >= 4 && callingChosen(progress)) unlocked.add('starlight_road');
+
+  const firstStepReady = progress.memories.includes('first_training');
+  if (firstStepReady) {
+    unlocked.add('first_step');
+
+    const wideWorldReady = requiredOutings.every(id => progress.visitedOutings.includes(id));
+    if (wideWorldReady) {
+      unlocked.add('wide_world');
+
+      const bondReady = trustedBondReady(progress);
+      if (bondReady) {
+        unlocked.add('trusted_bond');
+
+        const oathReady = rankAtLeast(progress.guardianRank, 'guardian') && callingChosen(progress);
+        if (oathReady) {
+          unlocked.add('guardian_oath');
+          if (rankAtLeast(progress.guardianRank, 'veteran') && progress.discoveries >= 4) unlocked.add('starlight_road');
+        }
+      }
+    }
+  }
+
   for (const id of progress.expeditionStoryEntries ?? []) {
     if (expeditionStoryDefinitions.some(entry => entry.stageId === id)) unlocked.add(id as ExpeditionStageId);
   }

--- a/src/story-chapters.ts
+++ b/src/story-chapters.ts
@@ -32,8 +32,8 @@ const coreStoryChapterDefinitions: StoryChapterDefinition[] = [
   { id: 'first_step', title: '첫 발걸음', summary: '루나는 처음으로 수호자 훈련을 마쳤다. 작은 한 걸음이 앞으로 이어질 긴 여정의 시작이 되었다.', unlockHint: '첫 훈련을 완료하면 열려요.', rewardGems: 0 },
   { id: 'wide_world', title: '넓어진 세계', summary: '별빛 숲과 마법 마을, 바람 호숫가를 돌아본 루나는 집 밖의 세계가 생각보다 훨씬 넓다는 걸 알게 되었다.', unlockHint: '세 곳의 외출 장소를 모두 방문하면 열려요.', rewardGems: 1 },
   { id: 'trusted_bond', title: '마음을 나누는 사이', summary: '함께 보낸 시간이 쌓이며 루나는 조심스럽게 마음속 이야기를 꺼내기 시작했다.', unlockHint: '루나와 가까운 친구가 되면 열려요.', rewardGems: 1 },
-  { id: 'guardian_oath', title: '수호자의 맹세', summary: '쌓아온 기억과 숙련은 이제 우연이 아니다. 루나는 정식 수호자로서 자신의 길을 선택한다.', unlockHint: '정식 수호자 등급에 도달하면 열려요.', rewardGems: 2 },
-  { id: 'starlight_road', title: '별빛으로 가는 길', summary: '숨겨진 흔적들이 하나의 방향을 가리킨다. 루나는 더 먼 곳에서 자신을 부르는 별빛을 느낀다.', unlockHint: '숙련 수호자 이상 + 숨겨진 발견물 4개가 필요해요.', rewardGems: 3 },
+  { id: 'guardian_oath', title: '수호자의 맹세', summary: '쌓아온 기억과 숙련은 이제 우연이 아니다. 루나는 정식 수호자로서 자신의 길을 선택한다.', unlockHint: '정식 수호자 등급에 도달하고 Calling을 선택하면 열려요.', rewardGems: 2 },
+  { id: 'starlight_road', title: '별빛으로 가는 길', summary: '숨겨진 흔적들이 하나의 방향을 가리킨다. 루나는 더 먼 곳에서 자신을 부르는 별빛을 느낀다.', unlockHint: 'Calling 선택 + 숙련 수호자 이상 + 숨겨진 발견물 4개가 필요해요.', rewardGems: 3 },
 ];
 
 export const coreStoryChapterIds = coreStoryChapterDefinitions.map(chapter => chapter.id as CoreStoryChapterId);


### PR DESCRIPTION
## 구현한 기능
- Raising Depth/Bond 보상 누락·중복 상태를 canonicalize하고 이미 지급된 보상을 재지급하지 않도록 복구 로직 보강
- Bond 결과(`shared_secret`)와 Calling 선택이 Story Chapter 조건에 실제 차이를 만들 수 있도록 `eligibleStoryChapters` 공개 입력 계약 보강
- 코어 육성 스토리를 `first_step → wide_world → trusted_bond → guardian_oath → starlight_road` 순서로 고정하면서, 선행 조건을 늦게 만족해도 한 번의 평가에서 catch-up 가능하도록 처리
- Career `story_witness`가 원정 스토리 개수로 우회되지 않도록 `openedRaisingStories` 입력 지원
- Career Record가 행동 순서와 비정상 점수(NaN/Infinity)에 흔들리지 않도록 방어
- `raising-story-flow.test.ts`로 Bond → Story → Career 공개 함수 연결 회귀 계약 추가

## 변경 파일
- `src/raising-depth-rewards.ts`
- `src/raising-depth-rewards.test.ts`
- `src/story-chapters.ts`
- `src/story-chapters.test.ts`
- `src/career-records.ts`
- `src/career-records.test.ts`
- `src/raising-story-flow.test.ts`

## 테스트 결과
- 담당 모듈 독립 targeted regression harness: 15/15 PASS
- 확인 범위: Bond 임계값/중복 보상/catch-up, Story 순서·경계값·Calling/Bond 차이, Career 임계값·행동 순서 불변성·NaN/Infinity 방어, raising-story-flow 연결
- 전체 `npm run build`는 현재 공용 `game.ts` / `game-core.ts` / `game-base.ts`의 기존 GameState/GrowthReport 타입 불일치 및 누락 export 때문에 실패 상태
- 최신 Vercel 로그에서 이 PR의 7개 담당 파일에서 새 타입 오류는 확인되지 않음

## 공용 파일 연결 필요사항
- `src/game-base.ts`의 `currentStoryChapters(state)`에서 `unlockedBondScenes: state.unlockedBondScenes`, `activeCalling: state.activeCalling`을 `eligibleStoryChapters()`에 전달
- `src/game-base.ts`의 `currentCareerTitles(state)`에서 전체 스토리 수와 별도로 `coreStoryChapterIds` 기준 육성 스토리 수를 계산해 `openedRaisingStories`로 전달
- `src/game-base.ts`의 진행 보상 reconciliation 순서를 현재 `Guardian → Story → Bond`에서 `Guardian → Bond → Story`로 바꿔, 같은 행동에서 열린 Bond가 Story에 한 박자 늦게 반영되는 순서 의존 버그 방지
- save/hydration에서 `rewardedBondScenes` claim을 `unlockedBondScenes` 누락 때문에 버리지 않도록 보존 필요

## 다른 작업방과 충돌 가능성이 있는 파일
- `src/game-base.ts` — 통합·QA 공용 핵심 파일
- `src/game-core.ts`, `src/game.ts` — 현재 전체 빌드 실패의 공용 타입 충돌 영역이며 이 PR에서는 수정하지 않음
- save/hydration 계열 — Bond reward claim 보존 정책과 충돌 가능

## 저장 데이터 영향
- 신규 저장 필드 추가 없음
- 기존 `unlockedBondScenes` / `rewardedBondScenes` 배열을 canonical order/unique 상태로 복구할 수 있음
- 이미 지급된 reward claim은 재지급하지 않는 것이 전제
- hydration에서 reward claim을 먼저 삭제하면 중복 지급 방지 증거를 잃을 수 있으므로 통합 시 주의 필요

## 06 통합 시 주의사항
- Bond/Calling 입력 연결과 reconciliation 순서 변경을 반드시 같이 적용해야 함. 입력만 연결하고 Story를 Bond보다 먼저 계산하면 `shared_secret`이 열린 행동에서 `trusted_bond`가 다음 행동까지 지연됨
- Career에는 `openedStories` 전체 개수만 넘기지 말고 `openedRaisingStories`를 별도로 전달해야 원정 스토리 우회가 막힘
- 기존 보상 지급 플래그를 초기화하거나 재계산하지 말 것
- 공용 타입 오류가 해결된 뒤 full `npm test` + `npm run build` + 실제 GameState end-to-end 회귀 테스트 필요

> 상태 메모: 이 PR은 새 Draft-only 운영 규칙 도입 전에 이미 `integration/v2`에 merge된 과거 통합 건입니다. 동일 diff로 새 Draft PR을 만들 수 없으므로 기록만 새 표준 형식으로 갱신했습니다. 이후 Raising 작업 묶음은 반드시 `work/raising-story` commit/push 후 `integration/v2` 대상 Draft PR을 생성/갱신하고 직접 merge하지 않습니다.