### PR TITLE
verify: apply current constellation fixture to db25 gate

### DIFF
--- a/src/season-meta-economy.test.ts
+++ b/src/season-meta-economy.test.ts
@@ -48,7 +48,7 @@ describe('season meta economy chain', () => {
       year:1,
       month:1,
       power:0,
-      constellations:['dawn_star','scholar_star'],
+      constellations:['dawn_compass','scholar_star'],
       claimedKeys:[],
     });
     expect(clear.accepted).toBe(true);


### PR DESCRIPTION
Temporary verification-only delta PR. Applies the Season-owned TypeScript fixture correction (`dawn_star` → current `dawn_compass`) from `work/season-meta` onto `verify/season-db25-compat`. Do not merge into integration/main.