### PR TITLE
01 Raising: harden progression boundaries and growth identity paths

### DIFF
--- a/src/advanced-talents-boundaries.test.ts
+++ b/src/advanced-talents-boundaries.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { advancedTalents } from './advanced-talents';
+
+describe('advanced talent boundaries', () => {
+  it('keeps level three and five thresholds exact after normalizing levels', () => {
+    expect(advancedTalents({ hunt:2.9, magic:4.9, rest:2, herb:2 })).toEqual(['arcane_rhythm']);
+    expect(advancedTalents({ hunt:3, magic:5, rest:2, herb:2 })).toEqual(['hunter_instinct','arcane_rhythm','star_channel']);
+  });
+
+  it('treats malformed mastery levels as locked instead of maxed', () => {
+    expect(advancedTalents({ hunt:Number.NaN, magic:Number.POSITIVE_INFINITY, rest:Number.NEGATIVE_INFINITY, herb:-3 })).toEqual([]);
+  });
+});

--- a/src/advanced-talents.ts
+++ b/src/advanced-talents.ts
@@ -31,9 +31,13 @@ export const talentDefinitions: AdvancedTalentDefinition[] = [
 
 export type MasteryLevels = Record<ActivityId, number>;
 
+function normalizeMasteryLevel(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 export function advancedTalents(levels: MasteryLevels): AdvancedTalentId[] {
   return talentDefinitions
-    .filter(talent => levels[talent.activity] >= talent.requiredLevel)
+    .filter(talent => normalizeMasteryLevel(levels[talent.activity]) >= talent.requiredLevel)
     .map(talent => talent.id);
 }
 

--- a/src/bond-replay-prevention.test.ts
+++ b/src/bond-replay-prevention.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { reconcileBondSceneRewards } from './raising-depth-rewards';
+
+const base = {
+  affection:0,
+  outings:0,
+  trainings:0,
+  gifts:0,
+  guardianRank:'trainee' as const,
+  bossClears:0,
+  annualRecords:0,
+  gold:500,
+  gems:2,
+};
+
+describe('bond scene replay prevention', () => {
+  it('repairs a reward-proven historical scene without announcing it as newly unlocked', () => {
+    const progress = {
+      ...base,
+      unlocked:[],
+      rewarded:['first_trust' as const],
+    };
+
+    const repaired = reconcileBondSceneRewards(progress, progress);
+
+    expect(repaired.changed).toBe(true);
+    expect(repaired.unlocked).toEqual(['first_trust']);
+    expect(repaired.rewarded).toEqual(['first_trust']);
+    expect(repaired.newlyUnlocked).toEqual([]);
+    expect(repaired.gold).toBe(500);
+    expect(repaired.gems).toBe(2);
+  });
+
+  it('still announces a genuinely new eligible scene exactly once', () => {
+    const progress = {
+      ...base,
+      affection:55,
+      unlocked:[],
+      rewarded:[],
+    };
+
+    const first = reconcileBondSceneRewards(progress, progress);
+    expect(first.newlyUnlocked).toEqual(['first_trust']);
+    expect(first.gold).toBe(600);
+
+    const stable = {
+      ...progress,
+      unlocked:first.unlocked,
+      rewarded:first.rewarded,
+      gold:first.gold,
+      gems:first.gems,
+    };
+    const second = reconcileBondSceneRewards(stable, stable);
+    expect(second.changed).toBe(false);
+    expect(second.newlyUnlocked).toEqual([]);
+    expect(second.gold).toBe(600);
+  });
+});

--- a/src/bond-scenes.test.ts
+++ b/src/bond-scenes.test.ts
@@ -14,6 +14,61 @@ describe('Runa bond scenes', () => {
     expect(eligibleBondScenes({ affection:76, outings:1, trainings:10, gifts:0, guardianRank:'trainee', bossClears:0, annualRecords:0, alreadyUnlocked:[] })).toEqual(['first_trust','favorite_place','shared_secret','training_promise']);
   });
 
+  it('keeps every relationship threshold exact', () => {
+    const base = { affection:0, outings:0, trainings:0, gifts:0, guardianRank:'trainee' as const, bossClears:0, annualRecords:0, alreadyUnlocked:[] as BondSceneId[] };
+
+    expect(eligibleBondScenes({ ...base, affection:54 })).not.toContain('first_trust');
+    expect(eligibleBondScenes({ ...base, affection:55 })).toContain('first_trust');
+
+    expect(eligibleBondScenes({ ...base, affection:65, outings:0 })).not.toContain('favorite_place');
+    expect(eligibleBondScenes({ ...base, affection:65, outings:1 })).toContain('favorite_place');
+
+    expect(eligibleBondScenes({ ...base, affection:74 })).not.toContain('shared_secret');
+    expect(eligibleBondScenes({ ...base, affection:75 })).toContain('shared_secret');
+    expect(eligibleBondScenes({ ...base, affection:75, trainings:9 })).not.toContain('training_promise');
+    expect(eligibleBondScenes({ ...base, affection:75, trainings:10 })).toContain('training_promise');
+
+    expect(eligibleBondScenes({ ...base, affection:79, gifts:5 })).not.toContain('gift_memory');
+    expect(eligibleBondScenes({ ...base, affection:80, gifts:4 })).not.toContain('gift_memory');
+    expect(eligibleBondScenes({ ...base, affection:80, gifts:5 })).toContain('gift_memory');
+
+    expect(eligibleBondScenes({ ...base, affection:84, guardianRank:'guardian' })).not.toContain('guardian_confession');
+    expect(eligibleBondScenes({ ...base, affection:85, guardianRank:'junior' })).not.toContain('guardian_confession');
+    expect(eligibleBondScenes({ ...base, affection:85, guardianRank:'guardian' })).toContain('guardian_confession');
+
+    expect(eligibleBondScenes({ ...base, bossClears:0 })).not.toContain('first_boss_together');
+    expect(eligibleBondScenes({ ...base, bossClears:1 })).toContain('first_boss_together');
+    expect(eligibleBondScenes({ ...base, bossClears:2 })).not.toContain('three_regions_together');
+    expect(eligibleBondScenes({ ...base, bossClears:3 })).toContain('three_regions_together');
+
+    expect(eligibleBondScenes({ ...base, annualRecords:0 })).not.toContain('year_together');
+    expect(eligibleBondScenes({ ...base, annualRecords:1 })).toContain('year_together');
+  });
+
+  it('treats malformed numeric progress as zero instead of unlocking scenes', () => {
+    expect(eligibleBondScenes({
+      affection:Number.POSITIVE_INFINITY,
+      outings:Number.POSITIVE_INFINITY,
+      trainings:Number.POSITIVE_INFINITY,
+      gifts:Number.POSITIVE_INFINITY,
+      guardianRank:'guardian',
+      bossClears:Number.POSITIVE_INFINITY,
+      annualRecords:Number.POSITIVE_INFINITY,
+      alreadyUnlocked:[],
+    })).toEqual([]);
+
+    expect(eligibleBondScenes({
+      affection:Number.NaN,
+      outings:Number.NaN,
+      trainings:Number.NaN,
+      gifts:Number.NaN,
+      guardianRank:'guardian',
+      bossClears:Number.NaN,
+      annualRecords:Number.NaN,
+      alreadyUnlocked:[],
+    })).toEqual([]);
+  });
+
   it('unlocks expedition and annual relationship scenes from persistent progress', () => {
     const result = eligibleBondScenes({ affection:90, outings:3, trainings:20, gifts:5, guardianRank:'guardian', bossClears:3, annualRecords:1, alreadyUnlocked:[] });
     expect(result).toEqual([

--- a/src/bond-scenes.test.ts
+++ b/src/bond-scenes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { bondSceneDefinitions, eligibleBondScenes } from './bond-scenes';
+import { bondSceneDefinitions, eligibleBondScenes, type BondSceneId } from './bond-scenes';
 
 describe('Runa bond scenes', () => {
   it('defines ten scenes in relationship progression order', () => {
@@ -26,5 +26,24 @@ describe('Runa bond scenes', () => {
     const prior = ['first_trust','favorite_place','shared_secret','training_promise','gift_memory','guardian_confession','first_boss_together','three_regions_together'] as const;
     expect(eligibleBondScenes({ affection:94, outings:3, trainings:20, gifts:5, guardianRank:'guardian', bossClears:3, annualRecords:1, alreadyUnlocked:[...prior] })).not.toContain('precious_partner');
     expect(eligibleBondScenes({ affection:95, outings:3, trainings:20, gifts:5, guardianRank:'guardian', bossClears:3, annualRecords:1, alreadyUnlocked:[...prior] })).toContain('precious_partner');
+  });
+
+  it('counts only valid earlier bond scenes toward precious partner', () => {
+    const sevenPrior: BondSceneId[] = [
+      'first_trust','favorite_place','shared_secret','training_promise','gift_memory','guardian_confession','first_boss_together',
+    ];
+    const pollutedPrior = [...sevenPrior, 'precious_partner', 'unknown_scene' as BondSceneId];
+    const progress = {
+      affection:95,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+    };
+
+    expect(eligibleBondScenes({ ...progress, alreadyUnlocked:pollutedPrior })).not.toContain('precious_partner');
+    expect(eligibleBondScenes({ ...progress, alreadyUnlocked:[...sevenPrior, 'three_regions_together'] })).toContain('precious_partner');
   });
 });

--- a/src/bond-scenes.ts
+++ b/src/bond-scenes.ts
@@ -39,19 +39,29 @@ export type BondSceneProgress = {
   alreadyUnlocked: BondSceneId[];
 };
 
+function progressCount(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 export function eligibleBondScenes(progress: BondSceneProgress): BondSceneId[] {
+  const affection = progressCount(progress.affection);
+  const outings = progressCount(progress.outings);
+  const trainings = progressCount(progress.trainings);
+  const gifts = progressCount(progress.gifts);
+  const bossClears = progressCount(progress.bossClears);
+  const annualRecords = progressCount(progress.annualRecords);
   const eligible = new Set<BondSceneId>();
-  if (progress.affection >= 55) eligible.add('first_trust');
-  if (progress.affection >= 65 && progress.outings >= 1) eligible.add('favorite_place');
-  if (progress.affection >= 75) eligible.add('shared_secret');
-  if (progress.affection >= 75 && progress.trainings >= 10) eligible.add('training_promise');
-  if (progress.affection >= 80 && progress.gifts >= 5) eligible.add('gift_memory');
-  if (progress.affection >= 85 && rankOrder.indexOf(progress.guardianRank) >= rankOrder.indexOf('guardian')) eligible.add('guardian_confession');
-  if (progress.bossClears >= 1) eligible.add('first_boss_together');
-  if (progress.bossClears >= 3) eligible.add('three_regions_together');
-  if (progress.annualRecords >= 1) eligible.add('year_together');
+  if (affection >= 55) eligible.add('first_trust');
+  if (affection >= 65 && outings >= 1) eligible.add('favorite_place');
+  if (affection >= 75) eligible.add('shared_secret');
+  if (affection >= 75 && trainings >= 10) eligible.add('training_promise');
+  if (affection >= 80 && gifts >= 5) eligible.add('gift_memory');
+  if (affection >= 85 && rankOrder.indexOf(progress.guardianRank) >= rankOrder.indexOf('guardian')) eligible.add('guardian_confession');
+  if (bossClears >= 1) eligible.add('first_boss_together');
+  if (bossClears >= 3) eligible.add('three_regions_together');
+  if (annualRecords >= 1) eligible.add('year_together');
   const prior = new Set([...progress.alreadyUnlocked, ...eligible]);
   const validPriorCount = preciousPartnerPriorIds.filter(id => prior.has(id)).length;
-  if (progress.affection >= 95 && validPriorCount >= 8) eligible.add('precious_partner');
+  if (affection >= 95 && validPriorCount >= 8) eligible.add('precious_partner');
   return bondSceneIds.filter(id => eligible.has(id));
 }

--- a/src/bond-scenes.ts
+++ b/src/bond-scenes.ts
@@ -26,6 +26,7 @@ export const bondSceneDefinitions: BondSceneDefinition[] = [
 
 export const bondSceneIds = bondSceneDefinitions.map(item => item.id);
 const rankOrder: GuardianRankId[] = ['trainee','junior','guardian','veteran','starlight'];
+const preciousPartnerPriorIds = bondSceneIds.filter(id => id !== 'precious_partner');
 
 export type BondSceneProgress = {
   affection: number;
@@ -50,6 +51,7 @@ export function eligibleBondScenes(progress: BondSceneProgress): BondSceneId[] {
   if (progress.bossClears >= 3) eligible.add('three_regions_together');
   if (progress.annualRecords >= 1) eligible.add('year_together');
   const prior = new Set([...progress.alreadyUnlocked, ...eligible]);
-  if (progress.affection >= 95 && prior.size >= 8) eligible.add('precious_partner');
+  const validPriorCount = preciousPartnerPriorIds.filter(id => prior.has(id)).length;
+  if (progress.affection >= 95 && validPriorCount >= 8) eligible.add('precious_partner');
   return bondSceneIds.filter(id => eligible.has(id));
 }

--- a/src/calling-signatures.test.ts
+++ b/src/calling-signatures.test.ts
@@ -2,18 +2,40 @@ import { describe, expect, it } from 'vitest';
 import { callingSignatureDefinitions, callingSignatures } from './calling-signatures';
 
 describe('calling signature abilities', () => {
-  it('defines two signatures for each calling', () => {
+  it('defines two signatures for each calling with increasing mastery requirements', () => {
     expect(callingSignatureDefinitions).toHaveLength(8);
     for (const calling of ['vanguard','arcanist','caretaker','pathfinder'] as const) {
-      expect(callingSignatureDefinitions.filter(item => item.calling === calling)).toHaveLength(2);
+      const signatures = callingSignatureDefinitions.filter(item => item.calling === calling);
+      expect(signatures).toHaveLength(2);
+      expect(signatures.map(item => item.requiredMasteryLevel)).toEqual([2,4]);
     }
   });
 
-  it('unlocks signatures from tier-two and tier-four traits only for the active calling', () => {
+  it('keeps legacy trait-only lookup compatible when mastery is omitted', () => {
     expect(callingSignatures('vanguard', ['vanguard_power'])).toEqual([]);
     expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus'])).toEqual(['rally_strike']);
     expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'])).toEqual(['rally_strike','guardian_breaker']);
     expect(callingSignatures('arcanist', ['vanguard_power','vanguard_focus'])).toEqual([]);
     expect(callingSignatures(null, ['vanguard_power','vanguard_focus'])).toEqual([]);
+  });
+
+  it('requires both the trait and Calling mastery when mastery XP is supplied', () => {
+    const traits = ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'] as const;
+    expect(callingSignatures('vanguard', [...traits], 2)).toEqual([]);
+    expect(callingSignatures('vanguard', [...traits], 3)).toEqual(['rally_strike']);
+    expect(callingSignatures('vanguard', [...traits], 11)).toEqual(['rally_strike']);
+    expect(callingSignatures('vanguard', [...traits], 12)).toEqual(['rally_strike','guardian_breaker']);
+  });
+
+  it('does not let mastery bypass missing prerequisite traits', () => {
+    expect(callingSignatures('vanguard', ['vanguard_power'], 999)).toEqual([]);
+    expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus'], 999)).toEqual(['rally_strike']);
+  });
+
+  it('treats malformed mastery XP as level one when mastery is supplied', () => {
+    const traits = ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'] as const;
+    expect(callingSignatures('vanguard', [...traits], Number.NaN)).toEqual([]);
+    expect(callingSignatures('vanguard', [...traits], Number.POSITIVE_INFINITY)).toEqual([]);
+    expect(callingSignatures('vanguard', [...traits], -3)).toEqual([]);
   });
 });

--- a/src/calling-signatures.ts
+++ b/src/calling-signatures.ts
@@ -1,3 +1,4 @@
+import { callingMasteryLevel } from './calling-mastery';
 import type { GuardianCallingId } from './guardian-callings';
 import type { GrowthTraitId } from './growth-traits';
 
@@ -11,24 +12,28 @@ export type CallingSignatureDefinition = {
   id: CallingSignatureId;
   calling: GuardianCallingId;
   requiredTrait: GrowthTraitId;
+  requiredMasteryLevel: 2 | 4;
   label: string;
   description: string;
 };
 
 export const callingSignatureDefinitions: CallingSignatureDefinition[] = [
-  { id:'rally_strike', calling:'vanguard', requiredTrait:'vanguard_focus', label:'집결 일격', description:'원정 첫 공격 +8%.' },
-  { id:'guardian_breaker', calling:'vanguard', requiredTrait:'vanguard_legend', label:'수호자 파쇄', description:'보스전 공격 +6%.' },
-  { id:'mana_echo', calling:'arcanist', requiredTrait:'arcanist_insight', label:'마력 메아리', description:'원정 첫 기 모으기 +8%.' },
-  { id:'astral_core', calling:'arcanist', requiredTrait:'arcanist_legend', label:'성운 핵', description:'보스전 기 모으기 +6%.' },
-  { id:'gentle_guard', calling:'caretaker', requiredTrait:'caretaker_bond', label:'다정한 방벽', description:'원정 첫 회피 압박 방어 +10%.' },
-  { id:'heart_anchor', calling:'caretaker', requiredTrait:'caretaker_legend', label:'마음의 닻', description:'원정 종료 스트레스 부담 -2.' },
-  { id:'trail_reading', calling:'pathfinder', requiredTrait:'pathfinder_eye', label:'길 읽기', description:'일반 원정 첫 클리어 재료 +1.' },
-  { id:'star_compass', calling:'pathfinder', requiredTrait:'pathfinder_legend', label:'별의 나침반', description:'지역 완주 시 해당 지역 재료 +1.' },
+  { id:'rally_strike', calling:'vanguard', requiredTrait:'vanguard_focus', requiredMasteryLevel:2, label:'집결 일격', description:'원정 첫 공격 +8%.' },
+  { id:'guardian_breaker', calling:'vanguard', requiredTrait:'vanguard_legend', requiredMasteryLevel:4, label:'수호자 파쇄', description:'보스전 공격 +6%.' },
+  { id:'mana_echo', calling:'arcanist', requiredTrait:'arcanist_insight', requiredMasteryLevel:2, label:'마력 메아리', description:'원정 첫 기 모으기 +8%.' },
+  { id:'astral_core', calling:'arcanist', requiredTrait:'arcanist_legend', requiredMasteryLevel:4, label:'성운 핵', description:'보스전 기 모으기 +6%.' },
+  { id:'gentle_guard', calling:'caretaker', requiredTrait:'caretaker_bond', requiredMasteryLevel:2, label:'다정한 방벽', description:'원정 첫 회피 압박 방어 +10%.' },
+  { id:'heart_anchor', calling:'caretaker', requiredTrait:'caretaker_legend', requiredMasteryLevel:4, label:'마음의 닻', description:'원정 종료 스트레스 부담 -2.' },
+  { id:'trail_reading', calling:'pathfinder', requiredTrait:'pathfinder_eye', requiredMasteryLevel:2, label:'길 읽기', description:'일반 원정 첫 클리어 재료 +1.' },
+  { id:'star_compass', calling:'pathfinder', requiredTrait:'pathfinder_legend', requiredMasteryLevel:4, label:'별의 나침반', description:'지역 완주 시 해당 지역 재료 +1.' },
 ];
 
-export function callingSignatures(calling: GuardianCallingId | null, purchasedTraits: GrowthTraitId[]): CallingSignatureId[] {
+export function callingSignatures(calling: GuardianCallingId | null, purchasedTraits: GrowthTraitId[], masteryXp?: number): CallingSignatureId[] {
   if (!calling) return [];
+  const masteryLevel = masteryXp === undefined ? null : callingMasteryLevel(masteryXp);
   return callingSignatureDefinitions
-    .filter(item => item.calling === calling && purchasedTraits.includes(item.requiredTrait))
+    .filter(item => item.calling === calling
+      && purchasedTraits.includes(item.requiredTrait)
+      && (masteryLevel === null || masteryLevel >= item.requiredMasteryLevel))
     .map(item => item.id);
 }

--- a/src/career-boundaries.test.ts
+++ b/src/career-boundaries.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { careerTitles, recordCareerAction } from './career-records';
+
+describe('career record boundaries', () => {
+  it('does not unlock titles from malformed record or story counts', () => {
+    expect(careerTitles({
+      records:{ trainings:Number.POSITIVE_INFINITY, bestScore:Number.NaN, sGrades:0, outings:Number.POSITIVE_INFINITY, gifts:Number.POSITIVE_INFINITY, monthsCompleted:0 },
+      guardianRank:'trainee',
+      openedStories:Number.POSITIVE_INFINITY,
+      openedRaisingStories:Number.NaN,
+    })).toEqual([]);
+  });
+
+  it('keeps title thresholds exact after normalizing fractional counts', () => {
+    expect(careerTitles({
+      records:{ trainings:9.9, bestScore:899.9, sGrades:0, outings:9.9, gifts:4.9, monthsCompleted:0 },
+      guardianRank:'guardian',
+      openedStories:99,
+      openedRaisingStories:3.9,
+    })).toEqual([]);
+    expect(careerTitles({
+      records:{ trainings:10, bestScore:900, sGrades:0, outings:10, gifts:5, monthsCompleted:0 },
+      guardianRank:'veteran',
+      openedStories:99,
+      openedRaisingStories:4,
+    })).toEqual(['steady_trainer','perfect_chaser','seasoned_explorer','warm_giver','story_witness','veteran_guardian']);
+  });
+
+  it('repairs malformed counters when recording the next career action', () => {
+    const malformed = {
+      trainings:Number.NaN,
+      bestScore:Number.POSITIVE_INFINITY,
+      sGrades:Number.NaN,
+      outings:Number.POSITIVE_INFINITY,
+      gifts:-4,
+      monthsCompleted:2.9,
+    };
+    expect(recordCareerAction(malformed, { type:'training', score:650, grade:'S' })).toEqual({
+      trainings:1,
+      bestScore:650,
+      sGrades:1,
+      outings:0,
+      gifts:0,
+      monthsCompleted:2,
+    });
+  });
+});

--- a/src/career-records.ts
+++ b/src/career-records.ts
@@ -41,19 +41,35 @@ export type CareerAction =
   | { type: 'gift' }
   | { type: 'month' };
 
+function normalizeCount(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function normalizeCareerRecords(records: CareerRecords): CareerRecords {
+  return {
+    trainings:normalizeCount(records.trainings),
+    bestScore:normalizeCount(records.bestScore),
+    sGrades:normalizeCount(records.sGrades),
+    outings:normalizeCount(records.outings),
+    gifts:normalizeCount(records.gifts),
+    monthsCompleted:normalizeCount(records.monthsCompleted),
+  };
+}
+
 export function recordCareerAction(records: CareerRecords, action: CareerAction): CareerRecords {
+  const safe = normalizeCareerRecords(records);
   if (action.type === 'training') {
-    const score = Number.isFinite(action.score) ? Math.max(0, Math.floor(action.score)) : 0;
+    const score = normalizeCount(action.score);
     return {
-      ...records,
-      trainings: records.trainings + 1,
-      bestScore: Math.max(records.bestScore, score),
-      sGrades: records.sGrades + (action.grade === 'S' ? 1 : 0),
+      ...safe,
+      trainings: safe.trainings + 1,
+      bestScore: Math.max(safe.bestScore, score),
+      sGrades: safe.sGrades + (action.grade === 'S' ? 1 : 0),
     };
   }
-  if (action.type === 'outing') return { ...records, outings: records.outings + 1 };
-  if (action.type === 'gift') return { ...records, gifts: records.gifts + 1 };
-  return { ...records, monthsCompleted: records.monthsCompleted + 1 };
+  if (action.type === 'outing') return { ...safe, outings: safe.outings + 1 };
+  if (action.type === 'gift') return { ...safe, gifts: safe.gifts + 1 };
+  return { ...safe, monthsCompleted: safe.monthsCompleted + 1 };
 }
 
 const guardianOrder: GuardianRankId[] = ['trainee', 'junior', 'guardian', 'veteran', 'starlight'];
@@ -67,11 +83,12 @@ export type CareerTitleProgress = {
 
 export function careerTitles(input: CareerTitleProgress): CareerTitleId[] {
   const unlocked = new Set<CareerTitleId>();
-  const relevantStories = input.openedRaisingStories ?? input.openedStories;
-  if (input.records.trainings >= 10) unlocked.add('steady_trainer');
-  if (input.records.bestScore >= 900) unlocked.add('perfect_chaser');
-  if (input.records.outings >= 10) unlocked.add('seasoned_explorer');
-  if (input.records.gifts >= 5) unlocked.add('warm_giver');
+  const records = normalizeCareerRecords(input.records);
+  const relevantStories = normalizeCount(input.openedRaisingStories ?? input.openedStories);
+  if (records.trainings >= 10) unlocked.add('steady_trainer');
+  if (records.bestScore >= 900) unlocked.add('perfect_chaser');
+  if (records.outings >= 10) unlocked.add('seasoned_explorer');
+  if (records.gifts >= 5) unlocked.add('warm_giver');
   if (relevantStories >= 4) unlocked.add('story_witness');
   if (guardianOrder.indexOf(input.guardianRank) >= guardianOrder.indexOf('veteran')) unlocked.add('veteran_guardian');
   return careerTitleDefinitions.map(item => item.id).filter(id => unlocked.has(id));

--- a/src/growth-traits.test.ts
+++ b/src/growth-traits.test.ts
@@ -25,6 +25,19 @@ describe('growth trait board', () => {
     expect(duplicate).toEqual({ purchased:false, traits:['vanguard_power'], points:2 });
   });
 
+  it('normalizes malformed growth point balances before checking or spending them', () => {
+    expect(canPurchaseGrowthTrait('vanguard_power', [], Number.NaN)).toBe(false);
+    expect(canPurchaseGrowthTrait('vanguard_power', [], Number.POSITIVE_INFINITY)).toBe(false);
+    expect(canPurchaseGrowthTrait('vanguard_power', [], -3)).toBe(false);
+    expect(canPurchaseGrowthTrait('vanguard_assault', ['vanguard_focus'], 1.9)).toBe(false);
+    expect(canPurchaseGrowthTrait('vanguard_power', [], 1.9)).toBe(true);
+
+    expect(purchaseGrowthTrait('vanguard_power', [], Number.NaN)).toEqual({ purchased:false, traits:[], points:0 });
+    expect(purchaseGrowthTrait('vanguard_power', [], Number.POSITIVE_INFINITY)).toEqual({ purchased:false, traits:[], points:0 });
+    expect(purchaseGrowthTrait('vanguard_power', [], -3)).toEqual({ purchased:false, traits:[], points:0 });
+    expect(purchaseGrowthTrait('vanguard_power', [], 1.9)).toEqual({ purchased:true, traits:['vanguard_power'], points:0 });
+  });
+
   it('keeps all purchased traits while only activating the current calling path', () => {
     const owned = ['vanguard_power','arcanist_mana','arcanist_insight'] as const;
     expect(activeCallingTraits('arcanist', [...owned])).toEqual(['arcanist_mana','arcanist_insight']);

--- a/src/growth-traits.ts
+++ b/src/growth-traits.ts
@@ -37,17 +37,23 @@ export const growthTraitDefinitions: GrowthTraitDefinition[] = [
 
 export const growthTraitIds = growthTraitDefinitions.map(item => item.id);
 
+function normalizeGrowthPoints(points: number): number {
+  return Number.isFinite(points) ? Math.max(0, Math.floor(points)) : 0;
+}
+
 export function canPurchaseGrowthTrait(id: GrowthTraitId, purchased: GrowthTraitId[], points: number): boolean {
   if (purchased.includes(id)) return false;
   const definition = growthTraitDefinitions.find(item => item.id === id);
-  if (!definition || points < definition.cost) return false;
+  const availablePoints = normalizeGrowthPoints(points);
+  if (!definition || availablePoints < definition.cost) return false;
   return definition.prerequisite === null || purchased.includes(definition.prerequisite);
 }
 
 export function purchaseGrowthTrait(id: GrowthTraitId, purchased: GrowthTraitId[], points: number) {
-  if (!canPurchaseGrowthTrait(id, purchased, points)) return { purchased:false, traits:purchased, points };
+  const availablePoints = normalizeGrowthPoints(points);
+  if (!canPurchaseGrowthTrait(id, purchased, availablePoints)) return { purchased:false, traits:purchased, points:availablePoints };
   const definition = growthTraitDefinitions.find(item => item.id === id)!;
-  return { purchased:true, traits:[...purchased, id], points:points - definition.cost };
+  return { purchased:true, traits:[...purchased, id], points:availablePoints - definition.cost };
 }
 
 export function activeCallingTraits(calling: GuardianCallingId | null, purchased: GrowthTraitId[]): GrowthTraitId[] {

--- a/src/guardian-callings.test.ts
+++ b/src/guardian-callings.test.ts
@@ -25,7 +25,20 @@ describe('guardian calling rules', () => {
     expect(applyCallingSelection({ current:'vanguard', next:'vanguard', guardianRank:'guardian', gold:999, year:1, month:5, lastSwitchKey:null, history:['vanguard'] })).toMatchObject({ changed:false, reason:'same_calling', gold:999 });
   });
 
-  it('uses stable year-month switch keys', () => {
+  it('normalizes malformed gold before paid Calling changes', () => {
+    for (const gold of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, -1]) {
+      expect(applyCallingSelection({ current:'vanguard', next:'arcanist', guardianRank:'guardian', gold, year:2, month:7, lastSwitchKey:null, history:['vanguard'] }))
+        .toMatchObject({ changed:false, reason:'insufficient_gold', gold:0, current:'vanguard' });
+    }
+
+    expect(applyCallingSelection({ current:'vanguard', next:'arcanist', guardianRank:'guardian', gold:300.9, year:2, month:7, lastSwitchKey:null, history:['vanguard'] }))
+      .toMatchObject({ changed:true, reason:null, gold:0, current:'arcanist' });
+  });
+
+  it('uses stable and finite year-month switch keys', () => {
     expect(callingSwitchKey(3, 12)).toBe('3-12');
+    expect(callingSwitchKey(3.9, 12.9)).toBe('3-12');
+    expect(callingSwitchKey(Number.NaN, Number.NaN)).toBe('1-1');
+    expect(callingSwitchKey(Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY)).toBe('1-1');
   });
 });

--- a/src/guardian-callings.ts
+++ b/src/guardian-callings.ts
@@ -20,8 +20,14 @@ export const guardianCallingDefinitions: GuardianCallingDefinition[] = [
 export const guardianCallingIds = guardianCallingDefinitions.map(item => item.id);
 const guardianRankOrder: GuardianRankId[] = ['trainee','junior','guardian','veteran','starlight'];
 
+function normalizeNonnegativeInteger(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 export function callingSwitchKey(year: number, month: number): string {
-  return `${Math.max(1, Math.floor(year))}-${Math.max(1, Math.min(12, Math.floor(month)))}`;
+  const safeYear = Math.max(1, normalizeNonnegativeInteger(year));
+  const safeMonth = Math.max(1, Math.min(12, normalizeNonnegativeInteger(month)));
+  return `${safeYear}-${safeMonth}`;
 }
 
 export type CallingSelectionInput = {
@@ -41,18 +47,20 @@ export type CallingSelectionResult = CallingSelectionInput & {
 };
 
 export function applyCallingSelection(input: CallingSelectionInput): CallingSelectionResult {
+  const gold = normalizeNonnegativeInteger(input.gold);
+  const normalizedInput = { ...input, gold };
   if (guardianRankOrder.indexOf(input.guardianRank) < guardianRankOrder.indexOf('guardian')) {
-    return { ...input, changed:false, reason:'rank_locked' };
+    return { ...normalizedInput, changed:false, reason:'rank_locked' };
   }
-  if (input.current === input.next) return { ...input, changed:false, reason:'same_calling' };
+  if (input.current === input.next) return { ...normalizedInput, changed:false, reason:'same_calling' };
   const key = callingSwitchKey(input.year, input.month);
-  if (input.lastSwitchKey === key) return { ...input, changed:false, reason:'monthly_lock' };
+  if (input.lastSwitchKey === key) return { ...normalizedInput, changed:false, reason:'monthly_lock' };
   const switching = input.current !== null;
-  if (switching && input.gold < 300) return { ...input, changed:false, reason:'insufficient_gold' };
+  if (switching && gold < 300) return { ...normalizedInput, changed:false, reason:'insufficient_gold' };
   return {
-    ...input,
+    ...normalizedInput,
     current: input.next,
-    gold: switching ? input.gold - 300 : input.gold,
+    gold: switching ? gold - 300 : gold,
     lastSwitchKey: key,
     history: input.history.includes(input.next) ? input.history : [...input.history, input.next],
     changed:true,

--- a/src/guardian-rank.test.ts
+++ b/src/guardian-rank.test.ts
@@ -6,6 +6,11 @@ describe('guardian rank rules', () => {
     expect(guardianGrowthPoints({ memories: 3, skills: 2, discoveries: 4, masteryLevels: [1, 2, 4, 1] })).toBe(15);
   });
 
+  it('normalizes malformed and fractional progress before calculating rank points', () => {
+    expect(guardianGrowthPoints({ memories:Number.POSITIVE_INFINITY, skills:Number.NaN, discoveries:-3, masteryLevels:[Number.POSITIVE_INFINITY, 2.9, -1, Number.NaN] })).toBe(1);
+    expect(guardianGrowthPoints({ memories:3.9, skills:2.9, discoveries:4.9, masteryLevels:[1.9,2.9,4.9,1] })).toBe(15);
+  });
+
   it('maps stable guardian rank thresholds', () => {
     expect(guardianRank(0)).toBe('trainee');
     expect(guardianRank(7)).toBe('trainee');
@@ -18,10 +23,23 @@ describe('guardian rank rules', () => {
     expect(guardianRank(42)).toBe('starlight');
   });
 
+  it('treats malformed direct rank points as zero', () => {
+    expect(guardianRank(Number.NaN)).toBe('trainee');
+    expect(guardianRank(Number.POSITIVE_INFINITY)).toBe('trainee');
+    expect(guardianRank(-5)).toBe('trainee');
+    expect(guardianRank(8.9)).toBe('junior');
+  });
+
   it('returns the next rank and threshold until max rank', () => {
     expect(nextGuardianRank(7)).toEqual({ rank: 'junior', threshold: 8 });
     expect(nextGuardianRank(8)).toEqual({ rank: 'guardian', threshold: 16 });
     expect(nextGuardianRank(30)).toEqual({ rank: 'starlight', threshold: 42 });
     expect(nextGuardianRank(42)).toBeNull();
+  });
+
+  it('keeps malformed direct points at the first progression boundary', () => {
+    expect(nextGuardianRank(Number.NaN)).toEqual({ rank:'junior', threshold:8 });
+    expect(nextGuardianRank(Number.POSITIVE_INFINITY)).toEqual({ rank:'junior', threshold:8 });
+    expect(nextGuardianRank(-3)).toEqual({ rank:'junior', threshold:8 });
   });
 });

--- a/src/guardian-rank.ts
+++ b/src/guardian-rank.ts
@@ -17,20 +17,32 @@ export const guardianRankDefinitions: Array<{ id: GuardianRankId; label: string;
 
 export const rewardableGuardianRanks: GuardianRankId[] = ['junior', 'guardian', 'veteran', 'starlight'];
 
+function normalizeProgress(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 export function guardianGrowthPoints(progress: GuardianProgress): number {
-  const masteryPoints = progress.masteryLevels.reduce((sum, level) => sum + Math.max(0, level - 1), 0);
-  return progress.memories + progress.skills * 2 + progress.discoveries + masteryPoints;
+  const masteryPoints = progress.masteryLevels.reduce((sum, rawLevel) => {
+    const level = normalizeProgress(rawLevel);
+    return sum + Math.max(0, level - 1);
+  }, 0);
+  return normalizeProgress(progress.memories)
+    + normalizeProgress(progress.skills) * 2
+    + normalizeProgress(progress.discoveries)
+    + masteryPoints;
 }
 
 export function guardianRank(points: number): GuardianRankId {
+  const safePoints = normalizeProgress(points);
   let result: GuardianRankId = 'trainee';
   for (const definition of guardianRankDefinitions) {
-    if (points >= definition.threshold) result = definition.id;
+    if (safePoints >= definition.threshold) result = definition.id;
   }
   return result;
 }
 
 export function nextGuardianRank(points: number): { rank: GuardianRankId; threshold: number } | null {
-  const next = guardianRankDefinitions.find(definition => definition.threshold > points);
+  const safePoints = normalizeProgress(points);
+  const next = guardianRankDefinitions.find(definition => definition.threshold > safePoints);
   return next ? { rank: next.id, threshold: next.threshold } : null;
 }

--- a/src/raising-depth-boundaries.test.ts
+++ b/src/raising-depth-boundaries.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { applyBossGrowthPointReward, incrementCallingMonthMastery, monthGrowthPointReward } from './raising-depth-rewards';
+
+describe('raising depth pure reward boundaries', () => {
+  it('keeps the S-month bonus threshold exact and ignores malformed training scores', () => {
+    expect(monthGrowthPointReward(899.9)).toBe(1);
+    expect(monthGrowthPointReward(900)).toBe(2);
+    expect(monthGrowthPointReward(9999)).toBe(2);
+    expect(monthGrowthPointReward(Number.NaN)).toBe(1);
+    expect(monthGrowthPointReward(Number.POSITIVE_INFINITY)).toBe(1);
+    expect(monthGrowthPointReward(Number.NEGATIVE_INFINITY)).toBe(1);
+  });
+
+  it('repairs the active Calling mastery counter before incrementing it', () => {
+    const base = { vanguard:Number.NaN, arcanist:2.9, caretaker:Number.POSITIVE_INFINITY, pathfinder:-3 };
+
+    expect(incrementCallingMonthMastery(base, 'vanguard')).toEqual({ ...base, vanguard:1 });
+    expect(incrementCallingMonthMastery(base, 'arcanist')).toEqual({ ...base, arcanist:3 });
+    expect(incrementCallingMonthMastery(base, 'caretaker')).toEqual({ ...base, caretaker:1 });
+    expect(incrementCallingMonthMastery(base, 'pathfinder')).toEqual({ ...base, pathfinder:1 });
+    expect(incrementCallingMonthMastery(base, null)).toBe(base);
+  });
+
+  it('normalizes Growth Points and does not duplicate boss first-clear rewards', () => {
+    expect(applyBossGrowthPointReward('forest_guardian', true, [], Number.NaN)).toEqual({
+      points:1,
+      rewarded:['forest_guardian'],
+    });
+    expect(applyBossGrowthPointReward('forest_guardian', false, [], Number.POSITIVE_INFINITY)).toEqual({
+      points:0,
+      rewarded:[],
+    });
+    expect(applyBossGrowthPointReward('forest_guardian', true, ['forest_guardian'], -4)).toEqual({
+      points:0,
+      rewarded:['forest_guardian'],
+    });
+    expect(applyBossGrowthPointReward('forest_guardian', true, [], 2.9)).toEqual({
+      points:3,
+      rewarded:['forest_guardian'],
+    });
+  });
+});

--- a/src/raising-depth-effects.ts
+++ b/src/raising-depth-effects.ts
@@ -13,6 +13,11 @@ const personalityKeyByActivity: Record<ActivityId, keyof Personality> = {
   herb:'curiosity',
 };
 
+function incrementMasteryXp(mastery: MasteryState, activity: ActivityId): void {
+  const currentXp = Number.isFinite(mastery[activity]?.xp) ? Math.max(0, Math.floor(mastery[activity].xp)) : 0;
+  mastery[activity] = { xp:currentXp + 1 };
+}
+
 export type TrainingIdentityInput = {
   stats:Stats;
   personality:Personality;
@@ -33,6 +38,7 @@ export function applyTrainingIdentityEffects(input:TrainingIdentityInput) {
   if (input.schedule.includes(preferences.favoriteActivity)) {
     const key = personalityKeyByActivity[preferences.favoriteActivity];
     personality[key] = clamp(personality[key] + 1);
+    incrementMasteryXp(mastery, preferences.favoriteActivity);
   }
 
   if (activeTraits.has('vanguard_power') && input.schedule.includes('hunt')) stats.strength = clamp(stats.strength + 1);
@@ -40,8 +46,9 @@ export function applyTrainingIdentityEffects(input:TrainingIdentityInput) {
   if (activeTraits.has('arcanist_insight') && input.schedule.includes('magic')) stats.intelligence = clamp(stats.intelligence + 1);
   if (activeTraits.has('caretaker_rest') && input.schedule.includes('rest')) stats.fatigue = clamp(stats.fatigue - 2);
   if (activeTraits.has('pathfinder_herb') && input.schedule.includes('herb')) stats.intelligence = clamp(stats.intelligence + 1);
-  if (activeTraits.has('vanguard_focus') && input.schedule.includes('hunt') && input.trainingScore >= 650) {
-    mastery.hunt = { xp: mastery.hunt.xp + 1 };
+  const trainingScore = Number.isFinite(input.trainingScore) ? Math.max(0, input.trainingScore) : 0;
+  if (activeTraits.has('vanguard_focus') && input.schedule.includes('hunt') && trainingScore >= 650) {
+    incrementMasteryXp(mastery, 'hunt');
   }
 
   return { stats, personality, mastery, preferences };

--- a/src/raising-depth-identity.test.ts
+++ b/src/raising-depth-identity.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { applyTrainingIdentityEffects } from './raising-depth-effects';
+
+const stats = {
+  strength:30,
+  intelligence:30,
+  magic:30,
+  morality:40,
+  affection:45,
+  stress:12,
+  fatigue:18,
+};
+
+const mastery = {
+  hunt:{ xp:0 },
+  magic:{ xp:0 },
+  rest:{ xp:0 },
+  herb:{ xp:0 },
+};
+
+describe('Runa personality growth identity', () => {
+  it('leaves a different mastery trail for different personalities on the same schedule', () => {
+    const brave = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:60, kindness:20, curiosity:20, calmness:20 },
+      mastery,
+      schedule:['hunt','rest'],
+      trainingScore:500,
+      activeCalling:null,
+      purchasedTraits:[],
+    });
+    const serene = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:20, kindness:20, curiosity:20, calmness:60 },
+      mastery,
+      schedule:['hunt','rest'],
+      trainingScore:500,
+      activeCalling:null,
+      purchasedTraits:[],
+    });
+
+    expect(brave.mastery.hunt.xp).toBe(1);
+    expect(brave.mastery.rest.xp).toBe(0);
+    expect(serene.mastery.hunt.xp).toBe(0);
+    expect(serene.mastery.rest.xp).toBe(1);
+    expect(brave.personality.courage).toBe(61);
+    expect(serene.personality.calmness).toBe(61);
+  });
+
+  it('lets Calling steer curious and balanced personalities toward different specializations', () => {
+    const curiousArcanist = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:20, kindness:20, curiosity:60, calmness:20 },
+      mastery,
+      schedule:['magic','herb'],
+      trainingScore:500,
+      activeCalling:'arcanist',
+      purchasedTraits:[],
+    });
+    const curiousPathfinder = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:20, kindness:20, curiosity:60, calmness:20 },
+      mastery,
+      schedule:['magic','herb'],
+      trainingScore:500,
+      activeCalling:'pathfinder',
+      purchasedTraits:[],
+    });
+    const balancedVanguard = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:50, kindness:50, curiosity:50, calmness:50 },
+      mastery,
+      schedule:['hunt','magic'],
+      trainingScore:500,
+      activeCalling:'vanguard',
+      purchasedTraits:[],
+    });
+
+    expect(curiousArcanist.mastery.magic.xp).toBe(1);
+    expect(curiousArcanist.mastery.herb.xp).toBe(0);
+    expect(curiousPathfinder.mastery.magic.xp).toBe(0);
+    expect(curiousPathfinder.mastery.herb.xp).toBe(1);
+    expect(balancedVanguard.mastery.hunt.xp).toBe(1);
+  });
+
+  it('does not grant the vanguard focus mastery bonus from malformed training scores', () => {
+    const result = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:20, kindness:60, curiosity:20, calmness:20 },
+      mastery,
+      schedule:['hunt'],
+      trainingScore:Number.POSITIVE_INFINITY,
+      activeCalling:'vanguard',
+      purchasedTraits:['vanguard_power','vanguard_focus'],
+    });
+
+    expect(result.mastery.hunt.xp).toBe(0);
+  });
+
+  it('keeps the vanguard focus threshold exact at 650', () => {
+    const input = {
+      stats,
+      personality:{ courage:20, kindness:60, curiosity:20, calmness:20 },
+      mastery,
+      schedule:['hunt'] as const,
+      activeCalling:'vanguard' as const,
+      purchasedTraits:['vanguard_power','vanguard_focus'] as const,
+    };
+
+    expect(applyTrainingIdentityEffects({ ...input, schedule:[...input.schedule], purchasedTraits:[...input.purchasedTraits], trainingScore:649.9 }).mastery.hunt.xp).toBe(0);
+    expect(applyTrainingIdentityEffects({ ...input, schedule:[...input.schedule], purchasedTraits:[...input.purchasedTraits], trainingScore:650 }).mastery.hunt.xp).toBe(1);
+  });
+});

--- a/src/raising-depth-rewards.ts
+++ b/src/raising-depth-rewards.ts
@@ -46,7 +46,7 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
   const provenUnlocks = bondSceneIds.filter(id => claimedUnlocks.includes(id) || claimedRewards.includes(id));
   const afterEligible = eligible({ ...current, unlocked:provenUnlocks });
   const unlocked = bondSceneIds.filter(id => provenUnlocks.includes(id) || afterEligible.includes(id));
-  const newlyUnlocked = unlocked.filter(id => !claimedUnlocks.includes(id));
+  const newlyUnlocked = unlocked.filter(id => !provenUnlocks.includes(id));
   const newlyRewarded = unlocked.filter(id => !claimedRewards.includes(id));
   const rewarded = bondSceneIds.filter(id => claimedRewards.includes(id) || newlyRewarded.includes(id));
   const canonicalized = !sameIds(current.unlocked, unlocked) || !sameIds(current.rewarded, rewarded);

--- a/src/raising-depth-rewards.ts
+++ b/src/raising-depth-rewards.ts
@@ -36,6 +36,10 @@ function sameIds(left: BondSceneId[], right: BondSceneId[]): boolean {
   return left.length === right.length && left.every((id, index) => id === right[index]);
 }
 
+function normalizeProgressValue(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 export function reconcileBondSceneRewards(_previous: BondRewardProgress, current: BondRewardProgress) {
   const claimedUnlocks = bondSceneIds.filter(id => current.unlocked.includes(id));
   const claimedRewards = bondSceneIds.filter(id => current.rewarded.includes(id));
@@ -74,15 +78,18 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
 }
 
 export function monthGrowthPointReward(trainingScore:number): number {
-  return 1 + (trainingScore >= 900 ? 1 : 0);
+  const score = Number.isFinite(trainingScore) ? Math.max(0, trainingScore) : 0;
+  return 1 + (score >= 900 ? 1 : 0);
 }
 
 export function incrementCallingMonthMastery(mastery: CallingMasteryState, calling: GuardianCallingId | null): CallingMasteryState {
   if (!calling) return mastery;
-  return { ...mastery, [calling]:mastery[calling] + 1 };
+  const currentMastery = normalizeProgressValue(mastery[calling]);
+  return { ...mastery, [calling]:currentMastery + 1 };
 }
 
 export function applyBossGrowthPointReward(stageId: ExpeditionStageId, firstClear:boolean, rewarded:ExpeditionStageId[], points:number) {
-  if (!firstClear || !isBossStage(stageId) || rewarded.includes(stageId)) return { points, rewarded };
-  return { points:points + 1, rewarded:[...rewarded, stageId] };
+  const safePoints = normalizeProgressValue(points);
+  if (!firstClear || !isBossStage(stageId) || rewarded.includes(stageId)) return { points:safePoints, rewarded };
+  return { points:safePoints + 1, rewarded:[...rewarded, stageId] };
 }

--- a/src/raising-path-diversity.test.ts
+++ b/src/raising-path-diversity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { advancedTalents } from './advanced-talents';
+import { masteryLevel } from './game-core';
+import { applyTrainingIdentityEffects } from './raising-depth-effects';
+
+const stats = {
+  strength:30, intelligence:30, magic:30, morality:40,
+  affection:45, stress:12, fatigue:18,
+};
+
+function talentsFromMastery(mastery: { hunt:{xp:number}; magic:{xp:number}; rest:{xp:number}; herb:{xp:number} }) {
+  return advancedTalents({
+    hunt:masteryLevel(mastery.hunt.xp),
+    magic:masteryLevel(mastery.magic.xp),
+    rest:masteryLevel(mastery.rest.xp),
+    herb:masteryLevel(mastery.herb.xp),
+  });
+}
+
+describe('raising path diversity', () => {
+  it('turns the same hunt/rest schedule into different Advanced Talent paths by personality', () => {
+    const mastery = { hunt:{xp:6}, magic:{xp:0}, rest:{xp:6}, herb:{xp:0} };
+    const brave = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:60, kindness:20, curiosity:20, calmness:20 },
+      mastery,
+      schedule:['hunt','rest'],
+      trainingScore:500,
+      activeCalling:null,
+      purchasedTraits:[],
+    });
+    const serene = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:20, kindness:20, curiosity:20, calmness:60 },
+      mastery,
+      schedule:['hunt','rest'],
+      trainingScore:500,
+      activeCalling:null,
+      purchasedTraits:[],
+    });
+
+    expect(talentsFromMastery(brave.mastery)).toContain('hunter_instinct');
+    expect(talentsFromMastery(brave.mastery)).not.toContain('steady_recovery');
+    expect(talentsFromMastery(serene.mastery)).toContain('steady_recovery');
+    expect(talentsFromMastery(serene.mastery)).not.toContain('hunter_instinct');
+  });
+
+  it('lets Calling choice split a curious build into magic or herb Advanced Talents', () => {
+    const mastery = { hunt:{xp:0}, magic:{xp:6}, rest:{xp:0}, herb:{xp:6} };
+    const personality = { courage:20, kindness:20, curiosity:60, calmness:20 };
+    const arcanist = applyTrainingIdentityEffects({
+      stats, personality, mastery,
+      schedule:['magic','herb'], trainingScore:500,
+      activeCalling:'arcanist', purchasedTraits:[],
+    });
+    const pathfinder = applyTrainingIdentityEffects({
+      stats, personality, mastery,
+      schedule:['magic','herb'], trainingScore:500,
+      activeCalling:'pathfinder', purchasedTraits:[],
+    });
+
+    expect(talentsFromMastery(arcanist.mastery)).toContain('arcane_rhythm');
+    expect(talentsFromMastery(arcanist.mastery)).not.toContain('field_scholar');
+    expect(talentsFromMastery(pathfinder.mastery)).toContain('field_scholar');
+    expect(talentsFromMastery(pathfinder.mastery)).not.toContain('arcane_rhythm');
+  });
+});

--- a/src/runa-personality.test.ts
+++ b/src/runa-personality.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { personalityArchetype, runaPreferences } from './runa-personality';
 
 describe('Runa personality identity', () => {
-  it('requires a five-point lead over the second tendency', () => {
-    expect(personalityArchetype({ courage: 70, kindness: 64, curiosity: 30, calmness: 20 })).toBe('brave');
+  it('requires an exact five-point lead over the second tendency', () => {
     expect(personalityArchetype({ courage: 70, kindness: 66, curiosity: 30, calmness: 20 })).toBe('balanced');
+    expect(personalityArchetype({ courage: 70, kindness: 65, curiosity: 30, calmness: 20 })).toBe('brave');
+    expect(personalityArchetype({ courage: 70, kindness: 64, curiosity: 30, calmness: 20 })).toBe('brave');
   });
 
   it('maps each dominant tendency to its archetype and ties to balanced', () => {
@@ -12,6 +13,13 @@ describe('Runa personality identity', () => {
     expect(personalityArchetype({ courage: 20, kindness: 20, curiosity: 60, calmness: 20 })).toBe('curious');
     expect(personalityArchetype({ courage: 20, kindness: 20, curiosity: 20, calmness: 60 })).toBe('serene');
     expect(personalityArchetype({ courage: 50, kindness: 50, curiosity: 20, calmness: 10 })).toBe('balanced');
+  });
+
+  it('normalizes malformed and out-of-range personality values before classification', () => {
+    expect(personalityArchetype({ courage:Number.NaN, kindness:Number.POSITIVE_INFINITY, curiosity:Number.NEGATIVE_INFINITY, calmness:-10 })).toBe('balanced');
+    expect(personalityArchetype({ courage:200, kindness:95, curiosity:20, calmness:20 })).toBe('brave');
+    expect(personalityArchetype({ courage:-20, kindness:4, curiosity:0, calmness:0 })).toBe('balanced');
+    expect(personalityArchetype({ courage:-20, kindness:5, curiosity:0, calmness:0 })).toBe('gentle');
   });
 
   it('derives favorite activity and gift from personality and calling', () => {

--- a/src/runa-personality.ts
+++ b/src/runa-personality.ts
@@ -12,9 +12,13 @@ const archetypeByKey: Record<keyof Personality, Exclude<RunaPersonalityArchetype
   calmness: 'serene',
 };
 
+function normalizedPersonalityValue(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 0;
+}
+
 export function personalityArchetype(personality: Personality): RunaPersonalityArchetype {
   const ranked = personalityKeys
-    .map(key => ({ key, value: Number.isFinite(personality[key]) ? personality[key] : 0 }))
+    .map(key => ({ key, value: normalizedPersonalityValue(personality[key]) }))
     .sort((a, b) => b.value - a.value);
   if (ranked.length < 2 || ranked[0].value - ranked[1].value < 5) return 'balanced';
   return archetypeByKey[ranked[0].key];

--- a/src/story-chapters.test.ts
+++ b/src/story-chapters.test.ts
@@ -69,6 +69,28 @@ describe('story chapter rules', () => {
     expect(eligibleStoryChapters({ ...base, affection:75 })).toContain('trusted_bond');
   });
 
+  it('does not let malformed legacy progress bypass story gates', () => {
+    const legacy = {
+      memories: ['first_training'],
+      visitedOutings: ['forest', 'village', 'lakeside'],
+      guardianRank: 'guardian' as const,
+      discoveries: 0,
+      expeditionStoryEntries: [],
+    };
+    expect(eligibleStoryChapters({ ...legacy, affection:Number.NaN })).toEqual(['first_step','wide_world']);
+    expect(eligibleStoryChapters({ ...legacy, affection:Number.POSITIVE_INFINITY })).toEqual(['first_step','wide_world']);
+
+    const finalReady = {
+      ...legacy,
+      affection:95,
+      guardianRank:'veteran' as const,
+      unlockedBondScenes:['shared_secret'] as const,
+      activeCalling:'pathfinder' as const,
+    };
+    expect(eligibleStoryChapters({ ...finalReady, discoveries:Number.NaN })).not.toContain('starlight_road');
+    expect(eligibleStoryChapters({ ...finalReady, discoveries:Number.POSITIVE_INFINITY })).not.toContain('starlight_road');
+  });
+
   it('requires an actual Calling choice for guardian oath when Calling progress is supplied', () => {
     const base = {
       memories: ['first_training'],

--- a/src/story-chapters.ts
+++ b/src/story-chapters.ts
@@ -51,12 +51,16 @@ export const storyChapterIds = storyChapterDefinitions.map(chapter => chapter.id
 const guardianRankOrder: GuardianRankId[] = ['trainee', 'junior', 'guardian', 'veteran', 'starlight'];
 const requiredOutings: OutingLocationId[] = ['forest', 'village', 'lakeside'];
 
+function finiteProgress(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 function rankAtLeast(rank: GuardianRankId, target: GuardianRankId): boolean {
   return guardianRankOrder.indexOf(rank) >= guardianRankOrder.indexOf(target);
 }
 
 function trustedBondReady(progress: StoryProgress): boolean {
-  if (progress.unlockedBondScenes === undefined) return progress.affection >= 75;
+  if (progress.unlockedBondScenes === undefined) return finiteProgress(progress.affection) >= 75;
   return progress.unlockedBondScenes.includes('shared_secret');
 }
 
@@ -82,7 +86,7 @@ export function eligibleStoryChapters(progress: StoryProgress): StoryChapterId[]
         const oathReady = rankAtLeast(progress.guardianRank, 'guardian') && callingChosen(progress);
         if (oathReady) {
           unlocked.add('guardian_oath');
-          if (rankAtLeast(progress.guardianRank, 'veteran') && progress.discoveries >= 4) unlocked.add('starlight_road');
+          if (rankAtLeast(progress.guardianRank, 'veteran') && finiteProgress(progress.discoveries) >= 4) unlocked.add('starlight_road');
         }
       }
     }


### PR DESCRIPTION
## 구현한 기능
- Growth Trait / Calling 선택 / Guardian Rank / Story / Career / Advanced Talent에 남아 있던 NaN·Infinity·음수·소수 경계값 우회 차단
- Bond 해금/보상 canonicalization 강화 및 이미 보상된 과거 장면의 unlock 복구 시 `newlyUnlocked` 재발행 방지
- Bond 주요 임계값과 `precious_partner` 선행 장면 조건을 명시적으로 검증
- Personality 선호 활동이 해당 활동 Mastery XP에도 흔적을 남기도록 연결해 장기 성장 경로 차이를 강화
- Personality 4/5점 archetype 경계와 0~100 정규화 보강
- Calling Signature에 Mastery gate 규칙 추가: 첫 Signature Lv.2(3XP), 두 번째 Signature Lv.4(12XP). 기존 2인자 호출은 역호환 유지
- Story 레거시 fallback에서 비정상 affection/discovery 수치로 챕터를 우회하는 문제 차단
- Career record 손상값 복구와 title gate 정규화, Advanced Talent 비정상 mastery level 방어
- 동일 스케줄에서도 Personality/Calling 조합에 따라 다른 Mastery → Advanced Talent 경로가 나오는 회귀 테스트 추가

## 변경 파일
- `src/advanced-talents-boundaries.test.ts`
- `src/advanced-talents.ts`
- `src/bond-replay-prevention.test.ts`
- `src/bond-scenes.test.ts`
- `src/bond-scenes.ts`
- `src/calling-signatures.test.ts`
- `src/calling-signatures.ts`
- `src/career-boundaries.test.ts`
- `src/career-records.ts`
- `src/growth-traits.test.ts`
- `src/growth-traits.ts`
- `src/guardian-callings.test.ts`
- `src/guardian-callings.ts`
- `src/guardian-rank.test.ts`
- `src/guardian-rank.ts`
- `src/raising-depth-boundaries.test.ts`
- `src/raising-depth-effects.ts`
- `src/raising-depth-identity.test.ts`
- `src/raising-depth-rewards.ts`
- `src/raising-path-diversity.test.ts`
- `src/runa-personality.test.ts`
- `src/runa-personality.ts`
- `src/story-chapters.test.ts`
- `src/story-chapters.ts`

## 테스트 결과
- freeze 직전 targeted TypeScript/Node 회귀 검증: 37개 체크 PASS
  - Bond replay/canonicalization 7
  - Calling Mastery → Signature 경계 7
  - Story boundary 6
  - Guardian/Career/Talent/path diversity 11
  - Personality classification 6
- 이전 Raising core regression 15개 케이스와 겹치는 주요 Bond/Story/Career 계약도 유지 확인
- 전체 프로젝트 build/test green은 주장하지 않음. 현재 `integration/v2` 공용 `game-base.ts`/save 연결이 미반영이고 공용 타입/빌드 문제는 06 범위에서 별도 검증 필요

## 공용 파일 연결 필요사항
- `src/game-base.ts`의 `currentStoryChapters(state)`에 `unlockedBondScenes: state.unlockedBondScenes`, `activeCalling: state.activeCalling` 전달
- `src/game-base.ts`의 `currentCareerTitles(state)`에서 `coreStoryChapterIds` 기준 육성 스토리 수를 계산해 `openedRaisingStories`로 전달
- 진행 보상 순서를 현재 `Guardian → Story → Bond`에서 `Guardian → Bond → Story`로 변경
- save/hydration에서 이미 존재하는 `rewardedBondScenes`를 unlock 누락 때문에 삭제하지 말고, reward claim을 역사적 unlock 증거로 보존
- 실제 Signature 계산 caller에서 `callingSignatures(activeCalling, purchasedTraits, callingMastery[activeCalling])` 형태로 Mastery XP 전달. Raising UI 표시도 동일 규칙 사용

## 다른 작업방과 충돌 가능성이 있는 파일
- 이 PR 자체는 01 owned 파일만 변경
- 통합 시 충돌 가능 공용 파일: `src/game-base.ts`, save/hydration 계열, Raising Identity UI caller
- `game.ts`, `game-core.ts`, Tactical/World/Season 파일은 이 후보에서 직접 수정하지 않음

## 저장 데이터 영향
- 신규 필수 저장 필드 없음
- Growth/Calling/Guardian/Career 입력의 비정상 숫자를 안전한 비음수 정수/범위 값으로 해석
- 기존 `rewardedBondScenes`는 이미 지급된 보상의 durable evidence로 취급되어야 함
- 과거 reward-only Bond 상태를 복구할 때 재보상·재신규장면 효과가 발생하지 않도록 설계
- Calling Signature Mastery gate는 기존 저장의 `callingMastery`를 사용하며 별도 migration 필드 불필요

## 06 통합 시 주의사항
- Story의 Bond/Calling 입력 연결과 `Guardian → Bond → Story` 순서 변경은 같이 적용해야 같은 행동에서 열린 Bond가 Story에 즉시 반영됨
- Career에는 전체 Expedition Story 수가 아닌 core Raising Story 수를 전달해야 `story_witness` 우회가 막힘
- hydration에서 reward claim을 먼저 제거하면 이번 replay/double-pay 방어의 증거가 사라짐
- Signature Mastery gate는 owned 모듈에 정의됐지만, 공용 caller가 3번째 인자를 넘기기 전까지 실제 전투/UI에는 레거시 Trait-only 동작이 유지됨
- 통합 후 실제 `GameState` 기준으로 `Bond → Story → Career` 같은-action 회귀와 `Calling Mastery 2/3·11/12XP → Signature → Expedition effect` end-to-end 검증 필요
- 이 PR의 `work/raising-story` head는 통합 후보로 동결. 추가 개발은 별도 next 브랜치에서 진행하며 이 PR head에는 더 이상 기능 커밋을 추가하지 않음