### PR TITLE
01 Raising: next progression resilience after candidate #13

### DIFF
--- a/src/advanced-talents.test.ts
+++ b/src/advanced-talents.test.ts
@@ -24,6 +24,30 @@ describe('advanced training talents', () => {
     expect(result.stats.intelligence).toBe(20);
   });
 
+  it('does not apply the same talent twice when the input list is duplicated', () => {
+    const result = applyAdvancedTalentBonuses(
+      { strength: 20, intelligence: 20, magic: 20, morality: 20, affection: 50, stress: 30, fatigue: 30 },
+      { courage: 20, kindness: 20, curiosity: 20, calmness: 20 },
+      ['hunter_instinct', 'hunter_instinct', 'guardian_strike', 'guardian_strike'],
+      ['hunt'],
+    );
+    expect(result.stats.strength).toBe(22);
+    expect(result.personality.courage).toBe(21);
+  });
+
+  it('repairs malformed touched values instead of propagating NaN or Infinity', () => {
+    const result = applyAdvancedTalentBonuses(
+      { strength:Number.NaN, intelligence:20, magic:20, morality:20, affection:50, stress:Number.POSITIVE_INFINITY, fatigue:Number.NaN },
+      { courage:Number.POSITIVE_INFINITY, kindness:20, curiosity:20, calmness:20 },
+      ['hunter_instinct','guardian_strike','steady_recovery','deep_rest'],
+      ['hunt','rest'],
+    );
+    expect(result.stats.strength).toBe(2);
+    expect(result.personality.courage).toBe(1);
+    expect(result.stats.fatigue).toBe(0);
+    expect(result.stats.stress).toBe(0);
+  });
+
   it('stacks late talents in small bounded increments', () => {
     const result = applyAdvancedTalentBonuses(
       { strength: 99, intelligence: 99, magic: 99, morality: 99, affection: 99, stress: 2, fatigue: 2 },

--- a/src/advanced-talents.ts
+++ b/src/advanced-talents.ts
@@ -41,7 +41,10 @@ export function advancedTalents(levels: MasteryLevels): AdvancedTalentId[] {
     .map(talent => talent.id);
 }
 
-const clamp = (value: number) => Math.max(0, Math.min(100, value));
+const clamp = (value: number) => {
+  const safe = Number.isFinite(value) ? value : 0;
+  return Math.max(0, Math.min(100, safe));
+};
 
 export function applyAdvancedTalentBonuses(
   stats: Stats,
@@ -53,17 +56,17 @@ export function applyAdvancedTalentBonuses(
   const nextPersonality = { ...personality };
   const active = new Set(schedule);
 
-  for (const id of talents) {
+  for (const id of new Set(talents)) {
     const definition = talentDefinitions.find(item => item.id === id);
     if (!definition || !active.has(definition.activity)) continue;
-    if (id === 'hunter_instinct') nextStats.strength = clamp(nextStats.strength + 2);
-    if (id === 'guardian_strike') nextPersonality.courage = clamp(nextPersonality.courage + 1);
-    if (id === 'arcane_rhythm') nextStats.magic = clamp(nextStats.magic + 2);
-    if (id === 'star_channel') nextStats.intelligence = clamp(nextStats.intelligence + 2);
-    if (id === 'steady_recovery') nextStats.fatigue = clamp(nextStats.fatigue - 3);
-    if (id === 'deep_rest') nextStats.stress = clamp(nextStats.stress - 3);
-    if (id === 'field_scholar') nextStats.morality = clamp(nextStats.morality + 2);
-    if (id === 'ancient_remedy') nextPersonality.curiosity = clamp(nextPersonality.curiosity + 1);
+    if (id === 'hunter_instinct') nextStats.strength = clamp(clamp(nextStats.strength) + 2);
+    if (id === 'guardian_strike') nextPersonality.courage = clamp(clamp(nextPersonality.courage) + 1);
+    if (id === 'arcane_rhythm') nextStats.magic = clamp(clamp(nextStats.magic) + 2);
+    if (id === 'star_channel') nextStats.intelligence = clamp(clamp(nextStats.intelligence) + 2);
+    if (id === 'steady_recovery') nextStats.fatigue = clamp(clamp(nextStats.fatigue) - 3);
+    if (id === 'deep_rest') nextStats.stress = clamp(clamp(nextStats.stress) - 3);
+    if (id === 'field_scholar') nextStats.morality = clamp(clamp(nextStats.morality) + 2);
+    if (id === 'ancient_remedy') nextPersonality.curiosity = clamp(clamp(nextPersonality.curiosity) + 1);
   }
 
   return { stats: nextStats, personality: nextPersonality };

--- a/src/calling-depth-contract.test.ts
+++ b/src/calling-depth-contract.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { applyExpeditionCallingRewards } from './calling-depth-effects';
+
+const vanguardTraits = ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'] as const;
+
+describe('Calling depth player-facing contracts', () => {
+  it('applies Vanguard Legend to the first successful expedition clear of a month even on a replayed stage', () => {
+    const result = applyExpeditionCallingRewards({
+      year:2,
+      month:6,
+      calling:'vanguard',
+      traits:[...vanguardTraits],
+      signatures:[],
+      legendRewardKeys:[],
+      stageId:'forest_path',
+      grade:'A',
+      firstClear:false,
+      discovery:null,
+      regionCompleted:null,
+      materialReward:1,
+      fatigueDelta:8,
+      stressDelta:6,
+    });
+
+    expect(result.fatigueDelta).toBe(6);
+    expect(result.legendRewardKeys).toEqual(['2-6:vanguard_legend']);
+    expect(result.applied).toContain('vanguard_legend');
+  });
+
+  it('does not spend the monthly Vanguard Legend benefit on a failed C-grade expedition', () => {
+    const result = applyExpeditionCallingRewards({
+      year:2,
+      month:6,
+      calling:'vanguard',
+      traits:[...vanguardTraits],
+      signatures:[],
+      legendRewardKeys:[],
+      stageId:'forest_path',
+      grade:'C',
+      firstClear:false,
+      discovery:null,
+      regionCompleted:null,
+      materialReward:0,
+      fatigueDelta:8,
+      stressDelta:6,
+    });
+
+    expect(result.fatigueDelta).toBe(8);
+    expect(result.legendRewardKeys).toEqual([]);
+    expect(result.applied).not.toContain('vanguard_legend');
+  });
+});

--- a/src/calling-depth-effects.test.ts
+++ b/src/calling-depth-effects.test.ts
@@ -9,11 +9,16 @@ import {
 describe('Calling depth effects', () => {
   it('builds stable monthly legend reward keys', () => {
     expect(legendRewardKey(2, 7, 'vanguard_legend')).toBe('2-7:vanguard_legend');
+    expect(legendRewardKey(2.9, 13.4, 'vanguard_legend')).toBe('2-12:vanguard_legend');
+    expect(legendRewardKey(Number.NaN, Number.POSITIVE_INFINITY, 'vanguard_legend')).toBe('1-1:vanguard_legend');
   });
 
   it('accelerates discovery eligibility only with Pathfinder eye', () => {
     expect(effectivePathfinderExplorationXp(3, 'pathfinder', ['pathfinder_eye'])).toBe(6);
     expect(effectivePathfinderExplorationXp(3, 'vanguard', ['pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(Number.NaN, 'pathfinder', ['pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(Number.POSITIVE_INFINITY, 'pathfinder', ['pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(-4, 'pathfinder', ['pathfinder_eye'])).toBe(3);
   });
 
   it('detects specialist Calling mastery from expedition actions', () => {
@@ -22,6 +27,13 @@ describe('Calling depth effects', () => {
     expect(specialistMasteryCalling('caretaker', { attack:0, dodge:1, charge:0 }, { grade:'B', discovery:null, materialReward:1 })).toBe('caretaker');
     expect(specialistMasteryCalling('pathfinder', { attack:1, dodge:0, charge:0 }, { grade:'A', discovery:'forest_echo', materialReward:0 })).toBe('pathfinder');
     expect(specialistMasteryCalling('vanguard', { attack:0, dodge:2, charge:0 }, { grade:'A', discovery:null, materialReward:1 })).toBeNull();
+  });
+
+  it('does not grant Calling mastery from corrupted action counts', () => {
+    expect(specialistMasteryCalling('vanguard', { attack:Number.POSITIVE_INFINITY, dodge:0, charge:0 }, { grade:'A', discovery:null, materialReward:1 })).toBeNull();
+    expect(specialistMasteryCalling('arcanist', { attack:0, dodge:0, charge:Number.NaN }, { grade:'S', discovery:null, materialReward:2 })).toBeNull();
+    expect(specialistMasteryCalling('caretaker', { attack:0, dodge:-1, charge:0 }, { grade:'B', discovery:null, materialReward:1 })).toBeNull();
+    expect(specialistMasteryCalling('pathfinder', { attack:Number.NaN, dodge:Number.POSITIVE_INFINITY, charge:-3 }, { grade:'A', discovery:'forest_echo', materialReward:2 })).toBeNull();
   });
 
   it('applies Pathfinder signature rewards without duplicating the existing supply trait', () => {
@@ -56,6 +68,19 @@ describe('Calling depth effects', () => {
     });
     expect(arcanist.stressDelta).toBe(4);
     expect(arcanist.legendRewardKeys).toContain('1-4:arcanist_legend');
+  });
+
+  it('normalizes corrupted reward deltas and duplicate monthly keys', () => {
+    const result = applyExpeditionCallingRewards({
+      year:1, month:4, calling:'vanguard', traits:['vanguard_legend'], signatures:[],
+      legendRewardKeys:['1-4:vanguard_legend','1-4:vanguard_legend'],
+      stageId:'forest_path', grade:'A', firstClear:true, discovery:null, regionCompleted:null,
+      materialReward:Number.POSITIVE_INFINITY, fatigueDelta:Number.NaN, stressDelta:Number.POSITIVE_INFINITY,
+    });
+    expect(result.fatigueDelta).toBe(0);
+    expect(result.stressDelta).toBe(0);
+    expect(result.legendRewardKeys).toEqual(['1-4:vanguard_legend']);
+    expect(result.applied).toEqual([]);
   });
 
   it('applies heart anchor stress protection whenever its signature is active', () => {

--- a/src/calling-depth-effects.test.ts
+++ b/src/calling-depth-effects.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyExpeditionCallingRewards,
+  applyPathfinderOutingLegend,
   effectivePathfinderExplorationXp,
   legendRewardKey,
   specialistMasteryCalling,
@@ -13,12 +14,13 @@ describe('Calling depth effects', () => {
     expect(legendRewardKey(Number.NaN, Number.POSITIVE_INFINITY, 'vanguard_legend')).toBe('1-1:vanguard_legend');
   });
 
-  it('accelerates discovery eligibility only with Pathfinder eye', () => {
-    expect(effectivePathfinderExplorationXp(3, 'pathfinder', ['pathfinder_eye'])).toBe(6);
-    expect(effectivePathfinderExplorationXp(3, 'vanguard', ['pathfinder_eye'])).toBe(3);
-    expect(effectivePathfinderExplorationXp(Number.NaN, 'pathfinder', ['pathfinder_eye'])).toBe(3);
-    expect(effectivePathfinderExplorationXp(Number.POSITIVE_INFINITY, 'pathfinder', ['pathfinder_eye'])).toBe(3);
-    expect(effectivePathfinderExplorationXp(-4, 'pathfinder', ['pathfinder_eye'])).toBe(3);
+  it('accelerates discovery eligibility only with a complete Pathfinder eye path', () => {
+    expect(effectivePathfinderExplorationXp(3, 'pathfinder', ['pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(3, 'pathfinder', ['pathfinder_herb','pathfinder_eye'])).toBe(6);
+    expect(effectivePathfinderExplorationXp(3, 'vanguard', ['pathfinder_herb','pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(Number.NaN, 'pathfinder', ['pathfinder_herb','pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(Number.POSITIVE_INFINITY, 'pathfinder', ['pathfinder_herb','pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(-4, 'pathfinder', ['pathfinder_herb','pathfinder_eye'])).toBe(3);
   });
 
   it('detects specialist Calling mastery from expedition actions', () => {
@@ -39,7 +41,7 @@ describe('Calling depth effects', () => {
   it('applies Pathfinder signature rewards without duplicating the existing supply trait', () => {
     const first = applyExpeditionCallingRewards({
       year:1, month:4, calling:'pathfinder',
-      traits:['pathfinder_eye','pathfinder_supply','pathfinder_legend'],
+      traits:['pathfinder_herb','pathfinder_eye','pathfinder_supply','pathfinder_legend'],
       signatures:['trail_reading','star_compass'], legendRewardKeys:[],
       stageId:'forest_glade', grade:'S', firstClear:true, discovery:'forest_echo',
       regionCompleted:'starlight_forest', materialReward:2, fatigueDelta:8, stressDelta:6,
@@ -49,30 +51,55 @@ describe('Calling depth effects', () => {
     expect(first.legendRewardKeys).toEqual([]);
   });
 
-  it('applies Vanguard and Arcanist monthly Legend effects once', () => {
+  it('applies Vanguard and Arcanist monthly Legend effects once with complete Trait paths', () => {
+    const vanguardTraits = ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'] as const;
     const vanguard = applyExpeditionCallingRewards({
-      year:1, month:4, calling:'vanguard', traits:['vanguard_legend'], signatures:[], legendRewardKeys:[],
+      year:1, month:4, calling:'vanguard', traits:[...vanguardTraits], signatures:[], legendRewardKeys:[],
       stageId:'forest_path', grade:'A', firstClear:true, discovery:null, regionCompleted:null, materialReward:1, fatigueDelta:8, stressDelta:6,
     });
     expect(vanguard.fatigueDelta).toBe(6);
     expect(vanguard.legendRewardKeys).toContain('1-4:vanguard_legend');
     const repeat = applyExpeditionCallingRewards({
-      year:1, month:4, calling:'vanguard', traits:['vanguard_legend'], signatures:[], legendRewardKeys:vanguard.legendRewardKeys,
+      year:1, month:4, calling:'vanguard', traits:[...vanguardTraits], signatures:[], legendRewardKeys:vanguard.legendRewardKeys,
       stageId:'forest_glade', grade:'A', firstClear:true, discovery:null, regionCompleted:null, materialReward:1, fatigueDelta:8, stressDelta:6,
     });
     expect(repeat.fatigueDelta).toBe(8);
 
     const arcanist = applyExpeditionCallingRewards({
-      year:1, month:4, calling:'arcanist', traits:['arcanist_legend'], signatures:[], legendRewardKeys:[],
+      year:1, month:4, calling:'arcanist', traits:['arcanist_mana','arcanist_insight','arcanist_channel','arcanist_legend'], signatures:[], legendRewardKeys:[],
       stageId:'city_square', grade:'S', firstClear:true, discovery:'city_rune', regionCompleted:null, materialReward:2, fatigueDelta:8, stressDelta:6,
     });
     expect(arcanist.stressDelta).toBe(4);
     expect(arcanist.legendRewardKeys).toContain('1-4:arcanist_legend');
   });
 
+  it('does not activate orphaned Legend traits in expedition rewards', () => {
+    const vanguard = applyExpeditionCallingRewards({
+      year:1, month:4, calling:'vanguard', traits:['vanguard_legend'], signatures:[], legendRewardKeys:[],
+      stageId:'forest_path', grade:'A', firstClear:true, discovery:null, regionCompleted:null, materialReward:1, fatigueDelta:8, stressDelta:6,
+    });
+    expect(vanguard.fatigueDelta).toBe(8);
+    expect(vanguard.legendRewardKeys).toEqual([]);
+    expect(vanguard.applied).toEqual([]);
+
+    const arcanist = applyExpeditionCallingRewards({
+      year:1, month:4, calling:'arcanist', traits:['arcanist_legend'], signatures:[], legendRewardKeys:[],
+      stageId:'city_square', grade:'S', firstClear:true, discovery:'city_rune', regionCompleted:null, materialReward:2, fatigueDelta:8, stressDelta:6,
+    });
+    expect(arcanist.stressDelta).toBe(6);
+    expect(arcanist.legendRewardKeys).toEqual([]);
+  });
+
+  it('requires a complete Pathfinder Legend path for the outing gold bonus', () => {
+    expect(applyPathfinderOutingLegend(1, 4, 'pathfinder', ['pathfinder_legend'], true, []))
+      .toEqual({ goldBonus:0, legendRewardKeys:[], applied:false });
+    expect(applyPathfinderOutingLegend(1, 4, 'pathfinder', ['pathfinder_herb','pathfinder_eye','pathfinder_supply','pathfinder_legend'], true, []))
+      .toEqual({ goldBonus:100, legendRewardKeys:['1-4:pathfinder_legend'], applied:true });
+  });
+
   it('normalizes corrupted reward deltas and duplicate monthly keys', () => {
     const result = applyExpeditionCallingRewards({
-      year:1, month:4, calling:'vanguard', traits:['vanguard_legend'], signatures:[],
+      year:1, month:4, calling:'vanguard', traits:['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'], signatures:[],
       legendRewardKeys:['1-4:vanguard_legend','1-4:vanguard_legend'],
       stageId:'forest_path', grade:'A', firstClear:true, discovery:null, regionCompleted:null,
       materialReward:Number.POSITIVE_INFINITY, fatigueDelta:Number.NaN, stressDelta:Number.POSITIVE_INFINITY,
@@ -85,7 +112,7 @@ describe('Calling depth effects', () => {
 
   it('applies heart anchor stress protection whenever its signature is active', () => {
     const result = applyExpeditionCallingRewards({
-      year:1, month:4, calling:'caretaker', traits:['caretaker_legend'], signatures:['heart_anchor'], legendRewardKeys:[],
+      year:1, month:4, calling:'caretaker', traits:['caretaker_rest','caretaker_bond','caretaker_guard','caretaker_legend'], signatures:['heart_anchor'], legendRewardKeys:[],
       stageId:'lake_channel', grade:'A', firstClear:false, discovery:null, regionCompleted:null, materialReward:1, fatigueDelta:8, stressDelta:6,
     });
     expect(result.stressDelta).toBe(4);

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -30,9 +30,9 @@ export function effectivePathfinderExplorationXp(
 export function specialistMasteryCalling(
   calling:GuardianCallingId | null,
   actions:ExpeditionActionCounts,
-  summary:{ grade:ExpeditionGrade; discovery:string | null; materialReward:number },
+  summary:{ accepted?:boolean; grade:ExpeditionGrade; discovery:string | null; materialReward:number },
 ): GuardianCallingId | null {
-  if (!calling || summary.grade === 'C') return null;
+  if (!calling || summary.accepted === false || summary.grade === 'C') return null;
   const attack = nonNegativeInt(actions.attack);
   const dodge = nonNegativeInt(actions.dodge);
   const charge = nonNegativeInt(actions.charge);

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -4,8 +4,18 @@ import type { ExpeditionGrade, ExpeditionRegionId, ExpeditionStageId } from './e
 import type { GuardianCallingId } from './guardian-callings';
 import type { GrowthTraitId } from './growth-traits';
 
+function nonNegativeInt(value:number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function nonNegativeNumber(value:number): number {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
 export function legendRewardKey(year:number, month:number, effectId:string): string {
-  return `${Math.max(1, Math.floor(year))}-${Math.max(1, Math.min(12, Math.floor(month)))}:${effectId}`;
+  const safeYear = Number.isFinite(year) ? Math.max(1, Math.floor(year)) : 1;
+  const safeMonth = Number.isFinite(month) ? Math.max(1, Math.min(12, Math.floor(month))) : 1;
+  return `${safeYear}-${safeMonth}:${effectId}`;
 }
 
 export function effectivePathfinderExplorationXp(
@@ -13,7 +23,7 @@ export function effectivePathfinderExplorationXp(
   calling:GuardianCallingId | null,
   traits:readonly GrowthTraitId[],
 ): number {
-  return Math.max(0, Math.floor(xp)) + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
+  return nonNegativeInt(xp) + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
 }
 
 export function specialistMasteryCalling(
@@ -22,10 +32,14 @@ export function specialistMasteryCalling(
   summary:{ grade:ExpeditionGrade; discovery:string | null; materialReward:number },
 ): GuardianCallingId | null {
   if (!calling || summary.grade === 'C') return null;
-  if (calling === 'vanguard') return actions.attack > 0 ? calling : null;
-  if (calling === 'arcanist') return actions.charge > 0 ? calling : null;
-  if (calling === 'caretaker') return actions.dodge > 0 ? calling : null;
-  return (actions.attack + actions.dodge + actions.charge > 0) && (summary.discovery !== null || summary.materialReward > 0) ? calling : null;
+  const attack = nonNegativeInt(actions.attack);
+  const dodge = nonNegativeInt(actions.dodge);
+  const charge = nonNegativeInt(actions.charge);
+  if (calling === 'vanguard') return attack > 0 ? calling : null;
+  if (calling === 'arcanist') return charge > 0 ? calling : null;
+  if (calling === 'caretaker') return dodge > 0 ? calling : null;
+  const materialReward = nonNegativeInt(summary.materialReward);
+  return (attack + dodge + charge > 0) && (summary.discovery !== null || materialReward > 0) ? calling : null;
 }
 
 export type ExpeditionCallingRewardInput = {
@@ -56,15 +70,16 @@ export type ExpeditionCallingRewardResult = {
 
 export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput): ExpeditionCallingRewardResult {
   let extraMaterial = 0;
-  let fatigueDelta = Math.max(0, input.fatigueDelta);
-  let stressDelta = Math.max(0, input.stressDelta);
-  let legendRewardKeys = [...input.legendRewardKeys];
+  let fatigueDelta = nonNegativeNumber(input.fatigueDelta);
+  let stressDelta = nonNegativeNumber(input.stressDelta);
+  let legendRewardKeys = [...new Set(input.legendRewardKeys)];
   const applied:string[] = [];
   const signatures = new Set(input.signatures);
   const traits = new Set(input.traits);
+  const materialReward = nonNegativeInt(input.materialReward);
 
   if (input.calling === 'pathfinder') {
-    if (signatures.has('trail_reading') && input.firstClear && input.materialReward > 0) {
+    if (signatures.has('trail_reading') && input.firstClear && materialReward > 0) {
       extraMaterial += 1;
       applied.push('trail_reading');
     }

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -95,7 +95,7 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
     applied.push('heart_anchor');
   }
 
-  if (input.calling === 'vanguard' && traits.has('vanguard_legend') && input.firstClear) {
+  if (input.calling === 'vanguard' && traits.has('vanguard_legend') && input.grade !== 'C') {
     const key = legendRewardKey(input.year, input.month, 'vanguard_legend');
     if (!legendRewardKeys.includes(key)) {
       fatigueDelta = Math.max(0, fatigueDelta - 2);

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -2,7 +2,7 @@ import type { CallingSignatureId } from './calling-signatures';
 import type { ExpeditionActionCounts } from './expedition-combat';
 import type { ExpeditionGrade, ExpeditionRegionId, ExpeditionStageId } from './expedition-regions';
 import type { GuardianCallingId } from './guardian-callings';
-import type { GrowthTraitId } from './growth-traits';
+import { activeCallingTraits, type GrowthTraitId } from './growth-traits';
 
 function nonNegativeInt(value:number): number {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
@@ -23,7 +23,8 @@ export function effectivePathfinderExplorationXp(
   calling:GuardianCallingId | null,
   traits:readonly GrowthTraitId[],
 ): number {
-  return nonNegativeInt(xp) + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
+  const activeTraits = new Set(activeCallingTraits(calling, [...traits]));
+  return nonNegativeInt(xp) + (activeTraits.has('pathfinder_eye') ? 3 : 0);
 }
 
 export function specialistMasteryCalling(
@@ -75,7 +76,7 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
   let legendRewardKeys = [...new Set(input.legendRewardKeys)];
   const applied:string[] = [];
   const signatures = new Set(input.signatures);
-  const traits = new Set(input.traits);
+  const traits = new Set(activeCallingTraits(input.calling, [...input.traits]));
   const materialReward = nonNegativeInt(input.materialReward);
 
   if (input.calling === 'pathfinder') {
@@ -123,7 +124,8 @@ export function applyPathfinderOutingLegend(
   discovered:boolean,
   existingKeys:string[],
 ): { goldBonus:number; legendRewardKeys:string[]; applied:boolean } {
-  if (calling !== 'pathfinder' || !traits.includes('pathfinder_legend') || !discovered) {
+  const activeTraits = new Set(activeCallingTraits(calling, [...traits]));
+  if (!activeTraits.has('pathfinder_legend') || !discovered) {
     return { goldBonus:0, legendRewardKeys:existingKeys, applied:false };
   }
   const key = legendRewardKey(year, month, 'pathfinder_legend');

--- a/src/calling-mastery-acceptance.test.ts
+++ b/src/calling-mastery-acceptance.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { specialistMasteryCalling } from './calling-depth-effects';
+
+describe('Calling mastery expedition acceptance', () => {
+  it('does not grant specialist mastery from a rejected expedition result', () => {
+    const rejected = { accepted:false, grade:'A' as const, discovery:null, materialReward:0 };
+
+    expect(specialistMasteryCalling('vanguard', { attack:1, dodge:0, charge:0 }, rejected)).toBeNull();
+    expect(specialistMasteryCalling('arcanist', { attack:0, dodge:0, charge:1 }, rejected)).toBeNull();
+    expect(specialistMasteryCalling('caretaker', { attack:0, dodge:1, charge:0 }, rejected)).toBeNull();
+  });
+});

--- a/src/calling-mastery-reachability.test.ts
+++ b/src/calling-mastery-reachability.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { callingMasteryLevel, emptyCallingMastery } from './calling-mastery';
+import { incrementCallingMonthMastery } from './raising-depth-rewards';
+import type { GuardianCallingId } from './guardian-callings';
+
+function advanceMonths(calling: GuardianCallingId, months: number) {
+  let mastery = emptyCallingMastery();
+  for (let month = 0; month < months; month += 1) mastery = incrementCallingMonthMastery(mastery, calling);
+  return mastery;
+}
+
+describe('Calling mastery reachability', () => {
+  it('lets every Calling reach level five from monthly progression alone', () => {
+    for (const calling of ['vanguard','arcanist','caretaker','pathfinder'] as const) {
+      const atLevelFour = advanceMonths(calling, 12);
+      const atLevelFive = advanceMonths(calling, 18);
+
+      expect(atLevelFour[calling]).toBe(12);
+      expect(callingMasteryLevel(atLevelFour[calling])).toBe(4);
+      expect(atLevelFive[calling]).toBe(18);
+      expect(callingMasteryLevel(atLevelFive[calling])).toBe(5);
+    }
+  });
+
+  it('preserves previous Calling mastery while only the active Calling gains the monthly point', () => {
+    let mastery = advanceMonths('vanguard', 7);
+    mastery = incrementCallingMonthMastery(mastery, 'arcanist');
+    mastery = incrementCallingMonthMastery(mastery, 'arcanist');
+
+    expect(mastery).toEqual({ vanguard:7, arcanist:2, caretaker:0, pathfinder:0 });
+    expect(callingMasteryLevel(mastery.vanguard)).toBe(3);
+    expect(callingMasteryLevel(mastery.arcanist)).toBe(1);
+  });
+});

--- a/src/calling-signatures.test.ts
+++ b/src/calling-signatures.test.ts
@@ -15,10 +15,10 @@ describe('calling signature abilities', () => {
     }
   });
 
-  it('keeps legacy trait-only lookup compatible when mastery is omitted', () => {
+  it('fails closed when Calling mastery XP is omitted instead of bypassing the mastery gate', () => {
     expect(callingSignatures('vanguard', ['vanguard_power'])).toEqual([]);
-    expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus'])).toEqual(['rally_strike']);
-    expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'])).toEqual(['rally_strike','guardian_breaker']);
+    expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus'])).toEqual([]);
+    expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'])).toEqual([]);
     expect(callingSignatures('arcanist', ['vanguard_power','vanguard_focus'])).toEqual([]);
     expect(callingSignatures(null, ['vanguard_power','vanguard_focus'])).toEqual([]);
   });

--- a/src/calling-signatures.test.ts
+++ b/src/calling-signatures.test.ts
@@ -32,6 +32,14 @@ describe('calling signature abilities', () => {
     expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus'], 999)).toEqual(['rally_strike']);
   });
 
+  it('does not unlock signatures from orphaned upper-tier traits', () => {
+    expect(callingSignatures('vanguard', ['vanguard_focus'], 3)).toEqual([]);
+    expect(callingSignatures('vanguard', ['vanguard_power','vanguard_legend'], 12)).toEqual([]);
+    expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus','vanguard_legend'], 12)).toEqual(['rally_strike']);
+    expect(callingSignatures('vanguard', ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'], 12))
+      .toEqual(['rally_strike','guardian_breaker']);
+  });
+
   it('treats malformed mastery XP as level one when mastery is supplied', () => {
     const traits = ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'] as const;
     expect(callingSignatures('vanguard', [...traits], Number.NaN)).toEqual([]);

--- a/src/calling-signatures.test.ts
+++ b/src/calling-signatures.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { callingSignatureDefinitions, callingSignatures } from './calling-signatures';
+import { growthTraitDefinitions } from './growth-traits';
 
 describe('calling signature abilities', () => {
   it('defines two signatures for each calling with increasing mastery requirements', () => {
     expect(callingSignatureDefinitions).toHaveLength(8);
+    expect(new Set(callingSignatureDefinitions.map(item => item.id)).size).toBe(callingSignatureDefinitions.length);
     for (const calling of ['vanguard','arcanist','caretaker','pathfinder'] as const) {
       const signatures = callingSignatureDefinitions.filter(item => item.calling === calling);
       expect(signatures).toHaveLength(2);
       expect(signatures.map(item => item.requiredMasteryLevel)).toEqual([2,4]);
+      expect(signatures.map(item => growthTraitDefinitions.find(trait => trait.id === item.requiredTrait)?.calling)).toEqual([calling, calling]);
+      expect(signatures.map(item => growthTraitDefinitions.find(trait => trait.id === item.requiredTrait)?.tier)).toEqual([2,4]);
     }
   });
 

--- a/src/calling-signatures.ts
+++ b/src/calling-signatures.ts
@@ -1,6 +1,6 @@
 import { callingMasteryLevel } from './calling-mastery';
 import type { GuardianCallingId } from './guardian-callings';
-import type { GrowthTraitId } from './growth-traits';
+import { hasCompleteGrowthTraitPath, type GrowthTraitId } from './growth-traits';
 
 export type CallingSignatureId =
   | 'rally_strike' | 'guardian_breaker'
@@ -33,7 +33,7 @@ export function callingSignatures(calling: GuardianCallingId | null, purchasedTr
   const masteryLevel = masteryXp === undefined ? null : callingMasteryLevel(masteryXp);
   return callingSignatureDefinitions
     .filter(item => item.calling === calling
-      && purchasedTraits.includes(item.requiredTrait)
+      && hasCompleteGrowthTraitPath(item.requiredTrait, purchasedTraits)
       && (masteryLevel === null || masteryLevel >= item.requiredMasteryLevel))
     .map(item => item.id);
 }

--- a/src/career-records.test.ts
+++ b/src/career-records.test.ts
@@ -40,7 +40,7 @@ describe('career records and titles', () => {
 
   it('derives long-term titles from records and existing growth progress', () => {
     const records = { trainings: 12, bestScore: 930, sGrades: 3, outings: 10, gifts: 5, monthsCompleted: 6 };
-    expect(careerTitles({ records, guardianRank: 'veteran', openedStories: 4 })).toEqual([
+    expect(careerTitles({ records, guardianRank: 'veteran', openedStories: 4, openedRaisingStories: 4 })).toEqual([
       'steady_trainer', 'perfect_chaser', 'seasoned_explorer', 'warm_giver', 'story_witness', 'veteran_guardian',
     ]);
   });
@@ -68,6 +68,14 @@ describe('career records and titles', () => {
       openedStories: 9,
       openedRaisingStories: 4,
     })).toContain('story_witness');
+  });
+
+  it('does not treat aggregate story count as raising-story progress when the dedicated count is missing', () => {
+    expect(careerTitles({
+      records: emptyCareerRecords(),
+      guardianRank: 'trainee',
+      openedStories: 9,
+    })).not.toContain('story_witness');
   });
 
   it('keeps different raising records meaningfully distinct in career results', () => {

--- a/src/career-records.ts
+++ b/src/career-records.ts
@@ -84,7 +84,7 @@ export type CareerTitleProgress = {
 export function careerTitles(input: CareerTitleProgress): CareerTitleId[] {
   const unlocked = new Set<CareerTitleId>();
   const records = normalizeCareerRecords(input.records);
-  const relevantStories = normalizeCount(input.openedRaisingStories ?? input.openedStories);
+  const relevantStories = normalizeCount(input.openedRaisingStories ?? 0);
   if (records.trainings >= 10) unlocked.add('steady_trainer');
   if (records.bestScore >= 900) unlocked.add('perfect_chaser');
   if (records.outings >= 10) unlocked.add('seasoned_explorer');

--- a/src/growth-traits.test.ts
+++ b/src/growth-traits.test.ts
@@ -18,6 +18,12 @@ describe('growth trait board', () => {
     expect(canPurchaseGrowthTrait('vanguard_focus', ['vanguard_power'], 1)).toBe(true);
   });
 
+  it('requires the complete prerequisite chain instead of trusting an orphaned upper trait', () => {
+    expect(canPurchaseGrowthTrait('vanguard_assault', ['vanguard_focus'], 2)).toBe(false);
+    expect(canPurchaseGrowthTrait('vanguard_legend', ['vanguard_assault'], 2)).toBe(false);
+    expect(canPurchaseGrowthTrait('vanguard_legend', ['vanguard_power','vanguard_focus','vanguard_assault'], 2)).toBe(true);
+  });
+
   it('spends exact points and never duplicates a purchased trait', () => {
     const first = purchaseGrowthTrait('vanguard_power', [], 3);
     expect(first).toEqual({ purchased:true, traits:['vanguard_power'], points:2 });
@@ -29,7 +35,7 @@ describe('growth trait board', () => {
     expect(canPurchaseGrowthTrait('vanguard_power', [], Number.NaN)).toBe(false);
     expect(canPurchaseGrowthTrait('vanguard_power', [], Number.POSITIVE_INFINITY)).toBe(false);
     expect(canPurchaseGrowthTrait('vanguard_power', [], -3)).toBe(false);
-    expect(canPurchaseGrowthTrait('vanguard_assault', ['vanguard_focus'], 1.9)).toBe(false);
+    expect(canPurchaseGrowthTrait('vanguard_assault', ['vanguard_power','vanguard_focus'], 1.9)).toBe(false);
     expect(canPurchaseGrowthTrait('vanguard_power', [], 1.9)).toBe(true);
 
     expect(purchaseGrowthTrait('vanguard_power', [], Number.NaN)).toEqual({ purchased:false, traits:[], points:0 });
@@ -43,5 +49,13 @@ describe('growth trait board', () => {
     expect(activeCallingTraits('arcanist', [...owned])).toEqual(['arcanist_mana','arcanist_insight']);
     expect(activeCallingTraits('vanguard', [...owned])).toEqual(['vanguard_power']);
     expect(activeCallingTraits(null, [...owned])).toEqual([]);
+  });
+
+  it('does not activate orphaned upper-tier traits from corrupted progression state', () => {
+    expect(activeCallingTraits('vanguard', ['vanguard_focus'])).toEqual([]);
+    expect(activeCallingTraits('vanguard', ['vanguard_power','vanguard_assault'])).toEqual(['vanguard_power']);
+    expect(activeCallingTraits('vanguard', ['vanguard_power','vanguard_focus','vanguard_legend'])).toEqual(['vanguard_power','vanguard_focus']);
+    expect(activeCallingTraits('vanguard', ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend']))
+      .toEqual(['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend']);
   });
 });

--- a/src/growth-traits.test.ts
+++ b/src/growth-traits.test.ts
@@ -4,10 +4,16 @@ import { activeCallingTraits, canPurchaseGrowthTrait, growthTraitDefinitions, pu
 describe('growth trait board', () => {
   it('defines sixteen ordered traits with costs 1,1,2,2 per calling', () => {
     expect(growthTraitDefinitions).toHaveLength(16);
+    expect(new Set(growthTraitDefinitions.map(item => item.id)).size).toBe(growthTraitDefinitions.length);
     for (const calling of ['vanguard','arcanist','caretaker','pathfinder'] as const) {
       const path = growthTraitDefinitions.filter(item => item.calling === calling);
       expect(path.map(item => item.tier)).toEqual([1,2,3,4]);
       expect(path.map(item => item.cost)).toEqual([1,1,2,2]);
+      expect(path[0].prerequisite).toBeNull();
+      for (let index = 1; index < path.length; index += 1) {
+        expect(path[index].prerequisite).toBe(path[index - 1].id);
+        expect(growthTraitDefinitions.find(item => item.id === path[index].prerequisite)?.calling).toBe(calling);
+      }
     }
   });
 

--- a/src/growth-traits.ts
+++ b/src/growth-traits.ts
@@ -41,22 +41,48 @@ function normalizeGrowthPoints(points: number): number {
   return Number.isFinite(points) ? Math.max(0, Math.floor(points)) : 0;
 }
 
+function growthTraitDefinition(id: GrowthTraitId): GrowthTraitDefinition | undefined {
+  return growthTraitDefinitions.find(item => item.id === id);
+}
+
+export function hasCompleteGrowthTraitPath(id: GrowthTraitId, purchased: readonly GrowthTraitId[]): boolean {
+  if (!purchased.includes(id)) return false;
+  const seen = new Set<GrowthTraitId>();
+  let current = growthTraitDefinition(id);
+  while (current) {
+    if (seen.has(current.id)) return false;
+    seen.add(current.id);
+    if (current.prerequisite === null) return true;
+    if (!purchased.includes(current.prerequisite)) return false;
+    current = growthTraitDefinition(current.prerequisite);
+  }
+  return false;
+}
+
+function hasPurchasePrerequisites(id: GrowthTraitId, purchased: readonly GrowthTraitId[]): boolean {
+  const definition = growthTraitDefinition(id);
+  if (!definition) return false;
+  return definition.prerequisite === null || hasCompleteGrowthTraitPath(definition.prerequisite, purchased);
+}
+
 export function canPurchaseGrowthTrait(id: GrowthTraitId, purchased: GrowthTraitId[], points: number): boolean {
   if (purchased.includes(id)) return false;
-  const definition = growthTraitDefinitions.find(item => item.id === id);
+  const definition = growthTraitDefinition(id);
   const availablePoints = normalizeGrowthPoints(points);
   if (!definition || availablePoints < definition.cost) return false;
-  return definition.prerequisite === null || purchased.includes(definition.prerequisite);
+  return hasPurchasePrerequisites(id, purchased);
 }
 
 export function purchaseGrowthTrait(id: GrowthTraitId, purchased: GrowthTraitId[], points: number) {
   const availablePoints = normalizeGrowthPoints(points);
   if (!canPurchaseGrowthTrait(id, purchased, availablePoints)) return { purchased:false, traits:purchased, points:availablePoints };
-  const definition = growthTraitDefinitions.find(item => item.id === id)!;
+  const definition = growthTraitDefinition(id)!;
   return { purchased:true, traits:[...purchased, id], points:availablePoints - definition.cost };
 }
 
 export function activeCallingTraits(calling: GuardianCallingId | null, purchased: GrowthTraitId[]): GrowthTraitId[] {
   if (!calling) return [];
-  return growthTraitDefinitions.filter(item => item.calling === calling && purchased.includes(item.id)).map(item => item.id);
+  return growthTraitDefinitions
+    .filter(item => item.calling === calling && hasCompleteGrowthTraitPath(item.id, purchased))
+    .map(item => item.id);
 }

--- a/src/guardian-rank.test.ts
+++ b/src/guardian-rank.test.ts
@@ -11,6 +11,11 @@ describe('guardian rank rules', () => {
     expect(guardianGrowthPoints({ memories:3.9, skills:2.9, discoveries:4.9, masteryLevels:[1.9,2.9,4.9,1] })).toBe(15);
   });
 
+  it('caps mastery levels at the real level-five maximum', () => {
+    expect(guardianGrowthPoints({ memories:0, skills:0, discoveries:0, masteryLevels:[1,5,99,-1] })).toBe(8);
+    expect(guardianGrowthPoints({ memories:0, skills:0, discoveries:0, masteryLevels:[999,999,999,999] })).toBe(16);
+  });
+
   it('maps stable guardian rank thresholds', () => {
     expect(guardianRank(0)).toBe('trainee');
     expect(guardianRank(7)).toBe('trainee');

--- a/src/guardian-rank.ts
+++ b/src/guardian-rank.ts
@@ -21,9 +21,13 @@ function normalizeProgress(value: number): number {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 
+function normalizeMasteryLevel(value: number): number {
+  return Math.min(5, normalizeProgress(value));
+}
+
 export function guardianGrowthPoints(progress: GuardianProgress): number {
   const masteryPoints = progress.masteryLevels.reduce((sum, rawLevel) => {
-    const level = normalizeProgress(rawLevel);
+    const level = normalizeMasteryLevel(rawLevel);
     return sum + Math.max(0, level - 1);
   }, 0);
   return normalizeProgress(progress.memories)

--- a/src/personality-choice-impact.test.ts
+++ b/src/personality-choice-impact.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { applyTrainingIdentityEffects } from './raising-depth-effects';
+
+const stats = {
+  strength: 30,
+  intelligence: 30,
+  magic: 30,
+  morality: 40,
+  affection: 45,
+  stress: 12,
+  fatigue: 18,
+};
+
+const mastery = {
+  hunt: { xp: 0 },
+  magic: { xp: 0 },
+  rest: { xp: 0 },
+  herb: { xp: 0 },
+};
+
+describe('personality choice impact', () => {
+  it('leaves one preferred-activity growth trace for each actual schedule choice', () => {
+    const result = applyTrainingIdentityEffects({
+      stats,
+      personality: { courage: 60, kindness: 20, curiosity: 20, calmness: 20 },
+      mastery,
+      schedule: ['hunt', 'hunt', 'hunt'],
+      trainingScore: 500,
+      activeCalling: null,
+      purchasedTraits: [],
+    });
+
+    expect(result.mastery.hunt.xp).toBe(3);
+    expect(result.personality.courage).toBe(63);
+  });
+});

--- a/src/raising-depth-boundaries.test.ts
+++ b/src/raising-depth-boundaries.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyBossGrowthPointReward, incrementCallingMonthMastery, monthGrowthPointReward } from './raising-depth-rewards';
+import { applyBossGrowthPointReward, incrementCallingMonthMastery, monthGrowthPointReward, reconcileBondSceneRewards } from './raising-depth-rewards';
 
 describe('raising depth pure reward boundaries', () => {
   it('keeps the S-month bonus threshold exact and ignores malformed training scores', () => {
@@ -19,6 +19,34 @@ describe('raising depth pure reward boundaries', () => {
     expect(incrementCallingMonthMastery(base, 'caretaker')).toEqual({ ...base, caretaker:1 });
     expect(incrementCallingMonthMastery(base, 'pathfinder')).toEqual({ ...base, pathfinder:1 });
     expect(incrementCallingMonthMastery(base, null)).toBe(base);
+  });
+
+  it('normalizes malformed Bond reward currency before applying rewards', () => {
+    const base = {
+      affection:55,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+      unlocked:[],
+      rewarded:[],
+    };
+
+    const malformed = reconcileBondSceneRewards(
+      { ...base, gold:Number.NaN, gems:Number.POSITIVE_INFINITY },
+      { ...base, gold:Number.NaN, gems:Number.POSITIVE_INFINITY },
+    );
+    expect(malformed.gold).toBe(100);
+    expect(malformed.gems).toBe(0);
+
+    const fractional = reconcileBondSceneRewards(
+      { ...base, gold:500.9, gems:2.9 },
+      { ...base, gold:500.9, gems:2.9 },
+    );
+    expect(fractional.gold).toBe(600);
+    expect(fractional.gems).toBe(2);
   });
 
   it('normalizes Growth Points and does not duplicate boss first-clear rewards', () => {

--- a/src/raising-depth-effects.ts
+++ b/src/raising-depth-effects.ts
@@ -38,10 +38,13 @@ export function applyTrainingIdentityEffects(input:TrainingIdentityInput) {
   const preferences = runaPreferences(personalityArchetype(input.personality), input.activeCalling);
   const activeTraits = new Set(activeCallingTraits(input.activeCalling, input.purchasedTraits));
 
-  if (input.schedule.includes(preferences.favoriteActivity)) {
+  const preferredActivityCount = input.schedule.filter(activity => activity === preferences.favoriteActivity).length;
+  if (preferredActivityCount > 0) {
     const key = personalityKeyByActivity[preferences.favoriteActivity];
-    personality[key] = clamp(clamp(personality[key]) + 1);
-    incrementMasteryXp(mastery, preferences.favoriteActivity);
+    personality[key] = clamp(clamp(personality[key]) + preferredActivityCount);
+    for (let count = 0; count < preferredActivityCount; count += 1) {
+      incrementMasteryXp(mastery, preferences.favoriteActivity);
+    }
   }
 
   if (activeTraits.has('vanguard_power') && input.schedule.includes('hunt')) stats.strength = clamp(clamp(stats.strength) + 1);

--- a/src/raising-depth-effects.ts
+++ b/src/raising-depth-effects.ts
@@ -4,7 +4,10 @@ import { activeCallingTraits, type GrowthTraitId } from './growth-traits';
 import type { GuardianCallingId } from './guardian-callings';
 import { personalityArchetype, runaPreferences } from './runa-personality';
 
-const clamp = (value:number) => Math.max(0, Math.min(100, value));
+const clamp = (value:number) => {
+  const safe = Number.isFinite(value) ? value : 0;
+  return Math.max(0, Math.min(100, safe));
+};
 
 const personalityKeyByActivity: Record<ActivityId, keyof Personality> = {
   hunt:'courage',
@@ -37,15 +40,15 @@ export function applyTrainingIdentityEffects(input:TrainingIdentityInput) {
 
   if (input.schedule.includes(preferences.favoriteActivity)) {
     const key = personalityKeyByActivity[preferences.favoriteActivity];
-    personality[key] = clamp(personality[key] + 1);
+    personality[key] = clamp(clamp(personality[key]) + 1);
     incrementMasteryXp(mastery, preferences.favoriteActivity);
   }
 
-  if (activeTraits.has('vanguard_power') && input.schedule.includes('hunt')) stats.strength = clamp(stats.strength + 1);
-  if (activeTraits.has('arcanist_mana') && input.schedule.includes('magic')) stats.magic = clamp(stats.magic + 1);
-  if (activeTraits.has('arcanist_insight') && input.schedule.includes('magic')) stats.intelligence = clamp(stats.intelligence + 1);
-  if (activeTraits.has('caretaker_rest') && input.schedule.includes('rest')) stats.fatigue = clamp(stats.fatigue - 2);
-  if (activeTraits.has('pathfinder_herb') && input.schedule.includes('herb')) stats.intelligence = clamp(stats.intelligence + 1);
+  if (activeTraits.has('vanguard_power') && input.schedule.includes('hunt')) stats.strength = clamp(clamp(stats.strength) + 1);
+  if (activeTraits.has('arcanist_mana') && input.schedule.includes('magic')) stats.magic = clamp(clamp(stats.magic) + 1);
+  if (activeTraits.has('arcanist_insight') && input.schedule.includes('magic')) stats.intelligence = clamp(clamp(stats.intelligence) + 1);
+  if (activeTraits.has('caretaker_rest') && input.schedule.includes('rest')) stats.fatigue = clamp(clamp(stats.fatigue) - 2);
+  if (activeTraits.has('pathfinder_herb') && input.schedule.includes('herb')) stats.intelligence = clamp(clamp(stats.intelligence) + 1);
   const trainingScore = Number.isFinite(input.trainingScore) ? Math.max(0, input.trainingScore) : 0;
   if (activeTraits.has('vanguard_focus') && input.schedule.includes('hunt') && trainingScore >= 650) {
     incrementMasteryXp(mastery, 'hunt');
@@ -66,7 +69,7 @@ export function applyGiftIdentityEffects(input:GiftIdentityInput) {
   const stats = { ...input.stats };
   const preferences = runaPreferences(personalityArchetype(input.personality), input.activeCalling);
   const activeTraits = new Set(activeCallingTraits(input.activeCalling, input.purchasedTraits));
-  if (input.item === preferences.favoriteGift) stats.affection = clamp(stats.affection + 2);
-  if (activeTraits.has('caretaker_bond')) stats.affection = clamp(stats.affection + 1);
+  if (input.item === preferences.favoriteGift) stats.affection = clamp(clamp(stats.affection) + 2);
+  if (activeTraits.has('caretaker_bond')) stats.affection = clamp(clamp(stats.affection) + 1);
   return { stats, preferences };
 }

--- a/src/raising-depth-identity.test.ts
+++ b/src/raising-depth-identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyTrainingIdentityEffects } from './raising-depth-effects';
+import { applyGiftIdentityEffects, applyTrainingIdentityEffects } from './raising-depth-effects';
 
 const stats = {
   strength:30,
@@ -81,6 +81,52 @@ describe('Runa personality growth identity', () => {
     expect(curiousPathfinder.mastery.magic.xp).toBe(0);
     expect(curiousPathfinder.mastery.herb.xp).toBe(1);
     expect(balancedVanguard.mastery.hunt.xp).toBe(1);
+  });
+
+  it('repairs malformed personality and stat values touched by training identity effects', () => {
+    const gentle = applyTrainingIdentityEffects({
+      stats:{ ...stats, fatigue:Number.POSITIVE_INFINITY },
+      personality:{ courage:20, kindness:60, curiosity:20, calmness:Number.NaN },
+      mastery,
+      schedule:['rest'],
+      trainingScore:500,
+      activeCalling:'caretaker',
+      purchasedTraits:['caretaker_rest'],
+    });
+    expect(gentle.personality.calmness).toBe(1);
+    expect(gentle.stats.fatigue).toBe(0);
+
+    const balancedVanguard = applyTrainingIdentityEffects({
+      stats:{ ...stats, strength:Number.NaN },
+      personality:{ courage:Number.NaN, kindness:Number.NaN, curiosity:Number.NaN, calmness:Number.NaN },
+      mastery,
+      schedule:['hunt'],
+      trainingScore:500,
+      activeCalling:'vanguard',
+      purchasedTraits:['vanguard_power'],
+    });
+    expect(balancedVanguard.personality.courage).toBe(1);
+    expect(balancedVanguard.stats.strength).toBe(1);
+  });
+
+  it('repairs malformed affection when favorite-gift or caretaker bonuses apply', () => {
+    const favorite = applyGiftIdentityEffects({
+      stats:{ ...stats, affection:Number.NaN },
+      personality:{ courage:50, kindness:50, curiosity:50, calmness:50 },
+      item:'herb_tea',
+      activeCalling:null,
+      purchasedTraits:[],
+    });
+    expect(favorite.stats.affection).toBe(2);
+
+    const caretaker = applyGiftIdentityEffects({
+      stats:{ ...stats, affection:Number.POSITIVE_INFINITY },
+      personality:{ courage:60, kindness:20, curiosity:20, calmness:20 },
+      item:'star_cookie',
+      activeCalling:'caretaker',
+      purchasedTraits:['caretaker_rest','caretaker_bond'],
+    });
+    expect(caretaker.stats.affection).toBe(1);
   });
 
   it('does not grant the vanguard focus mastery bonus from malformed training scores', () => {

--- a/src/raising-depth-rewards.ts
+++ b/src/raising-depth-rewards.ts
@@ -49,7 +49,12 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
   const newlyUnlocked = unlocked.filter(id => !provenUnlocks.includes(id));
   const newlyRewarded = unlocked.filter(id => !claimedRewards.includes(id));
   const rewarded = bondSceneIds.filter(id => claimedRewards.includes(id) || newlyRewarded.includes(id));
-  const canonicalized = !sameIds(current.unlocked, unlocked) || !sameIds(current.rewarded, rewarded);
+  const safeGold = normalizeProgressValue(current.gold);
+  const safeGems = normalizeProgressValue(current.gems);
+  const canonicalized = !sameIds(current.unlocked, unlocked)
+    || !sameIds(current.rewarded, rewarded)
+    || safeGold !== current.gold
+    || safeGems !== current.gems;
 
   if (!newlyUnlocked.length && !newlyRewarded.length && !canonicalized) return {
     changed:false,
@@ -60,8 +65,8 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
     newlyUnlocked:[] as BondSceneId[],
   };
 
-  let gold = current.gold;
-  let gems = current.gems;
+  let gold = safeGold;
+  let gems = safeGems;
   for (const id of newlyRewarded) {
     const reward = bondSceneDefinitions.find(item => item.id === id)?.reward;
     gold += reward?.gold ?? 0;

--- a/src/raising-depth-state.test.ts
+++ b/src/raising-depth-state.test.ts
@@ -40,4 +40,17 @@ describe('raising depth state hydration', () => {
     expect(reconciled.gems).toBe(2);
     expect(reconciled.newlyUnlocked).toEqual([]);
   });
+
+  it('canonicalizes persisted monthly Legend reward keys across zero-padded dates', () => {
+    const hydrated = hydrateRaisingDepthState({
+      legendRewardKeys:[
+        '2-06:vanguard_legend',
+        '2-6:vanguard_legend',
+        '0-6:vanguard_legend',
+        '2-13:vanguard_legend',
+      ],
+    });
+
+    expect(hydrated.legendRewardKeys).toEqual(['2-6:vanguard_legend']);
+  });
 });

--- a/src/raising-depth-state.test.ts
+++ b/src/raising-depth-state.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { hydrateRaisingDepthState } from './raising-depth-state';
+
+describe('raising depth state hydration', () => {
+  it('preserves rewarded bond scenes even when the unlock list was lost', () => {
+    const hydrated = hydrateRaisingDepthState({
+      unlockedBondScenes: [],
+      rewardedBondScenes: ['shared_secret'],
+    });
+
+    expect(hydrated.unlockedBondScenes).toEqual([]);
+    expect(hydrated.rewardedBondScenes).toEqual(['shared_secret']);
+  });
+});

--- a/src/raising-depth-state.test.ts
+++ b/src/raising-depth-state.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { reconcileBondSceneRewards } from './raising-depth-rewards';
 import { hydrateRaisingDepthState } from './raising-depth-state';
 
 describe('raising depth state hydration', () => {
@@ -10,5 +11,33 @@ describe('raising depth state hydration', () => {
 
     expect(hydrated.unlockedBondScenes).toEqual([]);
     expect(hydrated.rewardedBondScenes).toEqual(['shared_secret']);
+  });
+
+  it('restores a reward-only bond scene without paying it twice after hydration', () => {
+    const hydrated = hydrateRaisingDepthState({
+      unlockedBondScenes: [],
+      rewardedBondScenes: ['first_trust'],
+    });
+    const progress = {
+      affection:0,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+      unlocked:hydrated.unlockedBondScenes,
+      rewarded:hydrated.rewardedBondScenes,
+      gold:500,
+      gems:2,
+    };
+
+    const reconciled = reconcileBondSceneRewards(progress, progress);
+
+    expect(reconciled.unlocked).toEqual(['first_trust']);
+    expect(reconciled.rewarded).toEqual(['first_trust']);
+    expect(reconciled.gold).toBe(500);
+    expect(reconciled.gems).toBe(2);
+    expect(reconciled.newlyUnlocked).toEqual([]);
   });
 });

--- a/src/raising-depth-state.ts
+++ b/src/raising-depth-state.ts
@@ -63,7 +63,7 @@ export function hydrateRaisingDepthState(raw: unknown): RaisingDepthPersistentSt
     : null;
   const masterySource = isRecord(source.callingMastery) ? source.callingMastery : {};
   const unlockedBondScenes = uniqueAllowed(source.unlockedBondScenes, bondSceneIds);
-  const rewardedBondScenes = uniqueAllowed(source.rewardedBondScenes, bondSceneIds).filter(id => unlockedBondScenes.includes(id));
+  const rewardedBondScenes = uniqueAllowed(source.rewardedBondScenes, bondSceneIds);
   return {
     activeCalling,
     callingHistory:uniqueAllowed(source.callingHistory, guardianCallingIds),

--- a/src/raising-depth-state.ts
+++ b/src/raising-depth-state.ts
@@ -52,8 +52,18 @@ function hydrateSwitchKey(raw: unknown): string | null {
 
 function hydrateLegendRewardKeys(raw: unknown): string[] {
   if (!Array.isArray(raw)) return [];
-  const valid = raw.filter((value): value is string => typeof value === 'string' && /^\d+-\d+:[a-z0-9_:-]+$/.test(value));
-  return [...new Set(valid)];
+  const canonical: string[] = [];
+  for (const value of raw) {
+    if (typeof value !== 'string') continue;
+    const match = /^(\d+)-(\d+):([a-z0-9_:-]+)$/.exec(value);
+    if (!match) continue;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    if (year < 1 || month < 1 || month > 12) continue;
+    const key = `${year}-${month}:${match[3]}`;
+    if (!canonical.includes(key)) canonical.push(key);
+  }
+  return canonical;
 }
 
 export function hydrateRaisingDepthState(raw: unknown): RaisingDepthPersistentState {

--- a/src/raising-multirun-simulation.test.ts
+++ b/src/raising-multirun-simulation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { advancedTalents } from './advanced-talents';
+import { masteryLevel, type ActivityId, type MasteryState, type Personality } from './game-core';
+import type { GuardianCallingId } from './guardian-callings';
+import { applyTrainingIdentityEffects } from './raising-depth-effects';
+
+const stats = {
+  strength:30,
+  intelligence:30,
+  magic:30,
+  morality:40,
+  affection:45,
+  stress:12,
+  fatigue:18,
+};
+
+const schedule: ActivityId[] = ['hunt','magic','rest','herb'];
+
+function emptyMastery(): MasteryState {
+  return { hunt:{xp:0}, magic:{xp:0}, rest:{xp:0}, herb:{xp:0} };
+}
+
+function simulateIdentityMonths(personality: Personality, calling: GuardianCallingId, months: number) {
+  let nextPersonality = { ...personality };
+  let mastery = emptyMastery();
+  for (let month = 0; month < months; month += 1) {
+    const result = applyTrainingIdentityEffects({
+      stats,
+      personality:nextPersonality,
+      mastery,
+      schedule,
+      trainingScore:500,
+      activeCalling:calling,
+      purchasedTraits:[],
+    });
+    nextPersonality = result.personality;
+    mastery = result.mastery;
+  }
+  return advancedTalents({
+    hunt:masteryLevel(mastery.hunt.xp),
+    magic:masteryLevel(mastery.magic.xp),
+    rest:masteryLevel(mastery.rest.xp),
+    herb:masteryLevel(mastery.herb.xp),
+  });
+}
+
+describe('raising multi-run identity simulation', () => {
+  it('keeps four personality/calling paths distinct across the same repeated schedule', () => {
+    const paths = [
+      simulateIdentityMonths({ courage:70, kindness:20, curiosity:20, calmness:20 }, 'vanguard', 7),
+      simulateIdentityMonths({ courage:20, kindness:20, curiosity:70, calmness:20 }, 'arcanist', 7),
+      simulateIdentityMonths({ courage:20, kindness:20, curiosity:20, calmness:70 }, 'caretaker', 7),
+      simulateIdentityMonths({ courage:20, kindness:20, curiosity:70, calmness:20 }, 'pathfinder', 7),
+    ];
+
+    expect(paths).toEqual([
+      ['hunter_instinct'],
+      ['arcane_rhythm'],
+      ['steady_recovery'],
+      ['field_scholar'],
+    ]);
+    expect(new Set(paths.map(path => path[0])).size).toBe(4);
+  });
+});


### PR DESCRIPTION
## 구현한 기능
- Calling depth 숫자 경계 보강: 비정상 year/month, Pathfinder XP, expedition action count, fatigue/stress delta가 진행 상태를 오염하거나 Mastery를 우회하지 않도록 정규화
- 월별 Calling Legend reward key 중복 canonicalization
- Growth Trait은 직접 선행 노드뿐 아니라 **전체 prerequisite chain**이 완전해야 구매/활성 가능하도록 보강
- orphan 상위 Trait이 Calling Signature 또는 원정 Calling 효과(Pathfinder Eye, Vanguard/Arcanist/Pathfinder Legend)를 발동하지 못하도록 동일 trait-chain 판정 사용
- Guardian Rank 계산에서 Mastery level 기여를 실제 Lv.5 상한으로 제한해 손상된 `99/999` 레벨의 Rank 우회 방지
- Advanced Talent 입력 ID를 set으로 처리해 동일 Talent 중복 적용 방지
- Advanced Talent가 건드리는 NaN/Infinity stat/personality 값을 안전한 0~100 범위로 복구 후 효과 적용
- Raising identity에서 선호 활동/Calling Trait/선호 선물 보너스가 손상된 NaN/Infinity base 값을 그대로 전파하지 않도록 **base 정규화 후 delta 적용**으로 통일
- Bond reward reconcile 시 gold/gems를 비음수 정수로 canonicalize해 NaN/Infinity/소수 화폐 오염과 보상 계산 전파 방지
- Vanguard Legend의 실제 발동 조건을 플레이어 문구인 **월 첫 원정 클리어**에 맞춤: 생애 첫 stage clear가 아니어도 그 달 첫 성공 클리어면 발동, C등급 실패는 월 혜택을 소비하지 않음
- Growth Trait prerequisite와 Calling Signature requiredTrait/mastery 연결을 구조 테스트로 고정

## 변경 파일
- `src/advanced-talents.test.ts`
- `src/advanced-talents.ts`
- `src/calling-depth-contract.test.ts`
- `src/calling-depth-effects.test.ts`
- `src/calling-depth-effects.ts`
- `src/calling-signatures.test.ts`
- `src/calling-signatures.ts`
- `src/growth-traits.test.ts`
- `src/growth-traits.ts`
- `src/guardian-rank.test.ts`
- `src/guardian-rank.ts`
- `src/raising-depth-boundaries.test.ts`
- `src/raising-depth-effects.ts`
- `src/raising-depth-identity.test.ts`
- `src/raising-depth-rewards.ts`

## 테스트 결과
- Calling depth malformed input regression: 8 targeted checks PASS
- Growth Trait complete-chain regression: 9 targeted checks PASS
- Calling effect complete-chain regression: 8 targeted checks PASS
- Guardian mastery-cap regression: 4 targeted checks PASS
- Advanced Talent duplicate/NaN regression: 6 targeted checks PASS
- Raising identity malformed touched-value + normal boundary regression: 10 targeted checks PASS
- Bond reward currency canonicalization: 5 targeted checks PASS
- Vanguard monthly successful-clear contract: 4 targeted checks PASS
- Trait/Signature definition invariants: 18 targeted checks PASS
- 최신 핵심 next-branch 통합 smoke regression: **21/21 PASS**
- 각 신규 결함은 수정 전 별도 재현 하네스에서 실패를 확인한 뒤 수정 후 fresh 재검증함
- 전체 프로젝트 build/test green은 주장하지 않음. 이 PR은 #13 위에 쌓인 WIP Draft이며 공용 integration 연결은 아직 미반영
- 현재 head의 Vercel check는 failure이나 target이 `upgradeToPro=build-rate-limit`로 보고되어 **빌드 실행 결과가 아니라 Vercel build-rate-limit 외부 blocker** 상태임

## 공용 파일 연결 필요사항
- #13의 기존 공용 연결사항 유지: Story에 Bond/Calling 전달, Career `openedRaisingStories`, Guardian→Bond→Story 순서, Bond reward claim hydration 보존, Signature 계산에 active Calling Mastery XP 전달
- `src/game-base.ts`의 Caretaker Legend Bond 효과가 현재 `purchasedTraits.includes('caretaker_legend')`를 직접 검사하므로, orphan Trait 차단을 일관되게 하려면 `activeCallingTraits('caretaker', state.purchasedTraits)` 기준으로 활성 여부를 확인해야 함
- Raising Identity UI의 Signature 계산에는 active Calling Mastery XP를 전달해야 하며, Trait 표시도 invalid/orphan path를 실제 활성 효과처럼 오인하지 않도록 같은 valid-path 의미를 사용해야 함

## 다른 작업방과 충돌 가능성이 있는 파일
- 이 Draft는 01 Raising owned 파일만 수정
- 통합 시 충돌 가능 공용 파일: `src/game-base.ts`, Raising Identity UI caller, save/hydration 계열
- `App.tsx`, `Root.tsx`, `game.ts`, `game-base.ts`, `game-core.ts`, Tactical/World/Season 구현 파일은 직접 수정하지 않음

## 저장 데이터 영향
- 신규 저장 필드 없음
- 손상 저장에서 상위 Trait만 존재할 경우 해당 Trait 기록 자체를 삭제하지는 않지만, prerequisite chain이 복구될 때까지 실제 효과/Signature에는 사용하지 않음
- 기존 정상 Trait 체인은 동작 유지
- `legendRewardKeys`는 Calling expedition reward 결과에서 중복을 제거해 같은 월 보상 상태를 canonicalize
- Guardian Mastery level은 의미상 1~5 범위만 Rank 점수에 반영
- Raising identity가 실제로 건드리는 stat/personality 값은 non-finite인 경우 0 기준으로 복구 후 해당 보너스를 적용
- Bond reconcile가 건드리는 gold/gems는 non-finite/음수/소수 상태를 비음수 정수로 복구

## 06 통합 시 주의사항
- 이 PR은 **stacked WIP Draft**이며 base가 `work/raising-story`임. PR #13이 `integration/v2`에 흡수되기 전에는 06 통합 대상으로 사용하지 말 것
- #13 흡수 후 `work/raising-story-next`를 최신 `integration/v2` 기준으로 재정렬한 뒤 base를 `integration/v2`로 retarget하고 최종 회귀를 다시 수행할 것
- 공용 `game-base.ts`가 raw `purchasedTraits`를 직접 검사하는 지점은 valid Trait-chain helper와 일치시켜야 orphan Trait 방어가 end-to-end로 완성됨
- Vanguard Legend는 `firstClear`가 아니라 성공 grade + monthly key로 월 1회 발동하도록 변경됨. 통합 E2E에서 재클리어 A/B/S → 발동, C → 미발동, 같은 달 두 번째 성공 → 미발동을 확인할 것
- Vercel은 현재 build-rate-limit blocker이므로 rate limit이 해제되기 전까지 preview check 결과로 코드 성공/실패를 판정하지 말 것
- `main` merge 및 production 배포 금지