### PR TITLE
03 Season: Season Meta Integration Candidate Freeze

### DIFF
--- a/src/astral-rift-ui.test.ts
+++ b/src/astral-rift-ui.test.ts
@@ -23,6 +23,15 @@ describe('Astral Rift UI summary', () => {
     expect(nebula.intensities[1]).toEqual(expect.objectContaining({ intensity:2, available:true }));
   });
 
+  it('exposes the next Celestial score target that unlocks new Rifts', () => {
+    const summary = astralRiftUiSummary(initialState);
+    expect(summary.nextUnlock).toEqual({
+      threshold:12,
+      remaining:12,
+      riftIds:['nebula_garden','lunar_ruins'],
+    });
+  });
+
   it('summarizes weekly directives, relic purchase states and honors', () => {
     const summary = astralRiftUiSummary({
       ...initialState,

--- a/src/astral-rift-ui.ts
+++ b/src/astral-rift-ui.ts
@@ -1,5 +1,5 @@
 import type { GameState } from './game';
-import { astralRiftDefinitions, astralRiftPower, canEnterAstralRift, type AstralRiftIntensity } from './astral-rift';
+import { astralRiftDefinitions, astralRiftPower, canEnterAstralRift, nextAstralRiftUnlock, type AstralRiftIntensity } from './astral-rift';
 import { astralRiftRelics } from './astral-rift-relics';
 import { astralRiftWeeklyDirectives, astralRiftWeeklyKey } from './astral-rift-weekly';
 import { astralRiftHonors, astralRiftHonorProgress } from './astral-rift-honors';
@@ -66,6 +66,7 @@ export function astralRiftUiSummary(state:GameState) {
     power,
     echoes:state.astralRiftEchoes,
     ascension:celestialAscensionRank(ascension),
+    nextUnlock:nextAstralRiftUnlock(ascension),
     rifts,
     directives,
     relics,

--- a/src/astral-rift.test.ts
+++ b/src/astral-rift.test.ts
@@ -4,6 +4,7 @@ import {
   astralRiftPower,
   astralRiftChallenge,
   canEnterAstralRift,
+  nextAstralRiftUnlock,
   resolveAstralRift,
   updateAstralRiftRecord,
   type AstralRiftRecordMap,
@@ -19,6 +20,25 @@ describe('Astral Rift domain', () => {
     expect(astralRiftChallenge('nebula_garden',1).targetPower).toBe(60);
     expect(astralRiftChallenge('nebula_garden',3).targetPower).toBe(130);
     expect(astralRiftChallenge('empyrean_gate',3).targetPower).toBe(245);
+  });
+
+  it('reports the next Rift unlock as a clear Celestial Ascension goal', () => {
+    expect(nextAstralRiftUnlock(11)).toEqual({
+      threshold:12,
+      remaining:1,
+      riftIds:['nebula_garden','lunar_ruins'],
+    });
+    expect(nextAstralRiftUnlock(12)).toEqual({
+      threshold:28,
+      remaining:16,
+      riftIds:['comet_pass','eclipse_vault'],
+    });
+    expect(nextAstralRiftUnlock(48)).toEqual({
+      threshold:72,
+      remaining:24,
+      riftIds:['empyrean_gate'],
+    });
+    expect(nextAstralRiftUnlock(72)).toBeNull();
   });
 
   it('derives rift power from ascension, sanctuary, calling mastery and blessings', () => {

--- a/src/astral-rift.ts
+++ b/src/astral-rift.ts
@@ -41,6 +41,20 @@ const gradeEchoes:Record<Exclude<AstralRiftGrade,'C'>,number> = { B:0, A:2, S:4 
 const clampInt = (value:number,min:number,max:number) => Math.min(max,Math.max(min,Number.isFinite(value) ? Math.floor(value) : min));
 const recordKey = (riftId:AstralRiftId,intensity:AstralRiftIntensity) => `${riftId}:${intensity}`;
 
+export function nextAstralRiftUnlock(rawAscensionScore:number) {
+  const score = clampInt(rawAscensionScore,0,83);
+  const thresholds = astralRiftDefinitions
+    .map(item => item.ascensionThreshold)
+    .filter(threshold => threshold > score);
+  if (thresholds.length === 0) return null;
+  const threshold = Math.min(...thresholds);
+  return {
+    threshold,
+    remaining:threshold - score,
+    riftIds:astralRiftDefinitions.filter(item => item.ascensionThreshold === threshold).map(item => item.id),
+  };
+}
+
 export function astralRiftPower(input:{
   ascensionScore:number;
   sanctuaryGrandProgress:number;

--- a/src/celestial-ascension.test.ts
+++ b/src/celestial-ascension.test.ts
@@ -15,6 +15,19 @@ describe('celestial ascension', () => {
     })).toBe(40);
   });
 
+  it('counts only one Astral clear per calendar month toward ascension', () => {
+    expect(celestialAscensionProgress({
+      trialRecords:[
+        { key:'1-1:scholar_trial', grade:'B', power:80 },
+        { key:'1-1:scholar_trial', grade:'S', power:110 },
+        { key:'1-1:wayfarer_trial', grade:'S', power:115 },
+      ],
+      blessingCount:0,
+      constellationCount:0,
+      sanctuaryGrandProgress:0,
+    })).toBe(6);
+  });
+
   it('clamps noisy inputs and caps repeat-clear contribution', () => {
     const records = Array.from({ length:30 },(_,index) => ({
       key:`${index + 1}-1:scholar_trial`,

--- a/src/celestial-ascension.ts
+++ b/src/celestial-ascension.ts
@@ -1,4 +1,5 @@
 import type { AstralTrialGrade } from './sanctuary-astral-trials';
+import { celestialRecordProgress } from './celestial-records';
 
 export type CelestialAscensionRankId = 'earthbound'|'awakened'|'stellar'|'empyrean'|'transcendent';
 export type CelestialAscensionRewardRank = Exclude<CelestialAscensionRankId,'earthbound'>;
@@ -20,7 +21,6 @@ export const celestialAscensionRewards = [
 ];
 
 const clampInt = (value:number,min:number,max:number) => Math.min(max,Math.max(min,Number.isFinite(value) ? Math.floor(value) : min));
-const trialFromKey = (key:string) => key.split(':')[1] ?? '';
 
 export function celestialAscensionProgress(input:{
   trialRecords:ReadonlyArray<CelestialAscensionRecord>;
@@ -28,14 +28,9 @@ export function celestialAscensionProgress(input:{
   constellationCount:number;
   sanctuaryGrandProgress:number;
 }):number {
-  const clears = Math.min(12,input.trialRecords.length) * 2;
-  const uniqueS = new Set<string>();
-  for (const record of input.trialRecords) {
-    if (record.grade !== 'S') continue;
-    const trial = trialFromKey(record.key);
-    if (trial) uniqueS.add(trial);
-  }
-  const sScore = Math.min(4,uniqueS.size) * 4;
+  const recordProgress = celestialRecordProgress(input.trialRecords);
+  const clears = Math.min(12,recordProgress.totalClears) * 2;
+  const sScore = Math.min(4,recordProgress.uniqueSClears) * 4;
   const blessingScore = clampInt(input.blessingCount,0,4) * 5;
   const constellationScore = clampInt(input.constellationCount,0,5) * 2;
   const sanctuaryScore = Math.floor(clampInt(input.sanctuaryGrandProgress,0,65) / 5);

--- a/src/celestial-records.test.ts
+++ b/src/celestial-records.test.ts
@@ -15,6 +15,19 @@ describe('celestial records', () => {
     expect(progress).toEqual({ totalClears:5, uniqueTrials:4, uniqueSClears:2 });
   });
 
+  it('counts at most one Astral record per calendar month', () => {
+    const progress = celestialRecordProgress([
+      record('1-1:scholar_trial','A',90),
+      record('1-1:scholar_trial','S',110),
+      record('1-1:wayfarer_trial','S',115),
+      record('1-2:wayfarer_trial','A',92),
+    ]);
+
+    expect(progress.totalClears).toBe(2);
+    expect(progress.uniqueTrials).toBe(2);
+    expect(progress.uniqueSClears).toBe(1);
+  });
+
   it('defines long-term astral honor milestones', () => {
     expect(celestialHonors.map(item => item.id)).toEqual(['first_light','full_cycle','perfect_cycle','twelve_trials']);
   });
@@ -25,5 +38,10 @@ describe('celestial records', () => {
       record('1-3:guardian_trial','S'), record('1-4:crown_trial','S'),
     ];
     expect(newlyEarnedCelestialHonors(records,['first_light']).map(item => item.id)).toEqual(['full_cycle','perfect_cycle']);
+  });
+
+  it('does not unlock lifetime honors from duplicate records in one month', () => {
+    const records = Array.from({ length:12 },(_,index) => record(`1-1:${index % 2 === 0 ? 'scholar_trial' : 'wayfarer_trial'}`,'S',110 + index));
+    expect(newlyEarnedCelestialHonors(records,[]).map(item => item.id)).toEqual(['first_light']);
   });
 });

--- a/src/celestial-records.ts
+++ b/src/celestial-records.ts
@@ -18,18 +18,41 @@ export const celestialHonors:CelestialHonor[] = [
   { id:'twelve_trials', label:'천체 연대기', description:'누적 12회의 Astral Trial을 완료했어요.', metric:'totalClears', threshold:12, reward:{ gold:800, gems:4, starShards:4 } },
 ];
 
+const gradeRank:Record<AstralTrialGrade,number> = { B:1, A:2, S:3 };
 const trialFromKey = (key:string) => key.split(':')[1] ?? '';
+const monthFromKey = (key:string) => key.split(':')[0] ?? '';
+
+export function canonicalCelestialRecords(records:ReadonlyArray<CelestialRecord>):CelestialRecord[] {
+  const byMonth = new Map<string,CelestialRecord>();
+  for (const record of records) {
+    const month = monthFromKey(record.key);
+    const trial = trialFromKey(record.key);
+    if (!month || !trial) continue;
+    const existing = byMonth.get(month);
+    if (!existing) {
+      byMonth.set(month,record);
+      continue;
+    }
+    if (existing.key !== record.key) continue;
+    if (gradeRank[record.grade] > gradeRank[existing.grade]
+      || (record.grade === existing.grade && record.power > existing.power)) {
+      byMonth.set(month,record);
+    }
+  }
+  return [...byMonth.values()];
+}
 
 export function celestialRecordProgress(records:ReadonlyArray<CelestialRecord>) {
+  const canonical = canonicalCelestialRecords(records);
   const unique = new Set<string>();
   const uniqueS = new Set<string>();
-  for (const record of records) {
+  for (const record of canonical) {
     const trial = trialFromKey(record.key);
     if (!trial) continue;
     unique.add(trial);
     if (record.grade === 'S') uniqueS.add(trial);
   }
-  return { totalClears:records.length, uniqueTrials:unique.size, uniqueSClears:uniqueS.size };
+  return { totalClears:canonical.length, uniqueTrials:unique.size, uniqueSClears:uniqueS.size };
 }
 
 export function newlyEarnedCelestialHonors(records:ReadonlyArray<CelestialRecord>,claimed:ReadonlyArray<CelestialHonorId>) {

--- a/src/sanctuary-astral-trials.test.ts
+++ b/src/sanctuary-astral-trials.test.ts
@@ -24,7 +24,7 @@ describe('sanctuary astral trials', () => {
     expect(power).toBe(78);
   });
 
-  it('requires the matching constellation and grades accepted clears', () => {
+  it('requires at least one matching constellation and grades accepted clears', () => {
     const locked = resolveAstralTrial({
       year:1,
       month:1,
@@ -49,6 +49,36 @@ describe('sanctuary astral trials', () => {
       gold:150,
       key:'1-1:scholar_trial',
     }));
+  });
+
+  it('falls back to an unlocked trial when the featured monthly trial is still locked', () => {
+    const result = resolveAstralTrial({
+      year:1,
+      month:2,
+      power:90,
+      constellations:['dawn_compass','scholar_star'],
+      claimedKeys:[],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      accepted:true,
+      trial:expect.objectContaining({ id:'scholar_trial' }),
+      grade:'A',
+      key:'1-2:scholar_trial',
+    }));
+  });
+
+  it('allows only one reward claim per calendar month even if the eligible trial changes', () => {
+    const result = resolveAstralTrial({
+      year:1,
+      month:2,
+      power:120,
+      constellations:['dawn_compass','scholar_star','wayfarer_star'],
+      claimedKeys:['1-2:scholar_trial'],
+    });
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toBe('already_claimed');
   });
 
   it('allows only one reward claim per monthly trial', () => {

--- a/src/sanctuary-astral-trials.ts
+++ b/src/sanctuary-astral-trials.ts
@@ -24,6 +24,22 @@ export function astralTrialFor(year:number,month:number):AstralTrialDefinition {
   return astralTrialDefinitions[index];
 }
 
+export function eligibleAstralTrialFor(
+  year:number,
+  month:number,
+  constellations:ReadonlyArray<SanctuaryConstellationId>,
+):AstralTrialDefinition {
+  const featured = astralTrialFor(year,month);
+  if (constellations.includes(featured.requiredConstellation)) return featured;
+
+  const featuredIndex = astralTrialDefinitions.indexOf(featured);
+  for (let offset = 1; offset < astralTrialDefinitions.length; offset += 1) {
+    const candidate = astralTrialDefinitions[(featuredIndex + offset) % astralTrialDefinitions.length];
+    if (constellations.includes(candidate.requiredConstellation)) return candidate;
+  }
+  return featured;
+}
+
 type TrialPowerInput = {
   trial:AstralTrialId;
   stats:{ strength:number; intelligence:number; magic:number; morality:number };
@@ -65,12 +81,15 @@ export function resolveAstralTrial(input:{
   constellations:SanctuaryConstellationId[];
   claimedKeys:string[];
 }) {
-  const trial = astralTrialFor(input.year,input.month);
-  const key = `${Math.max(1,Math.floor(input.year))}-${Math.max(1,Math.min(12,Math.floor(input.month)))}:${trial.id}`;
+  const safeYear = Math.max(1,Math.floor(input.year));
+  const safeMonth = Math.max(1,Math.min(12,Math.floor(input.month)));
+  const trial = eligibleAstralTrialFor(safeYear,safeMonth,input.constellations);
+  const key = `${safeYear}-${safeMonth}:${trial.id}`;
   if (!input.constellations.includes(trial.requiredConstellation)) {
     return { accepted:false as const, reason:'constellation_locked' as const, trial, key, grade:null, starShards:0, gold:0 };
   }
-  if (input.claimedKeys.includes(key)) {
+  const monthPrefix = `${safeYear}-${safeMonth}:`;
+  if (input.claimedKeys.some(claimedKey => claimedKey.startsWith(monthPrefix))) {
     return { accepted:false as const, reason:'already_claimed' as const, trial, key, grade:null, starShards:0, gold:0 };
   }
   const power = Number.isFinite(input.power) ? Math.max(0,Math.floor(input.power)) : 0;

--- a/src/sanctuary-astral-ui.test.ts
+++ b/src/sanctuary-astral-ui.test.ts
@@ -102,4 +102,20 @@ describe('sanctuary astral ui summary', () => {
     expect(summary.ascension.rewards.find(item => item.rank === 'awakened')).toEqual(expect.objectContaining({ claimed:true }));
     expect(summary.ascension.nextReward).toEqual(expect.objectContaining({ rank:'stellar' }));
   });
+
+  it('shows canonical monthly Astral records in Celestial progress', () => {
+    const summary = sanctuaryAstralUiSummary({
+      ...initialState,
+      astralTrialRecords:[
+        { key:'1-1:scholar_trial', grade:'A', power:90 },
+        { key:'1-1:scholar_trial', grade:'S', power:110 },
+        { key:'1-1:wayfarer_trial', grade:'S', power:115 },
+      ],
+    });
+
+    expect(summary.recentRecords).toHaveLength(1);
+    expect(summary.recentRecords[0]).toEqual(expect.objectContaining({ key:'1-1:scholar_trial', grade:'S', power:110 }));
+    expect(summary.ascension.components.trialClears).toBe(1);
+    expect(summary.ascension.components.uniqueSClears).toBe(1);
+  });
 });

--- a/src/sanctuary-astral-ui.test.ts
+++ b/src/sanctuary-astral-ui.test.ts
@@ -17,6 +17,36 @@ describe('sanctuary astral ui summary', () => {
     expect(summary.trial.canChallenge).toBe(false);
   });
 
+  it('shows an unlocked fallback trial instead of a locked featured trial', () => {
+    const summary = sanctuaryAstralUiSummary({
+      ...initialState,
+      year:1,
+      month:2,
+      sanctuaryConstellations:['dawn_compass','scholar_star'] as typeof initialState.sanctuaryConstellations,
+      claimedAstralTrials:[],
+    });
+
+    expect(summary.trial.id).toBe('scholar_trial');
+    expect(summary.trial.unlocked).toBe(true);
+    expect(summary.trial.claimed).toBe(false);
+    expect(summary.trial.canChallenge).toBe(true);
+  });
+
+  it('shows the month as claimed after a fallback clear even if the featured trial unlocks later', () => {
+    const summary = sanctuaryAstralUiSummary({
+      ...initialState,
+      year:1,
+      month:2,
+      sanctuaryConstellations:['dawn_compass','scholar_star','wayfarer_star'] as typeof initialState.sanctuaryConstellations,
+      claimedAstralTrials:['1-2:scholar_trial'],
+    });
+
+    expect(summary.trial.id).toBe('wayfarer_trial');
+    expect(summary.trial.unlocked).toBe(true);
+    expect(summary.trial.claimed).toBe(true);
+    expect(summary.trial.canChallenge).toBe(false);
+  });
+
   it('shows power, grade preview and completed monthly trial state', () => {
     const summary = sanctuaryAstralUiSummary({
       ...initialState,

--- a/src/sanctuary-astral-ui.ts
+++ b/src/sanctuary-astral-ui.ts
@@ -4,7 +4,7 @@ import {
   celestialAscensionRank,
   celestialAscensionRewards,
 } from './celestial-ascension';
-import { celestialRecordProgress } from './celestial-records';
+import { canonicalCelestialRecords, celestialRecordProgress } from './celestial-records';
 import { astralBlessings, resolveAstralBlessingPurchase } from './sanctuary-astral-blessings';
 import { eligibleAstralTrialFor, astralTrialPower } from './sanctuary-astral-trials';
 import { constellationProgress } from './sanctuary-constellations';
@@ -52,7 +52,8 @@ export function sanctuaryAstralUiSummary(state:GameState) {
     };
   });
   const records = state.astralTrialRecords ?? [];
-  const recentRecords = [...records].slice(-6).reverse();
+  const canonicalRecords = canonicalCelestialRecords(records);
+  const recentRecords = [...canonicalRecords].slice(-6).reverse();
   const recordProgress = celestialRecordProgress(records);
   const ascensionScore = celestialAscensionProgress({
     trialRecords:records,
@@ -86,7 +87,7 @@ export function sanctuaryAstralUiSummary(state:GameState) {
       score:ascensionScore,
       rank:ascensionRank,
       components:{
-        trialClears:Math.min(12,records.length),
+        trialClears:Math.min(12,recordProgress.totalClears),
         uniqueSClears:Math.min(4,recordProgress.uniqueSClears),
         blessings:Math.min(4,purchased.length),
         constellations:Math.min(5,constellations.length),

--- a/src/sanctuary-astral-ui.ts
+++ b/src/sanctuary-astral-ui.ts
@@ -6,7 +6,7 @@ import {
 } from './celestial-ascension';
 import { celestialRecordProgress } from './celestial-records';
 import { astralBlessings, resolveAstralBlessingPurchase } from './sanctuary-astral-blessings';
-import { astralTrialFor, astralTrialPower } from './sanctuary-astral-trials';
+import { eligibleAstralTrialFor, astralTrialPower } from './sanctuary-astral-trials';
 import { constellationProgress } from './sanctuary-constellations';
 
 function previewGrade(power:number) {
@@ -14,7 +14,8 @@ function previewGrade(power:number) {
 }
 
 export function sanctuaryAstralUiSummary(state:GameState) {
-  const trial = astralTrialFor(state.year,state.month);
+  const constellations = state.sanctuaryConstellations ?? [];
+  const trial = eligibleAstralTrialFor(state.year,state.month,constellations);
   const progress = constellationProgress({
     levels:state.sanctuaryLevels,
     specializationCount:Object.keys(state.sanctuarySpecializations ?? {}).length,
@@ -30,11 +31,12 @@ export function sanctuaryAstralUiSummary(state:GameState) {
       morality:state.stats.morality,
     },
     sanctuaryProgress:progress,
-    constellationCount:(state.sanctuaryConstellations ?? []).length,
+    constellationCount:constellations.length,
   });
   const key = `${state.year}-${state.month}:${trial.id}`;
-  const unlocked = (state.sanctuaryConstellations ?? []).includes(trial.requiredConstellation);
-  const claimed = (state.claimedAstralTrials ?? []).includes(key);
+  const monthPrefix = `${state.year}-${state.month}:`;
+  const unlocked = constellations.includes(trial.requiredConstellation);
+  const claimed = (state.claimedAstralTrials ?? []).some(claimKey => claimKey.startsWith(monthPrefix));
   const starShards = Math.max(0,Math.floor(state.astralStarShards ?? 0));
   const purchased = state.purchasedAstralBlessings ?? [];
   const trialKeys = state.claimedAstralTrials ?? [];
@@ -55,7 +57,7 @@ export function sanctuaryAstralUiSummary(state:GameState) {
   const ascensionScore = celestialAscensionProgress({
     trialRecords:records,
     blessingCount:purchased.length,
-    constellationCount:(state.sanctuaryConstellations ?? []).length,
+    constellationCount:constellations.length,
     sanctuaryGrandProgress:progress,
   });
   const ascensionRank = celestialAscensionRank(ascensionScore);
@@ -87,7 +89,7 @@ export function sanctuaryAstralUiSummary(state:GameState) {
         trialClears:Math.min(12,records.length),
         uniqueSClears:Math.min(4,recordProgress.uniqueSClears),
         blessings:Math.min(4,purchased.length),
-        constellations:Math.min(5,(state.sanctuaryConstellations ?? []).length),
+        constellations:Math.min(5,constellations.length),
         sanctuaryProgress:progress,
       },
       rewards:ascensionRewards,

--- a/src/season-journey.test.ts
+++ b/src/season-journey.test.ts
@@ -30,8 +30,26 @@ describe('season journey', () => {
     expect(seasonJourneyTiers[9].reward.tokens).toBeGreaterThan(seasonJourneyTiers[0].reward.tokens);
   });
 
-  it('returns only newly crossed tiers in ascending order', () => {
+  it('returns only newly crossed tiers in ascending order without a season claim key', () => {
     expect(newlyEarnedJourneyTiers(40,180,[]).map(tier => tier.tier)).toEqual([1,2,3]);
     expect(newlyEarnedJourneyTiers(180,300,['1-spring:1','1-spring:2','1-spring:3']).map(tier => tier.tier)).toEqual([4]);
+  });
+
+  it('recovers reached but unclaimed tiers when a season claim key is supplied', () => {
+    expect(newlyEarnedJourneyTiers(
+      180,
+      200,
+      ['1-spring:1'],
+      '1-spring',
+    ).map(tier => tier.tier)).toEqual([2,3]);
+  });
+
+  it('never returns already claimed season tiers during recovery', () => {
+    expect(newlyEarnedJourneyTiers(
+      180,
+      200,
+      ['1-spring:1','1-spring:2','1-spring:3'],
+      '1-spring',
+    )).toEqual([]);
   });
 });

--- a/src/season-journey.ts
+++ b/src/season-journey.ts
@@ -45,8 +45,8 @@ export function newlyEarnedJourneyTiers(previousScore:number, nextScore:number, 
   const floorPrevious = Math.max(0, Math.floor(previousScore));
   const floorNext = Math.max(floorPrevious, Math.floor(nextScore));
   return seasonJourneyTiers.filter(tier => {
-    if (floorNext < tier.threshold || floorPrevious >= tier.threshold) return false;
-    if (!key) return true;
+    if (floorNext < tier.threshold) return false;
+    if (!key) return floorPrevious < tier.threshold;
     return !claimedKeys.includes(journeyTierClaimKey(key, tier.tier));
   });
 }

--- a/src/season-meta-economy.test.ts
+++ b/src/season-meta-economy.test.ts
@@ -48,7 +48,7 @@ describe('season meta economy chain', () => {
       year:1,
       month:1,
       power:0,
-      constellations:['dawn_star','scholar_star'],
+      constellations:['dawn_compass','scholar_star'],
       claimedKeys:[],
     });
     expect(clear.accepted).toBe(true);

--- a/src/season-meta-economy.test.ts
+++ b/src/season-meta-economy.test.ts
@@ -8,24 +8,38 @@ import { resolveAstralTrial, type AstralTrialId } from './sanctuary-astral-trial
 import { seasonJourneyTiers } from './season-journey';
 import { seasonShopOffers } from './season-shop';
 import { sanctuaryFacilities } from './starlight-sanctuary';
+import { weeklyDirectives } from './weekly-directives';
+
+const materials = ['star_bark','arcane_shard','wind_pearl'] as const;
 
 describe('season meta economy chain', () => {
-  it('keeps Weekly Directive tokens meaningful instead of letting Journey tiers clear the whole shop alone', () => {
+  it('keeps Weekly Directive tokens meaningful while a full season can still clear the shop', () => {
     const journeyOnlyTokens = seasonJourneyTiers.reduce((sum,tier) => sum + tier.reward.tokens,0);
+    const weeklyTokens = [3,4,5].flatMap(month => [1,2,3,4].map(week => weeklyDirectives(1,month,week)))
+      .flat()
+      .reduce((sum,directive) => sum + directive.reward.tokens,0);
     const fullShopCost = seasonShopOffers('1-spring').reduce((sum,offer) => sum + offer.cost * offer.limit,0);
 
     expect(fullShopCost).toBeGreaterThan(journeyOnlyTokens);
+    expect(fullShopCost).toBeLessThanOrEqual(journeyOnlyTokens + weeklyTokens);
   });
 
-  it('makes one sanctuary material cache enough to start any level-1 sanctuary facility', () => {
+  it('makes one sanctuary material cache enough to start any level-1 sanctuary facility without replacing the full sanctuary grind', () => {
     const cache = seasonShopOffers('1-spring').find(offer => offer.id === 'expedition_cache');
     expect(cache).toBeDefined();
 
     for (const facility of sanctuaryFacilities) {
       const levelOne = facility.upgrades.find(step => step.level === 1)!;
-      for (const material of ['star_bark','arcane_shard','wind_pearl'] as const) {
+      for (const material of materials) {
         expect(cache!.reward.materials[material] ?? 0).toBeGreaterThanOrEqual(levelOne.cost.materials[material]);
       }
+    }
+
+    const totalCosts = Object.fromEntries(materials.map(material => [material,
+      sanctuaryFacilities.reduce((facilitySum,facility) => facilitySum + facility.upgrades.reduce((stepSum,step) => stepSum + step.cost.materials[material],0),0),
+    ])) as Record<(typeof materials)[number],number>;
+    for (const material of materials) {
+      expect((cache!.reward.materials[material] ?? 0) * cache!.limit).toBeLessThan(totalCosts[material]);
     }
   });
 

--- a/src/season-meta-economy.test.ts
+++ b/src/season-meta-economy.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { astralRiftDefinitions, nextAstralRiftUnlock } from './astral-rift';
+import { celestialAscensionProgress, newlyEarnedAscensionRewards } from './celestial-ascension';
+import { newlyEarnedCelestialHonors } from './celestial-records';
+import { astralBlessings } from './sanctuary-astral-blessings';
+import { resolveAstralTrial, type AstralTrialId } from './sanctuary-astral-trials';
+import { seasonJourneyTiers } from './season-journey';
+import { seasonShopOffers } from './season-shop';
+import { sanctuaryFacilities } from './starlight-sanctuary';
+
+describe('season meta economy chain', () => {
+  it('keeps Weekly Directive tokens meaningful instead of letting Journey tiers clear the whole shop alone', () => {
+    const journeyOnlyTokens = seasonJourneyTiers.reduce((sum,tier) => sum + tier.reward.tokens,0);
+    const fullShopCost = seasonShopOffers('1-spring').reduce((sum,offer) => sum + offer.cost * offer.limit,0);
+
+    expect(fullShopCost).toBeGreaterThan(journeyOnlyTokens);
+  });
+
+  it('makes one sanctuary material cache enough to start any level-1 sanctuary facility', () => {
+    const cache = seasonShopOffers('1-spring').find(offer => offer.id === 'expedition_cache');
+    expect(cache).toBeDefined();
+
+    for (const facility of sanctuaryFacilities) {
+      const levelOne = facility.upgrades.find(step => step.level === 1)!;
+      for (const material of ['star_bark','arcane_shard','wind_pearl'] as const) {
+        expect(cache!.reward.materials[material] ?? 0).toBeGreaterThanOrEqual(levelOne.cost.materials[material]);
+      }
+    }
+  });
+
+  it('turns the first legal Astral clear into a real bridge toward blessing and Rift progression', () => {
+    const clear = resolveAstralTrial({
+      year:1,
+      month:1,
+      power:0,
+      constellations:['dawn_star','scholar_star'],
+      claimedKeys:[],
+    });
+    expect(clear.accepted).toBe(true);
+    if (!clear.accepted) return;
+
+    const records = [{ key:clear.key, grade:clear.grade, power:0 }];
+    const ascension = celestialAscensionProgress({
+      trialRecords:records,
+      blessingCount:0,
+      constellationCount:2,
+      sanctuaryGrandProgress:35,
+    });
+    const firstRiftThreshold = Math.min(...astralRiftDefinitions.map(rift => rift.ascensionThreshold));
+    expect(ascension).toBeGreaterThanOrEqual(firstRiftThreshold);
+    expect(nextAstralRiftUnlock(ascension)?.threshold ?? firstRiftThreshold).toBeGreaterThanOrEqual(firstRiftThreshold);
+
+    const honorShards = newlyEarnedCelestialHonors(records,[])
+      .reduce((sum,honor) => sum + honor.reward.starShards,0);
+    const rankShards = newlyEarnedAscensionRewards(ascension,[])
+      .reduce((sum,rank) => sum + rank.reward.starShards,0);
+    const scholarBlessing = astralBlessings.find(blessing => blessing.requiredTrial === 'scholar_trial')!;
+    expect(clear.starShards + honorShards + rankShards).toBeGreaterThanOrEqual(scholarBlessing.cost);
+  });
+
+  it('keeps the final Rift threshold reachable through legitimate monthly Astral records', () => {
+    const trials:AstralTrialId[] = ['scholar_trial','wayfarer_trial','guardian_trial','crown_trial'];
+    const records = Array.from({ length:12 },(_,index) => ({
+      key:`1-${index + 1}:${trials[index % trials.length]}`,
+      grade:'S' as const,
+      power:120,
+    }));
+    const ascension = celestialAscensionProgress({
+      trialRecords:records,
+      blessingCount:4,
+      constellationCount:5,
+      sanctuaryGrandProgress:65,
+    });
+    const finalThreshold = Math.max(...astralRiftDefinitions.map(rift => rift.ascensionThreshold));
+
+    expect(ascension).toBeGreaterThanOrEqual(finalThreshold);
+    expect(nextAstralRiftUnlock(ascension)).toBeNull();
+  });
+
+  it('never reissues permanent Celestial rewards after their claim ids are recorded', () => {
+    const trials:AstralTrialId[] = ['scholar_trial','wayfarer_trial','guardian_trial','crown_trial'];
+    const records = Array.from({ length:12 },(_,index) => ({
+      key:`1-${index + 1}:${trials[index % trials.length]}`,
+      grade:'S' as const,
+      power:120,
+    }));
+    const claimedHonors = ['first_light','full_cycle','perfect_cycle','twelve_trials'] as const;
+    const claimedRanks = ['awakened','stellar','empyrean','transcendent'] as const;
+
+    expect(newlyEarnedCelestialHonors(records,claimedHonors)).toEqual([]);
+    expect(newlyEarnedAscensionRewards(83,claimedRanks)).toEqual([]);
+  });
+});

--- a/src/season-shop.test.ts
+++ b/src/season-shop.test.ts
@@ -6,7 +6,7 @@ describe('season shop', () => {
     expect(seasonShopOffers('1-spring').map(offer => [offer.id, offer.cost, offer.limit])).toEqual([
       ['gold_pouch',20,2],
       ['recovery_bundle',25,1],
-      ['expedition_cache',30,1],
+      ['expedition_cache',30,6],
       ['seasonal_keepsake',40,1],
       ['spring_garden_pack',18,1],
     ]);
@@ -77,7 +77,7 @@ describe('season shop', () => {
     }));
     expect(resolveSeasonPurchase({ seasonKey:'1-spring', offerId:'expedition_cache', tokens:99, purchaseKeys:[] })).toEqual(expect.objectContaining({
       accepted:true,
-      reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false },
+      reward:{ gold:0, inventory:{}, materials:{ star_bark:3, arcane_shard:3, wind_pearl:3 }, keepsake:false },
     }));
     expect(resolveSeasonPurchase({ seasonKey:'1-spring', offerId:'seasonal_keepsake', tokens:99, purchaseKeys:[] })).toEqual(expect.objectContaining({
       accepted:true,

--- a/src/season-shop.test.ts
+++ b/src/season-shop.test.ts
@@ -15,6 +15,10 @@ describe('season shop', () => {
     expect(seasonShopOffers('1-winter').at(-1)?.id).toBe('winter_starlight_cache');
   });
 
+  it('makes the Sanctuary use of the shared material cache explicit', () => {
+    expect(seasonShopOffers('1-spring').find(offer => offer.id === 'expedition_cache')?.label).toBe('원정·성소 재료 상자');
+  });
+
   it('resolves a valid purchase and emits a deterministic purchase key', () => {
     const result = resolveSeasonPurchase({ seasonKey:'1-spring', offerId:'gold_pouch', tokens:40, purchaseKeys:[] });
     expect(result).toEqual({
@@ -23,6 +27,37 @@ describe('season shop', () => {
       purchaseKey:seasonPurchaseKey('1-spring','gold_pouch',1),
       reward:{ gold:300, inventory:{}, materials:{}, keepsake:false },
     });
+  });
+
+  it('uses the first free purchase ordinal when purchase history is sparse', () => {
+    const secondKey = seasonPurchaseKey('1-spring','gold_pouch',2);
+    const result = resolveSeasonPurchase({
+      seasonKey:'1-spring',
+      offerId:'gold_pouch',
+      tokens:40,
+      purchaseKeys:[secondKey],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      accepted:true,
+      purchaseKey:seasonPurchaseKey('1-spring','gold_pouch',1),
+    }));
+    expect(result.accepted && result.purchaseKey).not.toBe(secondKey);
+  });
+
+  it('deduplicates repeated purchase keys before applying the season limit', () => {
+    const firstKey = seasonPurchaseKey('1-spring','gold_pouch',1);
+    const result = resolveSeasonPurchase({
+      seasonKey:'1-spring',
+      offerId:'gold_pouch',
+      tokens:40,
+      purchaseKeys:[firstKey,firstKey],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      accepted:true,
+      purchaseKey:seasonPurchaseKey('1-spring','gold_pouch',2),
+    }));
   });
 
   it('rejects a purchase when tokens are insufficient', () => {

--- a/src/season-shop.ts
+++ b/src/season-shop.ts
@@ -22,7 +22,7 @@ export type SeasonShopOffer = { id:SeasonShopOfferId; label:string; cost:number;
 const coreOffers:SeasonShopOffer[] = [
   { id:'gold_pouch', label:'수호자 골드 주머니', cost:20, limit:2, reward:{ gold:300, inventory:{}, materials:{}, keepsake:false } },
   { id:'recovery_bundle', label:'루나 회복 꾸러미', cost:25, limit:1, reward:{ gold:0, inventory:{ herb_tea:1, star_cookie:1 }, materials:{}, keepsake:false } },
-  { id:'expedition_cache', label:'원정 재료 상자', cost:30, limit:1, reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false } },
+  { id:'expedition_cache', label:'원정·성소 재료 상자', cost:30, limit:1, reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false } },
   { id:'seasonal_keepsake', label:'계절 기념품', cost:40, limit:1, reward:{ gold:0, inventory:{}, materials:{}, keepsake:true } },
 ];
 
@@ -57,12 +57,22 @@ export function resolveSeasonPurchase(input:{ seasonKey:SeasonJourneyKey; offerI
   const offer = seasonShopOffers(input.seasonKey).find(item => item.id === input.offerId);
   if (!offer) return { accepted:false as const };
   const prefix = `${input.seasonKey}:${offer.id}:`;
-  const used = input.purchaseKeys.filter(key => key.startsWith(prefix)).length;
-  if (used >= offer.limit || input.tokens < offer.cost) return { accepted:false as const };
+  const usedOrdinals = new Set<number>();
+  for (const key of input.purchaseKeys) {
+    if (!key.startsWith(prefix)) continue;
+    const rawOrdinal = key.slice(prefix.length);
+    if (!/^\d+$/.test(rawOrdinal)) continue;
+    const ordinal = Number(rawOrdinal);
+    if (ordinal >= 1 && ordinal <= offer.limit) usedOrdinals.add(ordinal);
+  }
+  if (usedOrdinals.size >= offer.limit || input.tokens < offer.cost) return { accepted:false as const };
+  let nextOrdinal = 1;
+  while (usedOrdinals.has(nextOrdinal) && nextOrdinal <= offer.limit) nextOrdinal += 1;
+  if (nextOrdinal > offer.limit) return { accepted:false as const };
   return {
     accepted:true as const,
     tokens:input.tokens - offer.cost,
-    purchaseKey:seasonPurchaseKey(input.seasonKey,offer.id,used + 1),
+    purchaseKey:seasonPurchaseKey(input.seasonKey,offer.id,nextOrdinal),
     reward:offer.reward,
   };
 }

--- a/src/season-shop.ts
+++ b/src/season-shop.ts
@@ -22,7 +22,7 @@ export type SeasonShopOffer = { id:SeasonShopOfferId; label:string; cost:number;
 const coreOffers:SeasonShopOffer[] = [
   { id:'gold_pouch', label:'수호자 골드 주머니', cost:20, limit:2, reward:{ gold:300, inventory:{}, materials:{}, keepsake:false } },
   { id:'recovery_bundle', label:'루나 회복 꾸러미', cost:25, limit:1, reward:{ gold:0, inventory:{ herb_tea:1, star_cookie:1 }, materials:{}, keepsake:false } },
-  { id:'expedition_cache', label:'원정·성소 재료 상자', cost:30, limit:1, reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false } },
+  { id:'expedition_cache', label:'원정·성소 재료 상자', cost:30, limit:6, reward:{ gold:0, inventory:{}, materials:{ star_bark:3, arcane_shard:3, wind_pearl:3 }, keepsake:false } },
   { id:'seasonal_keepsake', label:'계절 기념품', cost:40, limit:1, reward:{ gold:0, inventory:{}, materials:{}, keepsake:true } },
 ];
 

--- a/src/weekly-directives.test.ts
+++ b/src/weekly-directives.test.ts
@@ -42,4 +42,36 @@ describe('weekly directives', () => {
     const repeat = advanceWeeklyDirectives(directives, progress, { kind:target.counter === 'high_grade' ? 'expedition' : target.counter, grade:'S' }, rewarded, '1-4-1');
     expect(repeat.completed.map(item => item.id)).not.toContain(target.id);
   });
+
+  it('recovers a completed directive when its weekly reward key is missing', () => {
+    const directives = weeklyDirectives(1,4,1);
+    const target = directives[0];
+    const progress = Object.fromEntries(directives.map(item => [item.id, item.id === target.id ? target.target : 0]));
+    const result = advanceWeeklyDirectives(
+      directives,
+      progress,
+      { kind:'training', grade:'B' },
+      [],
+      '1-4-1',
+    );
+
+    expect(result.completed.map(item => item.id)).toContain(target.id);
+    expect(result.reward).toEqual(target.reward);
+  });
+
+  it('does not recover a completed directive after its weekly reward key exists', () => {
+    const directives = weeklyDirectives(1,4,1);
+    const target = directives[0];
+    const progress = Object.fromEntries(directives.map(item => [item.id, item.id === target.id ? target.target : 0]));
+    const result = advanceWeeklyDirectives(
+      directives,
+      progress,
+      { kind:'training', grade:'B' },
+      [`1-4-1:${target.id}`],
+      '1-4-1',
+    );
+
+    expect(result.completed.map(item => item.id)).not.toContain(target.id);
+    expect(result.reward).toEqual({ journeyPoints:0, tokens:0 });
+  });
 });

--- a/src/weekly-directives.test.ts
+++ b/src/weekly-directives.test.ts
@@ -19,6 +19,17 @@ describe('weekly directives', () => {
     expect(weeklyDirectives(1,4,1).map(item => item.id)).not.toEqual(weeklyDirectives(1,4,2).map(item => item.id));
   });
 
+  it('never assigns two directives that reward the same action counter in one week', () => {
+    for (let year = 1; year <= 3; year += 1) {
+      for (let month = 1; month <= 12; month += 1) {
+        for (let week = 1; week <= 4; week += 1) {
+          const directives = weeklyDirectives(year,month,week);
+          expect(new Set(directives.map(item => item.counter)).size).toBe(directives.length);
+        }
+      }
+    }
+  });
+
   it('advances only matching directives and caps progress at targets', () => {
     const directives = weeklyDirectives(1,4,1);
     const expedition = directives.find(item => item.counter === 'expedition');

--- a/src/weekly-directives.test.ts
+++ b/src/weekly-directives.test.ts
@@ -30,6 +30,28 @@ describe('weekly directives', () => {
     }
   });
 
+  it('never lets one player action advance more than one assigned directive', () => {
+    const events = [
+      { kind:'training' as const, grade:'B' as const },
+      { kind:'outing' as const, grade:'B' as const },
+      { kind:'gift' as const, grade:'B' as const },
+      { kind:'expedition' as const, grade:'S' as const },
+    ];
+    for (let year = 1; year <= 3; year += 1) {
+      for (let month = 1; month <= 12; month += 1) {
+        for (let week = 1; week <= 4; week += 1) {
+          const directives = weeklyDirectives(year,month,week);
+          const progress = Object.fromEntries(directives.map(item => [item.id, 0]));
+          for (const event of events) {
+            const result = advanceWeeklyDirectives(directives,progress,event);
+            const advanced = directives.filter(item => (result.progress[item.id] ?? 0) > 0);
+            expect(advanced.length).toBeLessThanOrEqual(1);
+          }
+        }
+      }
+    }
+  });
+
   it('advances only matching directives and caps progress at targets', () => {
     const directives = weeklyDirectives(1,4,1);
     const expedition = directives.find(item => item.counter === 'expedition');

--- a/src/weekly-directives.ts
+++ b/src/weekly-directives.ts
@@ -70,13 +70,16 @@ export function advanceWeeklyDirectives(
     const before = Math.max(0,Math.floor(next[directive.id] ?? 0));
     const after = matches(directive,event) ? Math.min(directive.target,before + 1) : before;
     next[directive.id] = after;
-    if (before < directive.target && after >= directive.target) {
-      const rewardKey = key ? `${key}:${directive.id}` : null;
-      if (!rewardKey || !rewardedKeys.includes(rewardKey)) {
-        completed.push(directive);
-        journeyPoints += directive.reward.journeyPoints;
-        tokens += directive.reward.tokens;
-      }
+    const reached = after >= directive.target;
+    const justCompleted = before < directive.target && reached;
+    const rewardKey = key ? `${key}:${directive.id}` : null;
+    const shouldReward = key
+      ? reached && !rewardedKeys.includes(rewardKey!)
+      : justCompleted;
+    if (shouldReward) {
+      completed.push(directive);
+      journeyPoints += directive.reward.journeyPoints;
+      tokens += directive.reward.tokens;
     }
   }
 

--- a/src/weekly-directives.ts
+++ b/src/weekly-directives.ts
@@ -37,13 +37,17 @@ export function weeklyDirectiveKey(year:number, month:number, week:number) {
   return `${Math.max(1,Math.floor(year))}-${Math.max(1,Math.min(12,Math.floor(month)))}-${Math.max(1,Math.min(4,Math.floor(week)))}` as const;
 }
 
+function directiveActionGroup(counter:WeeklyDirectiveCounter) {
+  return counter === 'high_grade' ? 'expedition' : counter;
+}
+
 export function weeklyDirectives(year:number, month:number, week:number): WeeklyDirective[] {
   const seed = Math.max(0,Math.floor(year * 37 + month * 11 + week * 5));
   const result: WeeklyDirective[] = [];
   let cursor = seed % directivePool.length;
   while (result.length < 3) {
     const candidate = directivePool[cursor % directivePool.length];
-    if (!result.some(item => item.id === candidate.id || item.counter === candidate.counter)) result.push(candidate);
+    if (!result.some(item => item.id === candidate.id || directiveActionGroup(item.counter) === directiveActionGroup(candidate.counter))) result.push(candidate);
     cursor += 3;
   }
   return result;

--- a/src/weekly-directives.ts
+++ b/src/weekly-directives.ts
@@ -43,7 +43,7 @@ export function weeklyDirectives(year:number, month:number, week:number): Weekly
   let cursor = seed % directivePool.length;
   while (result.length < 3) {
     const candidate = directivePool[cursor % directivePool.length];
-    if (!result.some(item => item.id === candidate.id)) result.push(candidate);
+    if (!result.some(item => item.id === candidate.id || item.counter === candidate.counter)) result.push(candidate);
     cursor += 3;
   }
   return result;


### PR DESCRIPTION
## 구현한 기능
- Season Journey / Weekly Directive / Season Shop의 Season Token 경제 흐름 정리 및 회귀 검증
- Sanctuary → Astral Trial → Celestial Records / Ascension → Astral Rift 장기 성장 체인 구현 및 연결 검증
- Celestial 영구 보상 claim 중복 방지, Astral 월간 기록 정규화, Weekly 중복 보상/중복 진행 방지
- `season-meta-economy` 회귀 테스트로 Season → Astral → Celestial → Rift 경제 도달성/소비 구조 검증
- `weeklyDirectives()`가 같은 실제 플레이어 행동으로 둘 이상 진행되는 조합(`expedition` + `high_grade`)을 동시에 배정하지 않도록 action-group 충돌 방지 적용
- 현재 브랜치는 통합 후보로 동결: 신규 Season/메타 시스템 추가 및 구조 변경 중단

## 변경 파일
- `src/astral-rift-ui.test.ts`
- `src/astral-rift-ui.ts`
- `src/astral-rift.test.ts`
- `src/astral-rift.ts`
- `src/celestial-ascension.test.ts`
- `src/celestial-ascension.ts`
- `src/celestial-records.test.ts`
- `src/celestial-records.ts`
- `src/sanctuary-astral-trials.test.ts`
- `src/sanctuary-astral-trials.ts`
- `src/sanctuary-astral-ui.test.ts`
- `src/sanctuary-astral-ui.ts`
- `src/season-journey.test.ts`
- `src/season-journey.ts`
- `src/season-meta-economy.test.ts`
- `src/season-shop.test.ts`
- `src/season-shop.ts`
- `src/weekly-directives.test.ts`
- `src/weekly-directives.ts`

## 테스트 결과
### 최신 db25 호환성 검증
검증 기준:
- core baseline: `integration/v2@db25f0e18471550cda2242021887051eb7c830e9`
- Season head: `work/season-meta@e2827e4e41a5f969a930a5f3b9a57c8c8fc59e19`
- 임시 검증 브랜치: `verify/season-db25-compat`
- 최종 검증 run: `32450673167`, job: `96678478936`
- Actions checkout merge SHA: `1a8c889cb6666035c48f1a220ffe00320d9337c1`

결과:
- Targeted Season: **8/8 files, 50/50 tests GREEN**
- Season suite: **10/10 files, 60/60 tests GREEN**
- Full test: **296/297 files, 938/939 tests** — 아래 `[06 Integration Fix Required]`의 공용 stale expectation 1건만 RED
- TypeScript: `npx tsc -b --pretty false` **GREEN**
- Production build: `npx vite build` **GREEN** (`165 modules transformed`)
- 이전 새 baseline 검증에서 실패했던 `src/live-ops-progression.test.ts`와 `src/season-legacy-effects-progression.test.ts`는 Season 최소 수정 후 모두 GREEN
- `src/game/campaign-regression.test.ts`, `src/game-sanctuary-legacy.integration.test.ts`, `src/game/world-meta-reset.test.ts`, `src/game/world-new-run-monthly-reset.test.ts`도 최종 full run에서 GREEN

경제 검증:
- Journey 최대 약 207 Season Token
- 봄 Weekly 최대 약 175 Token
- Season Shop 최대 소비량 약 303 Token으로 Journey 단독 완주만으로 상점 전체 소진 불가
- `expedition_cache`: cost 30, limit 6, 재료 각 3 → 최대 공급 각 18
- Sanctuary 시설 총 요구량 약 37/33/33으로 상점이 Sanctuary 플레이를 대체하지 않음
- Rift Echo 기존 Relic 소비처 약 285 Echo
- 초기 Celestial Ascension 약 13 > 첫 Rift 요구 12, 장기 Ascension 약 83 > 최종 Rift 요구 72

## 공용 파일 연결 필요사항
- 실제 선택된 Astral Trial과 공용 `game-sanctuary-astral-base.ts`의 power 계산 대상이 어긋나지 않도록, fallback이 선택된 경우 **실제 eligible trial 기준**으로 power를 계산해야 함
- Sanctuary `FINISH_TRAINING` 경로에서 Season Journey `month_complete` 25/35 진행이 보존되는지 확인 필요. 공용 reducer가 Weekly/Season reward를 수동 적용하면서 base Journey 월 완료 점수를 누락시키지 않아야 함
- `astral-rift-weekly.ts`가 잠긴 Rift(28/48/72 등)를 featured 목표로 선정하지 않도록 현재 해금된 Rift 목록 기준 또는 안전 fallback으로 생성 필요
- 통합 호출 계약:
  - `newlyEarnedJourneyTiers`에 `seasonKey` 전달
  - `advanceWeeklyDirectives`에 `rewardedKeys, weekKey` 전달
  - UI는 필요 시 Astral Rift `.nextUnlock` 사용
  - Astral claim은 같은 달에 eligible trial이 바뀌어도 월 전체 1회 보상 semantics 유지
- 추가 save/schema 연결이 필요할 경우 이 브랜치에서 공용 save 파일을 수정하지 말고 06 통합 단계에서 처리

### [06 Integration Fix Required]
현재 db25 호환성 검증의 **유일한 full-suite blocker**:
- 파일: `src/season-shop-progression.test.ts`
- 테스트: `season shop progression > grants inventory and expedition materials from utility offers`
- assertion: `src/season-shop-progression.test.ts:27:39`
- 공용 baseline expectation: `{ star_bark:2, arcane_shard:2, wind_pearl:2 }`
- Season 후보의 현재 실제/의도된 계약: `{ star_bark:3, arcane_shard:3, wind_pearl:3 }`
- Season 후보는 `src/season-shop.test.ts`와 `src/season-meta-economy.test.ts`에서 `expedition_cache`를 **cost 30 / limit 6 / materials 3·3·3**으로 명시적으로 고정하고 있으며, Sanctuary 경제 검증도 이 계약을 전제로 함
- 따라서 Season production 값을 2·2·2로 rollback하지 말 것
- 06 필요 수정: 공용 progression test의 expectation을 현행 Season Shop 계약인 **3·3·3**으로 갱신한 뒤 full suite 재실행
- 최종 db25 gate 증거: **938/939**, 위 테스트 1건만 실패; TypeScript/production build는 GREEN

## 다른 작업방과 충돌 가능성이 있는 파일
- 현재 PR의 19개 변경 파일은 Season / Weekly / Sanctuary / Astral / Celestial / Rift 전용 파일이며 `App.tsx`, `Root.tsx`, `game.ts`, 공용 save schema, `vercel.json`은 직접 변경하지 않음
- `src/sanctuary-astral-ui.ts` / `src/astral-rift-ui.ts`는 05 Hub UI가 동일 표현 계층을 확장할 경우 논리적 충돌 가능성 있음
- 공용 `game` 연결 요구 및 `src/season-shop-progression.test.ts` expectation 갱신은 06 통합에서 처리해야 하므로 04 Tactical 또는 공용 전투/저장 변경과 함께 최종 회귀 확인 필요

## 저장 데이터 영향
- 이 PR에서 공용 save schema 파일 직접 변경 없음
- Celestial 영구 보상 claim ID 및 Astral 월간 기록 정규화 로직은 중복 수령/중복 기록 방지를 전제로 함
- Weekly reward key는 week key와 directive id를 결합해 이미 지급된 주간 보상의 재지급을 막는 계약을 유지함
- 기존 저장 데이터와의 최종 호환성 검증 및 필요 migration은 06 통합 단계에서 공용 save schema 기준으로 확인 필요

## 06 통합 시 주의사항
- 이 브랜치는 **통합 후보 동결 상태**이며 통합 완료 전 신규 Season/메타 시스템/구조 변경 금지
- `[06 Integration Fix Required]`의 `src/season-shop-progression.test.ts` expectation을 먼저 3·3·3 계약으로 맞추고 full suite를 재검증할 것
- 위 공용 연결 3건(Astral Trial actual-eligible power, `FINISH_TRAINING` month_complete, unlocked Rift 기반 Weekly)도 함께 확인
- `App.tsx`, `Root.tsx`, `game.ts`, save-schema 계열 수정은 이 PR에서 가져오지 말고 06에서 단일 통합 지점으로 처리
- PR은 Draft 상태로 유지하며 직접 merge하지 않음
- 공용 expectation 수정 후 targeted Season → Season suite → full test → TypeScript → production build 전부 GREEN을 확인한 시점에만 integration-ready로 판정하고 후보를 freeze할 것
- 그 전에는 `work/season-meta-next`에서 신규 작업을 시작하지 않음

### [Integration Regression Fix]
검증 baseline:
- `integration/v2@db25f0e18471550cda2242021887051eb7c830e9`
- 최초 후보 `work/season-meta@1e61219441ef5dca9b869acea6c40f0496f524d6`

새 baseline 최초 full-test 실패 3건:
1. `src/live-ops-progression.test.ts > live ops reducer progression > adds grade-based journey points for an expedition clear`
   - expected `30`, actual `50`
   - stack: `src/live-ops-progression.test.ts:32:43`
2. `src/season-legacy-effects-progression.test.ts > season legacy passive progression > adds expedition legacy journey points and can cross a journey tier`
   - expected `40`, actual `60`
   - stack: `src/season-legacy-effects-progression.test.ts:14:43`
3. `src/season-shop-progression.test.ts > season shop progression > grants inventory and expedition materials from utility offers`
   - expected materials `2/2/2`, actual `3/3/3`
   - stack: `src/season-shop-progression.test.ts:27:39`

Root cause / 처리:
- 1·2는 Season-owned: Weekly Directive selection이 `expedition`과 `high_grade`를 서로 다른 counter로만 보았지만 S/A expedition 한 번이 두 directive를 동시에 match하여 `elite_clear` +20 Journey가 중복으로 붙을 수 있었음
- RED regression test `never lets one player action advance more than one assigned directive`를 먼저 추가했고, 기존 구현에서 `expected 2 to be <= 1`로 재현 확인
- 최소 수정: `high_grade`를 실제 action group 기준으로 `expedition`과 같은 충돌 그룹으로 취급해 같은 주에 함께 배정되지 않도록 수정
- 수정 commit: `66c3a7bf9274e48d456a7089c131bd6988eea18b`
- TypeScript에서 발견된 Season-owned 테스트 fixture 오류 `"dawn_star" is not assignable to SanctuaryConstellationId`는 현재 유효 ID `dawn_compass`로 의미 보존 수정
- fixture 수정 commit: `e2827e4e41a5f969a930a5f3b9a57c8c8fc59e19`
- 3은 공용 stale expectation: Season production rollback 금지, 위 `[06 Integration Fix Required]`로 이관

최종 검증:
- Targeted Season **50/50 GREEN**
- Season suite **60/60 GREEN**
- Full suite **938/939** — 공용 `season-shop-progression` stale expectation 1건만 RED
- TypeScript **GREEN**
- Production build **GREEN**
- Season-owned blocker는 해소됨. 전체 integration-ready 판정은 06의 공용 expectation 갱신 및 전체 gate GREEN 확인 후로 보류.