### PR TITLE
verify: clean final Season candidate on db25

### DIFF
--- a/.github/workflows/verify-season-e282-clean.yml
+++ b/.github/workflows/verify-season-e282-clean.yml
@@ -1,0 +1,50 @@
+name: Verify final Season candidate on db25
+
+on:
+  push:
+    branches:
+      - verify/season-e282-clean
+  pull_request:
+
+jobs:
+  verify-season:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm install
+      - name: Targeted Season
+        run: >-
+          npx vitest run
+          src/season-journey.test.ts
+          src/weekly-directives.test.ts
+          src/season-shop.test.ts
+          src/season-meta-economy.test.ts
+          src/sanctuary-astral-trials.test.ts
+          src/celestial-records.test.ts
+          src/celestial-ascension.test.ts
+          src/astral-rift.test.ts
+      - name: Season suite
+        run: >-
+          npx vitest run
+          src/season-journey.test.ts
+          src/weekly-directives.test.ts
+          src/season-shop.test.ts
+          src/season-meta-economy.test.ts
+          src/sanctuary-astral-trials.test.ts
+          src/sanctuary-astral-ui.test.ts
+          src/celestial-records.test.ts
+          src/celestial-ascension.test.ts
+          src/astral-rift.test.ts
+          src/astral-rift-ui.test.ts
+      - name: Full test
+        run: npm run test
+      - name: TypeScript
+        if: always()
+        run: npx tsc -b --pretty false
+      - name: Production build
+        if: always()
+        run: npm run build

--- a/src/astral-rift-ui.test.ts
+++ b/src/astral-rift-ui.test.ts
@@ -23,6 +23,15 @@ describe('Astral Rift UI summary', () => {
     expect(nebula.intensities[1]).toEqual(expect.objectContaining({ intensity:2, available:true }));
   });
 
+  it('exposes the next Celestial score target that unlocks new Rifts', () => {
+    const summary = astralRiftUiSummary(initialState);
+    expect(summary.nextUnlock).toEqual({
+      threshold:12,
+      remaining:12,
+      riftIds:['nebula_garden','lunar_ruins'],
+    });
+  });
+
   it('summarizes weekly directives, relic purchase states and honors', () => {
     const summary = astralRiftUiSummary({
       ...initialState,

--- a/src/astral-rift-ui.ts
+++ b/src/astral-rift-ui.ts
@@ -1,5 +1,5 @@
 import type { GameState } from './game';
-import { astralRiftDefinitions, astralRiftPower, canEnterAstralRift, type AstralRiftIntensity } from './astral-rift';
+import { astralRiftDefinitions, astralRiftPower, canEnterAstralRift, nextAstralRiftUnlock, type AstralRiftIntensity } from './astral-rift';
 import { astralRiftRelics } from './astral-rift-relics';
 import { astralRiftWeeklyDirectives, astralRiftWeeklyKey } from './astral-rift-weekly';
 import { astralRiftHonors, astralRiftHonorProgress } from './astral-rift-honors';
@@ -66,6 +66,7 @@ export function astralRiftUiSummary(state:GameState) {
     power,
     echoes:state.astralRiftEchoes,
     ascension:celestialAscensionRank(ascension),
+    nextUnlock:nextAstralRiftUnlock(ascension),
     rifts,
     directives,
     relics,

--- a/src/astral-rift.test.ts
+++ b/src/astral-rift.test.ts
@@ -4,6 +4,7 @@ import {
   astralRiftPower,
   astralRiftChallenge,
   canEnterAstralRift,
+  nextAstralRiftUnlock,
   resolveAstralRift,
   updateAstralRiftRecord,
   type AstralRiftRecordMap,
@@ -19,6 +20,25 @@ describe('Astral Rift domain', () => {
     expect(astralRiftChallenge('nebula_garden',1).targetPower).toBe(60);
     expect(astralRiftChallenge('nebula_garden',3).targetPower).toBe(130);
     expect(astralRiftChallenge('empyrean_gate',3).targetPower).toBe(245);
+  });
+
+  it('reports the next Rift unlock as a clear Celestial Ascension goal', () => {
+    expect(nextAstralRiftUnlock(11)).toEqual({
+      threshold:12,
+      remaining:1,
+      riftIds:['nebula_garden','lunar_ruins'],
+    });
+    expect(nextAstralRiftUnlock(12)).toEqual({
+      threshold:28,
+      remaining:16,
+      riftIds:['comet_pass','eclipse_vault'],
+    });
+    expect(nextAstralRiftUnlock(48)).toEqual({
+      threshold:72,
+      remaining:24,
+      riftIds:['empyrean_gate'],
+    });
+    expect(nextAstralRiftUnlock(72)).toBeNull();
   });
 
   it('derives rift power from ascension, sanctuary, calling mastery and blessings', () => {

--- a/src/astral-rift.ts
+++ b/src/astral-rift.ts
@@ -41,6 +41,20 @@ const gradeEchoes:Record<Exclude<AstralRiftGrade,'C'>,number> = { B:0, A:2, S:4 
 const clampInt = (value:number,min:number,max:number) => Math.min(max,Math.max(min,Number.isFinite(value) ? Math.floor(value) : min));
 const recordKey = (riftId:AstralRiftId,intensity:AstralRiftIntensity) => `${riftId}:${intensity}`;
 
+export function nextAstralRiftUnlock(rawAscensionScore:number) {
+  const score = clampInt(rawAscensionScore,0,83);
+  const thresholds = astralRiftDefinitions
+    .map(item => item.ascensionThreshold)
+    .filter(threshold => threshold > score);
+  if (thresholds.length === 0) return null;
+  const threshold = Math.min(...thresholds);
+  return {
+    threshold,
+    remaining:threshold - score,
+    riftIds:astralRiftDefinitions.filter(item => item.ascensionThreshold === threshold).map(item => item.id),
+  };
+}
+
 export function astralRiftPower(input:{
   ascensionScore:number;
   sanctuaryGrandProgress:number;

--- a/src/celestial-ascension.test.ts
+++ b/src/celestial-ascension.test.ts
@@ -15,6 +15,19 @@ describe('celestial ascension', () => {
     })).toBe(40);
   });
 
+  it('counts only one Astral clear per calendar month toward ascension', () => {
+    expect(celestialAscensionProgress({
+      trialRecords:[
+        { key:'1-1:scholar_trial', grade:'B', power:80 },
+        { key:'1-1:scholar_trial', grade:'S', power:110 },
+        { key:'1-1:wayfarer_trial', grade:'S', power:115 },
+      ],
+      blessingCount:0,
+      constellationCount:0,
+      sanctuaryGrandProgress:0,
+    })).toBe(6);
+  });
+
   it('clamps noisy inputs and caps repeat-clear contribution', () => {
     const records = Array.from({ length:30 },(_,index) => ({
       key:`${index + 1}-1:scholar_trial`,

--- a/src/celestial-ascension.ts
+++ b/src/celestial-ascension.ts
@@ -1,4 +1,5 @@
 import type { AstralTrialGrade } from './sanctuary-astral-trials';
+import { celestialRecordProgress } from './celestial-records';
 
 export type CelestialAscensionRankId = 'earthbound'|'awakened'|'stellar'|'empyrean'|'transcendent';
 export type CelestialAscensionRewardRank = Exclude<CelestialAscensionRankId,'earthbound'>;
@@ -20,7 +21,6 @@ export const celestialAscensionRewards = [
 ];
 
 const clampInt = (value:number,min:number,max:number) => Math.min(max,Math.max(min,Number.isFinite(value) ? Math.floor(value) : min));
-const trialFromKey = (key:string) => key.split(':')[1] ?? '';
 
 export function celestialAscensionProgress(input:{
   trialRecords:ReadonlyArray<CelestialAscensionRecord>;
@@ -28,14 +28,9 @@ export function celestialAscensionProgress(input:{
   constellationCount:number;
   sanctuaryGrandProgress:number;
 }):number {
-  const clears = Math.min(12,input.trialRecords.length) * 2;
-  const uniqueS = new Set<string>();
-  for (const record of input.trialRecords) {
-    if (record.grade !== 'S') continue;
-    const trial = trialFromKey(record.key);
-    if (trial) uniqueS.add(trial);
-  }
-  const sScore = Math.min(4,uniqueS.size) * 4;
+  const recordProgress = celestialRecordProgress(input.trialRecords);
+  const clears = Math.min(12,recordProgress.totalClears) * 2;
+  const sScore = Math.min(4,recordProgress.uniqueSClears) * 4;
   const blessingScore = clampInt(input.blessingCount,0,4) * 5;
   const constellationScore = clampInt(input.constellationCount,0,5) * 2;
   const sanctuaryScore = Math.floor(clampInt(input.sanctuaryGrandProgress,0,65) / 5);

--- a/src/celestial-records.test.ts
+++ b/src/celestial-records.test.ts
@@ -15,6 +15,19 @@ describe('celestial records', () => {
     expect(progress).toEqual({ totalClears:5, uniqueTrials:4, uniqueSClears:2 });
   });
 
+  it('counts at most one Astral record per calendar month', () => {
+    const progress = celestialRecordProgress([
+      record('1-1:scholar_trial','A',90),
+      record('1-1:scholar_trial','S',110),
+      record('1-1:wayfarer_trial','S',115),
+      record('1-2:wayfarer_trial','A',92),
+    ]);
+
+    expect(progress.totalClears).toBe(2);
+    expect(progress.uniqueTrials).toBe(2);
+    expect(progress.uniqueSClears).toBe(1);
+  });
+
   it('defines long-term astral honor milestones', () => {
     expect(celestialHonors.map(item => item.id)).toEqual(['first_light','full_cycle','perfect_cycle','twelve_trials']);
   });
@@ -25,5 +38,10 @@ describe('celestial records', () => {
       record('1-3:guardian_trial','S'), record('1-4:crown_trial','S'),
     ];
     expect(newlyEarnedCelestialHonors(records,['first_light']).map(item => item.id)).toEqual(['full_cycle','perfect_cycle']);
+  });
+
+  it('does not unlock lifetime honors from duplicate records in one month', () => {
+    const records = Array.from({ length:12 },(_,index) => record(`1-1:${index % 2 === 0 ? 'scholar_trial' : 'wayfarer_trial'}`,'S',110 + index));
+    expect(newlyEarnedCelestialHonors(records,[]).map(item => item.id)).toEqual(['first_light']);
   });
 });

--- a/src/celestial-records.ts
+++ b/src/celestial-records.ts
@@ -18,18 +18,41 @@ export const celestialHonors:CelestialHonor[] = [
   { id:'twelve_trials', label:'천체 연대기', description:'누적 12회의 Astral Trial을 완료했어요.', metric:'totalClears', threshold:12, reward:{ gold:800, gems:4, starShards:4 } },
 ];
 
+const gradeRank:Record<AstralTrialGrade,number> = { B:1, A:2, S:3 };
 const trialFromKey = (key:string) => key.split(':')[1] ?? '';
+const monthFromKey = (key:string) => key.split(':')[0] ?? '';
+
+export function canonicalCelestialRecords(records:ReadonlyArray<CelestialRecord>):CelestialRecord[] {
+  const byMonth = new Map<string,CelestialRecord>();
+  for (const record of records) {
+    const month = monthFromKey(record.key);
+    const trial = trialFromKey(record.key);
+    if (!month || !trial) continue;
+    const existing = byMonth.get(month);
+    if (!existing) {
+      byMonth.set(month,record);
+      continue;
+    }
+    if (existing.key !== record.key) continue;
+    if (gradeRank[record.grade] > gradeRank[existing.grade]
+      || (record.grade === existing.grade && record.power > existing.power)) {
+      byMonth.set(month,record);
+    }
+  }
+  return [...byMonth.values()];
+}
 
 export function celestialRecordProgress(records:ReadonlyArray<CelestialRecord>) {
+  const canonical = canonicalCelestialRecords(records);
   const unique = new Set<string>();
   const uniqueS = new Set<string>();
-  for (const record of records) {
+  for (const record of canonical) {
     const trial = trialFromKey(record.key);
     if (!trial) continue;
     unique.add(trial);
     if (record.grade === 'S') uniqueS.add(trial);
   }
-  return { totalClears:records.length, uniqueTrials:unique.size, uniqueSClears:uniqueS.size };
+  return { totalClears:canonical.length, uniqueTrials:unique.size, uniqueSClears:uniqueS.size };
 }
 
 export function newlyEarnedCelestialHonors(records:ReadonlyArray<CelestialRecord>,claimed:ReadonlyArray<CelestialHonorId>) {

--- a/src/sanctuary-astral-trials.test.ts
+++ b/src/sanctuary-astral-trials.test.ts
@@ -24,7 +24,7 @@ describe('sanctuary astral trials', () => {
     expect(power).toBe(78);
   });
 
-  it('requires the matching constellation and grades accepted clears', () => {
+  it('requires at least one matching constellation and grades accepted clears', () => {
     const locked = resolveAstralTrial({
       year:1,
       month:1,
@@ -49,6 +49,36 @@ describe('sanctuary astral trials', () => {
       gold:150,
       key:'1-1:scholar_trial',
     }));
+  });
+
+  it('falls back to an unlocked trial when the featured monthly trial is still locked', () => {
+    const result = resolveAstralTrial({
+      year:1,
+      month:2,
+      power:90,
+      constellations:['dawn_compass','scholar_star'],
+      claimedKeys:[],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      accepted:true,
+      trial:expect.objectContaining({ id:'scholar_trial' }),
+      grade:'A',
+      key:'1-2:scholar_trial',
+    }));
+  });
+
+  it('allows only one reward claim per calendar month even if the eligible trial changes', () => {
+    const result = resolveAstralTrial({
+      year:1,
+      month:2,
+      power:120,
+      constellations:['dawn_compass','scholar_star','wayfarer_star'],
+      claimedKeys:['1-2:scholar_trial'],
+    });
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toBe('already_claimed');
   });
 
   it('allows only one reward claim per monthly trial', () => {

--- a/src/sanctuary-astral-trials.ts
+++ b/src/sanctuary-astral-trials.ts
@@ -24,6 +24,22 @@ export function astralTrialFor(year:number,month:number):AstralTrialDefinition {
   return astralTrialDefinitions[index];
 }
 
+export function eligibleAstralTrialFor(
+  year:number,
+  month:number,
+  constellations:ReadonlyArray<SanctuaryConstellationId>,
+):AstralTrialDefinition {
+  const featured = astralTrialFor(year,month);
+  if (constellations.includes(featured.requiredConstellation)) return featured;
+
+  const featuredIndex = astralTrialDefinitions.indexOf(featured);
+  for (let offset = 1; offset < astralTrialDefinitions.length; offset += 1) {
+    const candidate = astralTrialDefinitions[(featuredIndex + offset) % astralTrialDefinitions.length];
+    if (constellations.includes(candidate.requiredConstellation)) return candidate;
+  }
+  return featured;
+}
+
 type TrialPowerInput = {
   trial:AstralTrialId;
   stats:{ strength:number; intelligence:number; magic:number; morality:number };
@@ -65,12 +81,15 @@ export function resolveAstralTrial(input:{
   constellations:SanctuaryConstellationId[];
   claimedKeys:string[];
 }) {
-  const trial = astralTrialFor(input.year,input.month);
-  const key = `${Math.max(1,Math.floor(input.year))}-${Math.max(1,Math.min(12,Math.floor(input.month)))}:${trial.id}`;
+  const safeYear = Math.max(1,Math.floor(input.year));
+  const safeMonth = Math.max(1,Math.min(12,Math.floor(input.month)));
+  const trial = eligibleAstralTrialFor(safeYear,safeMonth,input.constellations);
+  const key = `${safeYear}-${safeMonth}:${trial.id}`;
   if (!input.constellations.includes(trial.requiredConstellation)) {
     return { accepted:false as const, reason:'constellation_locked' as const, trial, key, grade:null, starShards:0, gold:0 };
   }
-  if (input.claimedKeys.includes(key)) {
+  const monthPrefix = `${safeYear}-${safeMonth}:`;
+  if (input.claimedKeys.some(claimedKey => claimedKey.startsWith(monthPrefix))) {
     return { accepted:false as const, reason:'already_claimed' as const, trial, key, grade:null, starShards:0, gold:0 };
   }
   const power = Number.isFinite(input.power) ? Math.max(0,Math.floor(input.power)) : 0;

--- a/src/sanctuary-astral-ui.test.ts
+++ b/src/sanctuary-astral-ui.test.ts
@@ -102,4 +102,20 @@ describe('sanctuary astral ui summary', () => {
     expect(summary.ascension.rewards.find(item => item.rank === 'awakened')).toEqual(expect.objectContaining({ claimed:true }));
     expect(summary.ascension.nextReward).toEqual(expect.objectContaining({ rank:'stellar' }));
   });
+
+  it('shows canonical monthly Astral records in Celestial progress', () => {
+    const summary = sanctuaryAstralUiSummary({
+      ...initialState,
+      astralTrialRecords:[
+        { key:'1-1:scholar_trial', grade:'A', power:90 },
+        { key:'1-1:scholar_trial', grade:'S', power:110 },
+        { key:'1-1:wayfarer_trial', grade:'S', power:115 },
+      ],
+    });
+
+    expect(summary.recentRecords).toHaveLength(1);
+    expect(summary.recentRecords[0]).toEqual(expect.objectContaining({ key:'1-1:scholar_trial', grade:'S', power:110 }));
+    expect(summary.ascension.components.trialClears).toBe(1);
+    expect(summary.ascension.components.uniqueSClears).toBe(1);
+  });
 });

--- a/src/sanctuary-astral-ui.test.ts
+++ b/src/sanctuary-astral-ui.test.ts
@@ -17,6 +17,36 @@ describe('sanctuary astral ui summary', () => {
     expect(summary.trial.canChallenge).toBe(false);
   });
 
+  it('shows an unlocked fallback trial instead of a locked featured trial', () => {
+    const summary = sanctuaryAstralUiSummary({
+      ...initialState,
+      year:1,
+      month:2,
+      sanctuaryConstellations:['dawn_compass','scholar_star'] as typeof initialState.sanctuaryConstellations,
+      claimedAstralTrials:[],
+    });
+
+    expect(summary.trial.id).toBe('scholar_trial');
+    expect(summary.trial.unlocked).toBe(true);
+    expect(summary.trial.claimed).toBe(false);
+    expect(summary.trial.canChallenge).toBe(true);
+  });
+
+  it('shows the month as claimed after a fallback clear even if the featured trial unlocks later', () => {
+    const summary = sanctuaryAstralUiSummary({
+      ...initialState,
+      year:1,
+      month:2,
+      sanctuaryConstellations:['dawn_compass','scholar_star','wayfarer_star'] as typeof initialState.sanctuaryConstellations,
+      claimedAstralTrials:['1-2:scholar_trial'],
+    });
+
+    expect(summary.trial.id).toBe('wayfarer_trial');
+    expect(summary.trial.unlocked).toBe(true);
+    expect(summary.trial.claimed).toBe(true);
+    expect(summary.trial.canChallenge).toBe(false);
+  });
+
   it('shows power, grade preview and completed monthly trial state', () => {
     const summary = sanctuaryAstralUiSummary({
       ...initialState,
@@ -71,5 +101,21 @@ describe('sanctuary astral ui summary', () => {
     }));
     expect(summary.ascension.rewards.find(item => item.rank === 'awakened')).toEqual(expect.objectContaining({ claimed:true }));
     expect(summary.ascension.nextReward).toEqual(expect.objectContaining({ rank:'stellar' }));
+  });
+
+  it('shows canonical monthly Astral records in Celestial progress', () => {
+    const summary = sanctuaryAstralUiSummary({
+      ...initialState,
+      astralTrialRecords:[
+        { key:'1-1:scholar_trial', grade:'A', power:90 },
+        { key:'1-1:scholar_trial', grade:'S', power:110 },
+        { key:'1-1:wayfarer_trial', grade:'S', power:115 },
+      ],
+    });
+
+    expect(summary.recentRecords).toHaveLength(1);
+    expect(summary.recentRecords[0]).toEqual(expect.objectContaining({ key:'1-1:scholar_trial', grade:'S', power:110 }));
+    expect(summary.ascension.components.trialClears).toBe(1);
+    expect(summary.ascension.components.uniqueSClears).toBe(1);
   });
 });

--- a/src/sanctuary-astral-ui.test.ts
+++ b/src/sanctuary-astral-ui.test.ts
@@ -17,6 +17,36 @@ describe('sanctuary astral ui summary', () => {
     expect(summary.trial.canChallenge).toBe(false);
   });
 
+  it('shows an unlocked fallback trial instead of a locked featured trial', () => {
+    const summary = sanctuaryAstralUiSummary({
+      ...initialState,
+      year:1,
+      month:2,
+      sanctuaryConstellations:['dawn_compass','scholar_star'] as typeof initialState.sanctuaryConstellations,
+      claimedAstralTrials:[],
+    });
+
+    expect(summary.trial.id).toBe('scholar_trial');
+    expect(summary.trial.unlocked).toBe(true);
+    expect(summary.trial.claimed).toBe(false);
+    expect(summary.trial.canChallenge).toBe(true);
+  });
+
+  it('shows the month as claimed after a fallback clear even if the featured trial unlocks later', () => {
+    const summary = sanctuaryAstralUiSummary({
+      ...initialState,
+      year:1,
+      month:2,
+      sanctuaryConstellations:['dawn_compass','scholar_star','wayfarer_star'] as typeof initialState.sanctuaryConstellations,
+      claimedAstralTrials:['1-2:scholar_trial'],
+    });
+
+    expect(summary.trial.id).toBe('wayfarer_trial');
+    expect(summary.trial.unlocked).toBe(true);
+    expect(summary.trial.claimed).toBe(true);
+    expect(summary.trial.canChallenge).toBe(false);
+  });
+
   it('shows power, grade preview and completed monthly trial state', () => {
     const summary = sanctuaryAstralUiSummary({
       ...initialState,

--- a/src/sanctuary-astral-ui.ts
+++ b/src/sanctuary-astral-ui.ts
@@ -4,9 +4,9 @@ import {
   celestialAscensionRank,
   celestialAscensionRewards,
 } from './celestial-ascension';
-import { celestialRecordProgress } from './celestial-records';
+import { canonicalCelestialRecords, celestialRecordProgress } from './celestial-records';
 import { astralBlessings, resolveAstralBlessingPurchase } from './sanctuary-astral-blessings';
-import { astralTrialFor, astralTrialPower } from './sanctuary-astral-trials';
+import { eligibleAstralTrialFor, astralTrialPower } from './sanctuary-astral-trials';
 import { constellationProgress } from './sanctuary-constellations';
 
 function previewGrade(power:number) {
@@ -14,7 +14,8 @@ function previewGrade(power:number) {
 }
 
 export function sanctuaryAstralUiSummary(state:GameState) {
-  const trial = astralTrialFor(state.year,state.month);
+  const constellations = state.sanctuaryConstellations ?? [];
+  const trial = eligibleAstralTrialFor(state.year,state.month,constellations);
   const progress = constellationProgress({
     levels:state.sanctuaryLevels,
     specializationCount:Object.keys(state.sanctuarySpecializations ?? {}).length,
@@ -30,11 +31,12 @@ export function sanctuaryAstralUiSummary(state:GameState) {
       morality:state.stats.morality,
     },
     sanctuaryProgress:progress,
-    constellationCount:(state.sanctuaryConstellations ?? []).length,
+    constellationCount:constellations.length,
   });
   const key = `${state.year}-${state.month}:${trial.id}`;
-  const unlocked = (state.sanctuaryConstellations ?? []).includes(trial.requiredConstellation);
-  const claimed = (state.claimedAstralTrials ?? []).includes(key);
+  const monthPrefix = `${state.year}-${state.month}:`;
+  const unlocked = constellations.includes(trial.requiredConstellation);
+  const claimed = (state.claimedAstralTrials ?? []).some(claimKey => claimKey.startsWith(monthPrefix));
   const starShards = Math.max(0,Math.floor(state.astralStarShards ?? 0));
   const purchased = state.purchasedAstralBlessings ?? [];
   const trialKeys = state.claimedAstralTrials ?? [];
@@ -50,12 +52,13 @@ export function sanctuaryAstralUiSummary(state:GameState) {
     };
   });
   const records = state.astralTrialRecords ?? [];
-  const recentRecords = [...records].slice(-6).reverse();
+  const canonicalRecords = canonicalCelestialRecords(records);
+  const recentRecords = [...canonicalRecords].slice(-6).reverse();
   const recordProgress = celestialRecordProgress(records);
   const ascensionScore = celestialAscensionProgress({
     trialRecords:records,
     blessingCount:purchased.length,
-    constellationCount:(state.sanctuaryConstellations ?? []).length,
+    constellationCount:constellations.length,
     sanctuaryGrandProgress:progress,
   });
   const ascensionRank = celestialAscensionRank(ascensionScore);
@@ -84,10 +87,10 @@ export function sanctuaryAstralUiSummary(state:GameState) {
       score:ascensionScore,
       rank:ascensionRank,
       components:{
-        trialClears:Math.min(12,records.length),
+        trialClears:Math.min(12,recordProgress.totalClears),
         uniqueSClears:Math.min(4,recordProgress.uniqueSClears),
         blessings:Math.min(4,purchased.length),
-        constellations:Math.min(5,(state.sanctuaryConstellations ?? []).length),
+        constellations:Math.min(5,constellations.length),
         sanctuaryProgress:progress,
       },
       rewards:ascensionRewards,

--- a/src/sanctuary-astral-ui.ts
+++ b/src/sanctuary-astral-ui.ts
@@ -4,7 +4,7 @@ import {
   celestialAscensionRank,
   celestialAscensionRewards,
 } from './celestial-ascension';
-import { celestialRecordProgress } from './celestial-records';
+import { canonicalCelestialRecords, celestialRecordProgress } from './celestial-records';
 import { astralBlessings, resolveAstralBlessingPurchase } from './sanctuary-astral-blessings';
 import { eligibleAstralTrialFor, astralTrialPower } from './sanctuary-astral-trials';
 import { constellationProgress } from './sanctuary-constellations';
@@ -52,7 +52,8 @@ export function sanctuaryAstralUiSummary(state:GameState) {
     };
   });
   const records = state.astralTrialRecords ?? [];
-  const recentRecords = [...records].slice(-6).reverse();
+  const canonicalRecords = canonicalCelestialRecords(records);
+  const recentRecords = [...canonicalRecords].slice(-6).reverse();
   const recordProgress = celestialRecordProgress(records);
   const ascensionScore = celestialAscensionProgress({
     trialRecords:records,
@@ -86,7 +87,7 @@ export function sanctuaryAstralUiSummary(state:GameState) {
       score:ascensionScore,
       rank:ascensionRank,
       components:{
-        trialClears:Math.min(12,records.length),
+        trialClears:Math.min(12,recordProgress.totalClears),
         uniqueSClears:Math.min(4,recordProgress.uniqueSClears),
         blessings:Math.min(4,purchased.length),
         constellations:Math.min(5,constellations.length),

--- a/src/sanctuary-astral-ui.ts
+++ b/src/sanctuary-astral-ui.ts
@@ -6,7 +6,7 @@ import {
 } from './celestial-ascension';
 import { celestialRecordProgress } from './celestial-records';
 import { astralBlessings, resolveAstralBlessingPurchase } from './sanctuary-astral-blessings';
-import { astralTrialFor, astralTrialPower } from './sanctuary-astral-trials';
+import { eligibleAstralTrialFor, astralTrialPower } from './sanctuary-astral-trials';
 import { constellationProgress } from './sanctuary-constellations';
 
 function previewGrade(power:number) {
@@ -14,7 +14,8 @@ function previewGrade(power:number) {
 }
 
 export function sanctuaryAstralUiSummary(state:GameState) {
-  const trial = astralTrialFor(state.year,state.month);
+  const constellations = state.sanctuaryConstellations ?? [];
+  const trial = eligibleAstralTrialFor(state.year,state.month,constellations);
   const progress = constellationProgress({
     levels:state.sanctuaryLevels,
     specializationCount:Object.keys(state.sanctuarySpecializations ?? {}).length,
@@ -30,11 +31,12 @@ export function sanctuaryAstralUiSummary(state:GameState) {
       morality:state.stats.morality,
     },
     sanctuaryProgress:progress,
-    constellationCount:(state.sanctuaryConstellations ?? []).length,
+    constellationCount:constellations.length,
   });
   const key = `${state.year}-${state.month}:${trial.id}`;
-  const unlocked = (state.sanctuaryConstellations ?? []).includes(trial.requiredConstellation);
-  const claimed = (state.claimedAstralTrials ?? []).includes(key);
+  const monthPrefix = `${state.year}-${state.month}:`;
+  const unlocked = constellations.includes(trial.requiredConstellation);
+  const claimed = (state.claimedAstralTrials ?? []).some(claimKey => claimKey.startsWith(monthPrefix));
   const starShards = Math.max(0,Math.floor(state.astralStarShards ?? 0));
   const purchased = state.purchasedAstralBlessings ?? [];
   const trialKeys = state.claimedAstralTrials ?? [];
@@ -55,7 +57,7 @@ export function sanctuaryAstralUiSummary(state:GameState) {
   const ascensionScore = celestialAscensionProgress({
     trialRecords:records,
     blessingCount:purchased.length,
-    constellationCount:(state.sanctuaryConstellations ?? []).length,
+    constellationCount:constellations.length,
     sanctuaryGrandProgress:progress,
   });
   const ascensionRank = celestialAscensionRank(ascensionScore);
@@ -87,7 +89,7 @@ export function sanctuaryAstralUiSummary(state:GameState) {
         trialClears:Math.min(12,records.length),
         uniqueSClears:Math.min(4,recordProgress.uniqueSClears),
         blessings:Math.min(4,purchased.length),
-        constellations:Math.min(5,(state.sanctuaryConstellations ?? []).length),
+        constellations:Math.min(5,constellations.length),
         sanctuaryProgress:progress,
       },
       rewards:ascensionRewards,

--- a/src/season-journey.test.ts
+++ b/src/season-journey.test.ts
@@ -30,8 +30,26 @@ describe('season journey', () => {
     expect(seasonJourneyTiers[9].reward.tokens).toBeGreaterThan(seasonJourneyTiers[0].reward.tokens);
   });
 
-  it('returns only newly crossed tiers in ascending order', () => {
+  it('returns only newly crossed tiers in ascending order without a season claim key', () => {
     expect(newlyEarnedJourneyTiers(40,180,[]).map(tier => tier.tier)).toEqual([1,2,3]);
     expect(newlyEarnedJourneyTiers(180,300,['1-spring:1','1-spring:2','1-spring:3']).map(tier => tier.tier)).toEqual([4]);
+  });
+
+  it('recovers reached but unclaimed tiers when a season claim key is supplied', () => {
+    expect(newlyEarnedJourneyTiers(
+      180,
+      200,
+      ['1-spring:1'],
+      '1-spring',
+    ).map(tier => tier.tier)).toEqual([2,3]);
+  });
+
+  it('never returns already claimed season tiers during recovery', () => {
+    expect(newlyEarnedJourneyTiers(
+      180,
+      200,
+      ['1-spring:1','1-spring:2','1-spring:3'],
+      '1-spring',
+    )).toEqual([]);
   });
 });

--- a/src/season-journey.ts
+++ b/src/season-journey.ts
@@ -45,8 +45,8 @@ export function newlyEarnedJourneyTiers(previousScore:number, nextScore:number, 
   const floorPrevious = Math.max(0, Math.floor(previousScore));
   const floorNext = Math.max(floorPrevious, Math.floor(nextScore));
   return seasonJourneyTiers.filter(tier => {
-    if (floorNext < tier.threshold || floorPrevious >= tier.threshold) return false;
-    if (!key) return true;
+    if (floorNext < tier.threshold) return false;
+    if (!key) return floorPrevious < tier.threshold;
     return !claimedKeys.includes(journeyTierClaimKey(key, tier.tier));
   });
 }

--- a/src/season-meta-economy.test.ts
+++ b/src/season-meta-economy.test.ts
@@ -48,7 +48,7 @@ describe('season meta economy chain', () => {
       year:1,
       month:1,
       power:0,
-      constellations:['dawn_star','scholar_star'],
+      constellations:['dawn_compass','scholar_star'],
       claimedKeys:[],
     });
     expect(clear.accepted).toBe(true);

--- a/src/season-meta-economy.test.ts
+++ b/src/season-meta-economy.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { astralRiftDefinitions, nextAstralRiftUnlock } from './astral-rift';
+import { celestialAscensionProgress, newlyEarnedAscensionRewards } from './celestial-ascension';
+import { newlyEarnedCelestialHonors } from './celestial-records';
+import { astralBlessings } from './sanctuary-astral-blessings';
+import { resolveAstralTrial, type AstralTrialId } from './sanctuary-astral-trials';
+import { seasonJourneyTiers } from './season-journey';
+import { seasonShopOffers } from './season-shop';
+import { sanctuaryFacilities } from './starlight-sanctuary';
+import { weeklyDirectives } from './weekly-directives';
+
+const materials = ['star_bark','arcane_shard','wind_pearl'] as const;
+
+describe('season meta economy chain', () => {
+  it('keeps Weekly Directive tokens meaningful while a full season can still clear the shop', () => {
+    const journeyOnlyTokens = seasonJourneyTiers.reduce((sum,tier) => sum + tier.reward.tokens,0);
+    const weeklyTokens = [3,4,5].flatMap(month => [1,2,3,4].map(week => weeklyDirectives(1,month,week)))
+      .flat()
+      .reduce((sum,directive) => sum + directive.reward.tokens,0);
+    const fullShopCost = seasonShopOffers('1-spring').reduce((sum,offer) => sum + offer.cost * offer.limit,0);
+
+    expect(fullShopCost).toBeGreaterThan(journeyOnlyTokens);
+    expect(fullShopCost).toBeLessThanOrEqual(journeyOnlyTokens + weeklyTokens);
+  });
+
+  it('makes one sanctuary material cache enough to start any level-1 sanctuary facility without replacing the full sanctuary grind', () => {
+    const cache = seasonShopOffers('1-spring').find(offer => offer.id === 'expedition_cache');
+    expect(cache).toBeDefined();
+
+    for (const facility of sanctuaryFacilities) {
+      const levelOne = facility.upgrades.find(step => step.level === 1)!;
+      for (const material of materials) {
+        expect(cache!.reward.materials[material] ?? 0).toBeGreaterThanOrEqual(levelOne.cost.materials[material]);
+      }
+    }
+
+    const totalCosts = Object.fromEntries(materials.map(material => [material,
+      sanctuaryFacilities.reduce((facilitySum,facility) => facilitySum + facility.upgrades.reduce((stepSum,step) => stepSum + step.cost.materials[material],0),0),
+    ])) as Record<(typeof materials)[number],number>;
+    for (const material of materials) {
+      expect((cache!.reward.materials[material] ?? 0) * cache!.limit).toBeLessThan(totalCosts[material]);
+    }
+  });
+
+  it('turns the first legal Astral clear into a real bridge toward blessing and Rift progression', () => {
+    const clear = resolveAstralTrial({
+      year:1,
+      month:1,
+      power:0,
+      constellations:['dawn_compass','scholar_star'],
+      claimedKeys:[],
+    });
+    expect(clear.accepted).toBe(true);
+    if (!clear.accepted) return;
+
+    const records = [{ key:clear.key, grade:clear.grade, power:0 }];
+    const ascension = celestialAscensionProgress({
+      trialRecords:records,
+      blessingCount:0,
+      constellationCount:2,
+      sanctuaryGrandProgress:35,
+    });
+    const firstRiftThreshold = Math.min(...astralRiftDefinitions.map(rift => rift.ascensionThreshold));
+    expect(ascension).toBeGreaterThanOrEqual(firstRiftThreshold);
+    expect(nextAstralRiftUnlock(ascension)?.threshold ?? firstRiftThreshold).toBeGreaterThanOrEqual(firstRiftThreshold);
+
+    const honorShards = newlyEarnedCelestialHonors(records,[])
+      .reduce((sum,honor) => sum + honor.reward.starShards,0);
+    const rankShards = newlyEarnedAscensionRewards(ascension,[])
+      .reduce((sum,rank) => sum + rank.reward.starShards,0);
+    const scholarBlessing = astralBlessings.find(blessing => blessing.requiredTrial === 'scholar_trial')!;
+    expect(clear.starShards + honorShards + rankShards).toBeGreaterThanOrEqual(scholarBlessing.cost);
+  });
+
+  it('keeps the final Rift threshold reachable through legitimate monthly Astral records', () => {
+    const trials:AstralTrialId[] = ['scholar_trial','wayfarer_trial','guardian_trial','crown_trial'];
+    const records = Array.from({ length:12 },(_,index) => ({
+      key:`1-${index + 1}:${trials[index % trials.length]}`,
+      grade:'S' as const,
+      power:120,
+    }));
+    const ascension = celestialAscensionProgress({
+      trialRecords:records,
+      blessingCount:4,
+      constellationCount:5,
+      sanctuaryGrandProgress:65,
+    });
+    const finalThreshold = Math.max(...astralRiftDefinitions.map(rift => rift.ascensionThreshold));
+
+    expect(ascension).toBeGreaterThanOrEqual(finalThreshold);
+    expect(nextAstralRiftUnlock(ascension)).toBeNull();
+  });
+
+  it('never reissues permanent Celestial rewards after their claim ids are recorded', () => {
+    const trials:AstralTrialId[] = ['scholar_trial','wayfarer_trial','guardian_trial','crown_trial'];
+    const records = Array.from({ length:12 },(_,index) => ({
+      key:`1-${index + 1}:${trials[index % trials.length]}`,
+      grade:'S' as const,
+      power:120,
+    }));
+    const claimedHonors = ['first_light','full_cycle','perfect_cycle','twelve_trials'] as const;
+    const claimedRanks = ['awakened','stellar','empyrean','transcendent'] as const;
+
+    expect(newlyEarnedCelestialHonors(records,claimedHonors)).toEqual([]);
+    expect(newlyEarnedAscensionRewards(83,claimedRanks)).toEqual([]);
+  });
+});

--- a/src/season-meta-economy.test.ts
+++ b/src/season-meta-economy.test.ts
@@ -8,24 +8,38 @@ import { resolveAstralTrial, type AstralTrialId } from './sanctuary-astral-trial
 import { seasonJourneyTiers } from './season-journey';
 import { seasonShopOffers } from './season-shop';
 import { sanctuaryFacilities } from './starlight-sanctuary';
+import { weeklyDirectives } from './weekly-directives';
+
+const materials = ['star_bark','arcane_shard','wind_pearl'] as const;
 
 describe('season meta economy chain', () => {
-  it('keeps Weekly Directive tokens meaningful instead of letting Journey tiers clear the whole shop alone', () => {
+  it('keeps Weekly Directive tokens meaningful while a full season can still clear the shop', () => {
     const journeyOnlyTokens = seasonJourneyTiers.reduce((sum,tier) => sum + tier.reward.tokens,0);
+    const weeklyTokens = [3,4,5].flatMap(month => [1,2,3,4].map(week => weeklyDirectives(1,month,week)))
+      .flat()
+      .reduce((sum,directive) => sum + directive.reward.tokens,0);
     const fullShopCost = seasonShopOffers('1-spring').reduce((sum,offer) => sum + offer.cost * offer.limit,0);
 
     expect(fullShopCost).toBeGreaterThan(journeyOnlyTokens);
+    expect(fullShopCost).toBeLessThanOrEqual(journeyOnlyTokens + weeklyTokens);
   });
 
-  it('makes one sanctuary material cache enough to start any level-1 sanctuary facility', () => {
+  it('makes one sanctuary material cache enough to start any level-1 sanctuary facility without replacing the full sanctuary grind', () => {
     const cache = seasonShopOffers('1-spring').find(offer => offer.id === 'expedition_cache');
     expect(cache).toBeDefined();
 
     for (const facility of sanctuaryFacilities) {
       const levelOne = facility.upgrades.find(step => step.level === 1)!;
-      for (const material of ['star_bark','arcane_shard','wind_pearl'] as const) {
+      for (const material of materials) {
         expect(cache!.reward.materials[material] ?? 0).toBeGreaterThanOrEqual(levelOne.cost.materials[material]);
       }
+    }
+
+    const totalCosts = Object.fromEntries(materials.map(material => [material,
+      sanctuaryFacilities.reduce((facilitySum,facility) => facilitySum + facility.upgrades.reduce((stepSum,step) => stepSum + step.cost.materials[material],0),0),
+    ])) as Record<(typeof materials)[number],number>;
+    for (const material of materials) {
+      expect((cache!.reward.materials[material] ?? 0) * cache!.limit).toBeLessThan(totalCosts[material]);
     }
   });
 

--- a/src/season-meta-economy.test.ts
+++ b/src/season-meta-economy.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { astralRiftDefinitions, nextAstralRiftUnlock } from './astral-rift';
+import { celestialAscensionProgress, newlyEarnedAscensionRewards } from './celestial-ascension';
+import { newlyEarnedCelestialHonors } from './celestial-records';
+import { astralBlessings } from './sanctuary-astral-blessings';
+import { resolveAstralTrial, type AstralTrialId } from './sanctuary-astral-trials';
+import { seasonJourneyTiers } from './season-journey';
+import { seasonShopOffers } from './season-shop';
+import { sanctuaryFacilities } from './starlight-sanctuary';
+
+describe('season meta economy chain', () => {
+  it('keeps Weekly Directive tokens meaningful instead of letting Journey tiers clear the whole shop alone', () => {
+    const journeyOnlyTokens = seasonJourneyTiers.reduce((sum,tier) => sum + tier.reward.tokens,0);
+    const fullShopCost = seasonShopOffers('1-spring').reduce((sum,offer) => sum + offer.cost * offer.limit,0);
+
+    expect(fullShopCost).toBeGreaterThan(journeyOnlyTokens);
+  });
+
+  it('makes one sanctuary material cache enough to start any level-1 sanctuary facility', () => {
+    const cache = seasonShopOffers('1-spring').find(offer => offer.id === 'expedition_cache');
+    expect(cache).toBeDefined();
+
+    for (const facility of sanctuaryFacilities) {
+      const levelOne = facility.upgrades.find(step => step.level === 1)!;
+      for (const material of ['star_bark','arcane_shard','wind_pearl'] as const) {
+        expect(cache!.reward.materials[material] ?? 0).toBeGreaterThanOrEqual(levelOne.cost.materials[material]);
+      }
+    }
+  });
+
+  it('turns the first legal Astral clear into a real bridge toward blessing and Rift progression', () => {
+    const clear = resolveAstralTrial({
+      year:1,
+      month:1,
+      power:0,
+      constellations:['dawn_star','scholar_star'],
+      claimedKeys:[],
+    });
+    expect(clear.accepted).toBe(true);
+    if (!clear.accepted) return;
+
+    const records = [{ key:clear.key, grade:clear.grade, power:0 }];
+    const ascension = celestialAscensionProgress({
+      trialRecords:records,
+      blessingCount:0,
+      constellationCount:2,
+      sanctuaryGrandProgress:35,
+    });
+    const firstRiftThreshold = Math.min(...astralRiftDefinitions.map(rift => rift.ascensionThreshold));
+    expect(ascension).toBeGreaterThanOrEqual(firstRiftThreshold);
+    expect(nextAstralRiftUnlock(ascension)?.threshold ?? firstRiftThreshold).toBeGreaterThanOrEqual(firstRiftThreshold);
+
+    const honorShards = newlyEarnedCelestialHonors(records,[])
+      .reduce((sum,honor) => sum + honor.reward.starShards,0);
+    const rankShards = newlyEarnedAscensionRewards(ascension,[])
+      .reduce((sum,rank) => sum + rank.reward.starShards,0);
+    const scholarBlessing = astralBlessings.find(blessing => blessing.requiredTrial === 'scholar_trial')!;
+    expect(clear.starShards + honorShards + rankShards).toBeGreaterThanOrEqual(scholarBlessing.cost);
+  });
+
+  it('keeps the final Rift threshold reachable through legitimate monthly Astral records', () => {
+    const trials:AstralTrialId[] = ['scholar_trial','wayfarer_trial','guardian_trial','crown_trial'];
+    const records = Array.from({ length:12 },(_,index) => ({
+      key:`1-${index + 1}:${trials[index % trials.length]}`,
+      grade:'S' as const,
+      power:120,
+    }));
+    const ascension = celestialAscensionProgress({
+      trialRecords:records,
+      blessingCount:4,
+      constellationCount:5,
+      sanctuaryGrandProgress:65,
+    });
+    const finalThreshold = Math.max(...astralRiftDefinitions.map(rift => rift.ascensionThreshold));
+
+    expect(ascension).toBeGreaterThanOrEqual(finalThreshold);
+    expect(nextAstralRiftUnlock(ascension)).toBeNull();
+  });
+
+  it('never reissues permanent Celestial rewards after their claim ids are recorded', () => {
+    const trials:AstralTrialId[] = ['scholar_trial','wayfarer_trial','guardian_trial','crown_trial'];
+    const records = Array.from({ length:12 },(_,index) => ({
+      key:`1-${index + 1}:${trials[index % trials.length]}`,
+      grade:'S' as const,
+      power:120,
+    }));
+    const claimedHonors = ['first_light','full_cycle','perfect_cycle','twelve_trials'] as const;
+    const claimedRanks = ['awakened','stellar','empyrean','transcendent'] as const;
+
+    expect(newlyEarnedCelestialHonors(records,claimedHonors)).toEqual([]);
+    expect(newlyEarnedAscensionRewards(83,claimedRanks)).toEqual([]);
+  });
+});

--- a/src/season-shop-progression.test.ts
+++ b/src/season-shop-progression.test.ts
@@ -24,7 +24,7 @@ describe('season shop progression', () => {
     expect(recovery.inventory.herb_tea).toBe(ready.inventory.herb_tea + 1);
     expect(recovery.inventory.star_cookie).toBe(ready.inventory.star_cookie + 1);
     const cache = reducer(recovery,{ type:'PURCHASE_SEASON_OFFER', offerId:'expedition_cache' });
-    expect(cache.expeditionMaterials).toEqual({ star_bark:2, arcane_shard:2, wind_pearl:2 });
+    expect(cache.expeditionMaterials).toEqual({ star_bark:3, arcane_shard:3, wind_pearl:3 });
   });
 
   it('returns the identical state when purchase is unaffordable or exhausted', () => {

--- a/src/season-shop.test.ts
+++ b/src/season-shop.test.ts
@@ -6,7 +6,7 @@ describe('season shop', () => {
     expect(seasonShopOffers('1-spring').map(offer => [offer.id, offer.cost, offer.limit])).toEqual([
       ['gold_pouch',20,2],
       ['recovery_bundle',25,1],
-      ['expedition_cache',30,1],
+      ['expedition_cache',30,6],
       ['seasonal_keepsake',40,1],
       ['spring_garden_pack',18,1],
     ]);
@@ -77,7 +77,7 @@ describe('season shop', () => {
     }));
     expect(resolveSeasonPurchase({ seasonKey:'1-spring', offerId:'expedition_cache', tokens:99, purchaseKeys:[] })).toEqual(expect.objectContaining({
       accepted:true,
-      reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false },
+      reward:{ gold:0, inventory:{}, materials:{ star_bark:3, arcane_shard:3, wind_pearl:3 }, keepsake:false },
     }));
     expect(resolveSeasonPurchase({ seasonKey:'1-spring', offerId:'seasonal_keepsake', tokens:99, purchaseKeys:[] })).toEqual(expect.objectContaining({
       accepted:true,

--- a/src/season-shop.test.ts
+++ b/src/season-shop.test.ts
@@ -15,6 +15,10 @@ describe('season shop', () => {
     expect(seasonShopOffers('1-winter').at(-1)?.id).toBe('winter_starlight_cache');
   });
 
+  it('makes the Sanctuary use of the shared material cache explicit', () => {
+    expect(seasonShopOffers('1-spring').find(offer => offer.id === 'expedition_cache')?.label).toBe('원정·성소 재료 상자');
+  });
+
   it('resolves a valid purchase and emits a deterministic purchase key', () => {
     const result = resolveSeasonPurchase({ seasonKey:'1-spring', offerId:'gold_pouch', tokens:40, purchaseKeys:[] });
     expect(result).toEqual({
@@ -23,6 +27,37 @@ describe('season shop', () => {
       purchaseKey:seasonPurchaseKey('1-spring','gold_pouch',1),
       reward:{ gold:300, inventory:{}, materials:{}, keepsake:false },
     });
+  });
+
+  it('uses the first free purchase ordinal when purchase history is sparse', () => {
+    const secondKey = seasonPurchaseKey('1-spring','gold_pouch',2);
+    const result = resolveSeasonPurchase({
+      seasonKey:'1-spring',
+      offerId:'gold_pouch',
+      tokens:40,
+      purchaseKeys:[secondKey],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      accepted:true,
+      purchaseKey:seasonPurchaseKey('1-spring','gold_pouch',1),
+    }));
+    expect(result.accepted && result.purchaseKey).not.toBe(secondKey);
+  });
+
+  it('deduplicates repeated purchase keys before applying the season limit', () => {
+    const firstKey = seasonPurchaseKey('1-spring','gold_pouch',1);
+    const result = resolveSeasonPurchase({
+      seasonKey:'1-spring',
+      offerId:'gold_pouch',
+      tokens:40,
+      purchaseKeys:[firstKey,firstKey],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      accepted:true,
+      purchaseKey:seasonPurchaseKey('1-spring','gold_pouch',2),
+    }));
   });
 
   it('rejects a purchase when tokens are insufficient', () => {

--- a/src/season-shop.test.ts
+++ b/src/season-shop.test.ts
@@ -6,13 +6,17 @@ describe('season shop', () => {
     expect(seasonShopOffers('1-spring').map(offer => [offer.id, offer.cost, offer.limit])).toEqual([
       ['gold_pouch',20,2],
       ['recovery_bundle',25,1],
-      ['expedition_cache',30,1],
+      ['expedition_cache',30,6],
       ['seasonal_keepsake',40,1],
       ['spring_garden_pack',18,1],
     ]);
     expect(seasonShopOffers('1-summer').at(-1)?.id).toBe('summer_lake_cache');
     expect(seasonShopOffers('1-autumn').at(-1)?.id).toBe('autumn_arcane_cache');
     expect(seasonShopOffers('1-winter').at(-1)?.id).toBe('winter_starlight_cache');
+  });
+
+  it('makes the Sanctuary use of the shared material cache explicit', () => {
+    expect(seasonShopOffers('1-spring').find(offer => offer.id === 'expedition_cache')?.label).toBe('원정·성소 재료 상자');
   });
 
   it('resolves a valid purchase and emits a deterministic purchase key', () => {
@@ -23,6 +27,37 @@ describe('season shop', () => {
       purchaseKey:seasonPurchaseKey('1-spring','gold_pouch',1),
       reward:{ gold:300, inventory:{}, materials:{}, keepsake:false },
     });
+  });
+
+  it('uses the first free purchase ordinal when purchase history is sparse', () => {
+    const secondKey = seasonPurchaseKey('1-spring','gold_pouch',2);
+    const result = resolveSeasonPurchase({
+      seasonKey:'1-spring',
+      offerId:'gold_pouch',
+      tokens:40,
+      purchaseKeys:[secondKey],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      accepted:true,
+      purchaseKey:seasonPurchaseKey('1-spring','gold_pouch',1),
+    }));
+    expect(result.accepted && result.purchaseKey).not.toBe(secondKey);
+  });
+
+  it('deduplicates repeated purchase keys before applying the season limit', () => {
+    const firstKey = seasonPurchaseKey('1-spring','gold_pouch',1);
+    const result = resolveSeasonPurchase({
+      seasonKey:'1-spring',
+      offerId:'gold_pouch',
+      tokens:40,
+      purchaseKeys:[firstKey,firstKey],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      accepted:true,
+      purchaseKey:seasonPurchaseKey('1-spring','gold_pouch',2),
+    }));
   });
 
   it('rejects a purchase when tokens are insufficient', () => {
@@ -42,7 +77,7 @@ describe('season shop', () => {
     }));
     expect(resolveSeasonPurchase({ seasonKey:'1-spring', offerId:'expedition_cache', tokens:99, purchaseKeys:[] })).toEqual(expect.objectContaining({
       accepted:true,
-      reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false },
+      reward:{ gold:0, inventory:{}, materials:{ star_bark:3, arcane_shard:3, wind_pearl:3 }, keepsake:false },
     }));
     expect(resolveSeasonPurchase({ seasonKey:'1-spring', offerId:'seasonal_keepsake', tokens:99, purchaseKeys:[] })).toEqual(expect.objectContaining({
       accepted:true,

--- a/src/season-shop.ts
+++ b/src/season-shop.ts
@@ -22,7 +22,7 @@ export type SeasonShopOffer = { id:SeasonShopOfferId; label:string; cost:number;
 const coreOffers:SeasonShopOffer[] = [
   { id:'gold_pouch', label:'수호자 골드 주머니', cost:20, limit:2, reward:{ gold:300, inventory:{}, materials:{}, keepsake:false } },
   { id:'recovery_bundle', label:'루나 회복 꾸러미', cost:25, limit:1, reward:{ gold:0, inventory:{ herb_tea:1, star_cookie:1 }, materials:{}, keepsake:false } },
-  { id:'expedition_cache', label:'원정 재료 상자', cost:30, limit:1, reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false } },
+  { id:'expedition_cache', label:'원정·성소 재료 상자', cost:30, limit:1, reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false } },
   { id:'seasonal_keepsake', label:'계절 기념품', cost:40, limit:1, reward:{ gold:0, inventory:{}, materials:{}, keepsake:true } },
 ];
 
@@ -57,12 +57,22 @@ export function resolveSeasonPurchase(input:{ seasonKey:SeasonJourneyKey; offerI
   const offer = seasonShopOffers(input.seasonKey).find(item => item.id === input.offerId);
   if (!offer) return { accepted:false as const };
   const prefix = `${input.seasonKey}:${offer.id}:`;
-  const used = input.purchaseKeys.filter(key => key.startsWith(prefix)).length;
-  if (used >= offer.limit || input.tokens < offer.cost) return { accepted:false as const };
+  const usedOrdinals = new Set<number>();
+  for (const key of input.purchaseKeys) {
+    if (!key.startsWith(prefix)) continue;
+    const rawOrdinal = key.slice(prefix.length);
+    if (!/^\d+$/.test(rawOrdinal)) continue;
+    const ordinal = Number(rawOrdinal);
+    if (ordinal >= 1 && ordinal <= offer.limit) usedOrdinals.add(ordinal);
+  }
+  if (usedOrdinals.size >= offer.limit || input.tokens < offer.cost) return { accepted:false as const };
+  let nextOrdinal = 1;
+  while (usedOrdinals.has(nextOrdinal) && nextOrdinal <= offer.limit) nextOrdinal += 1;
+  if (nextOrdinal > offer.limit) return { accepted:false as const };
   return {
     accepted:true as const,
     tokens:input.tokens - offer.cost,
-    purchaseKey:seasonPurchaseKey(input.seasonKey,offer.id,used + 1),
+    purchaseKey:seasonPurchaseKey(input.seasonKey,offer.id,nextOrdinal),
     reward:offer.reward,
   };
 }

--- a/src/season-shop.ts
+++ b/src/season-shop.ts
@@ -22,7 +22,7 @@ export type SeasonShopOffer = { id:SeasonShopOfferId; label:string; cost:number;
 const coreOffers:SeasonShopOffer[] = [
   { id:'gold_pouch', label:'수호자 골드 주머니', cost:20, limit:2, reward:{ gold:300, inventory:{}, materials:{}, keepsake:false } },
   { id:'recovery_bundle', label:'루나 회복 꾸러미', cost:25, limit:1, reward:{ gold:0, inventory:{ herb_tea:1, star_cookie:1 }, materials:{}, keepsake:false } },
-  { id:'expedition_cache', label:'원정 재료 상자', cost:30, limit:1, reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false } },
+  { id:'expedition_cache', label:'원정·성소 재료 상자', cost:30, limit:6, reward:{ gold:0, inventory:{}, materials:{ star_bark:3, arcane_shard:3, wind_pearl:3 }, keepsake:false } },
   { id:'seasonal_keepsake', label:'계절 기념품', cost:40, limit:1, reward:{ gold:0, inventory:{}, materials:{}, keepsake:true } },
 ];
 
@@ -57,12 +57,22 @@ export function resolveSeasonPurchase(input:{ seasonKey:SeasonJourneyKey; offerI
   const offer = seasonShopOffers(input.seasonKey).find(item => item.id === input.offerId);
   if (!offer) return { accepted:false as const };
   const prefix = `${input.seasonKey}:${offer.id}:`;
-  const used = input.purchaseKeys.filter(key => key.startsWith(prefix)).length;
-  if (used >= offer.limit || input.tokens < offer.cost) return { accepted:false as const };
+  const usedOrdinals = new Set<number>();
+  for (const key of input.purchaseKeys) {
+    if (!key.startsWith(prefix)) continue;
+    const rawOrdinal = key.slice(prefix.length);
+    if (!/^\d+$/.test(rawOrdinal)) continue;
+    const ordinal = Number(rawOrdinal);
+    if (ordinal >= 1 && ordinal <= offer.limit) usedOrdinals.add(ordinal);
+  }
+  if (usedOrdinals.size >= offer.limit || input.tokens < offer.cost) return { accepted:false as const };
+  let nextOrdinal = 1;
+  while (usedOrdinals.has(nextOrdinal) && nextOrdinal <= offer.limit) nextOrdinal += 1;
+  if (nextOrdinal > offer.limit) return { accepted:false as const };
   return {
     accepted:true as const,
     tokens:input.tokens - offer.cost,
-    purchaseKey:seasonPurchaseKey(input.seasonKey,offer.id,used + 1),
+    purchaseKey:seasonPurchaseKey(input.seasonKey,offer.id,nextOrdinal),
     reward:offer.reward,
   };
 }

--- a/src/season-shop.ts
+++ b/src/season-shop.ts
@@ -22,7 +22,7 @@ export type SeasonShopOffer = { id:SeasonShopOfferId; label:string; cost:number;
 const coreOffers:SeasonShopOffer[] = [
   { id:'gold_pouch', label:'수호자 골드 주머니', cost:20, limit:2, reward:{ gold:300, inventory:{}, materials:{}, keepsake:false } },
   { id:'recovery_bundle', label:'루나 회복 꾸러미', cost:25, limit:1, reward:{ gold:0, inventory:{ herb_tea:1, star_cookie:1 }, materials:{}, keepsake:false } },
-  { id:'expedition_cache', label:'원정·성소 재료 상자', cost:30, limit:1, reward:{ gold:0, inventory:{}, materials:{ star_bark:2, arcane_shard:2, wind_pearl:2 }, keepsake:false } },
+  { id:'expedition_cache', label:'원정·성소 재료 상자', cost:30, limit:6, reward:{ gold:0, inventory:{}, materials:{ star_bark:3, arcane_shard:3, wind_pearl:3 }, keepsake:false } },
   { id:'seasonal_keepsake', label:'계절 기념품', cost:40, limit:1, reward:{ gold:0, inventory:{}, materials:{}, keepsake:true } },
 ];
 

--- a/src/weekly-directives.test.ts
+++ b/src/weekly-directives.test.ts
@@ -42,4 +42,36 @@ describe('weekly directives', () => {
     const repeat = advanceWeeklyDirectives(directives, progress, { kind:target.counter === 'high_grade' ? 'expedition' : target.counter, grade:'S' }, rewarded, '1-4-1');
     expect(repeat.completed.map(item => item.id)).not.toContain(target.id);
   });
+
+  it('recovers a completed directive when its weekly reward key is missing', () => {
+    const directives = weeklyDirectives(1,4,1);
+    const target = directives[0];
+    const progress = Object.fromEntries(directives.map(item => [item.id, item.id === target.id ? target.target : 0]));
+    const result = advanceWeeklyDirectives(
+      directives,
+      progress,
+      { kind:'training', grade:'B' },
+      [],
+      '1-4-1',
+    );
+
+    expect(result.completed.map(item => item.id)).toContain(target.id);
+    expect(result.reward).toEqual(target.reward);
+  });
+
+  it('does not recover a completed directive after its weekly reward key exists', () => {
+    const directives = weeklyDirectives(1,4,1);
+    const target = directives[0];
+    const progress = Object.fromEntries(directives.map(item => [item.id, item.id === target.id ? target.target : 0]));
+    const result = advanceWeeklyDirectives(
+      directives,
+      progress,
+      { kind:'training', grade:'B' },
+      [`1-4-1:${target.id}`],
+      '1-4-1',
+    );
+
+    expect(result.completed.map(item => item.id)).not.toContain(target.id);
+    expect(result.reward).toEqual({ journeyPoints:0, tokens:0 });
+  });
 });

--- a/src/weekly-directives.test.ts
+++ b/src/weekly-directives.test.ts
@@ -19,6 +19,39 @@ describe('weekly directives', () => {
     expect(weeklyDirectives(1,4,1).map(item => item.id)).not.toEqual(weeklyDirectives(1,4,2).map(item => item.id));
   });
 
+  it('never assigns two directives that reward the same action counter in one week', () => {
+    for (let year = 1; year <= 3; year += 1) {
+      for (let month = 1; month <= 12; month += 1) {
+        for (let week = 1; week <= 4; week += 1) {
+          const directives = weeklyDirectives(year,month,week);
+          expect(new Set(directives.map(item => item.counter)).size).toBe(directives.length);
+        }
+      }
+    }
+  });
+
+  it('never lets one player action advance more than one assigned directive', () => {
+    const events = [
+      { kind:'training' as const, grade:'B' as const },
+      { kind:'outing' as const, grade:'B' as const },
+      { kind:'gift' as const, grade:'B' as const },
+      { kind:'expedition' as const, grade:'S' as const },
+    ];
+    for (let year = 1; year <= 3; year += 1) {
+      for (let month = 1; month <= 12; month += 1) {
+        for (let week = 1; week <= 4; week += 1) {
+          const directives = weeklyDirectives(year,month,week);
+          const progress = Object.fromEntries(directives.map(item => [item.id, 0]));
+          for (const event of events) {
+            const result = advanceWeeklyDirectives(directives,progress,event);
+            const advanced = directives.filter(item => (result.progress[item.id] ?? 0) > 0);
+            expect(advanced.length).toBeLessThanOrEqual(1);
+          }
+        }
+      }
+    }
+  });
+
   it('advances only matching directives and caps progress at targets', () => {
     const directives = weeklyDirectives(1,4,1);
     const expedition = directives.find(item => item.counter === 'expedition');
@@ -41,5 +74,37 @@ describe('weekly directives', () => {
     const rewarded = [`1-4-1:${target.id}`];
     const repeat = advanceWeeklyDirectives(directives, progress, { kind:target.counter === 'high_grade' ? 'expedition' : target.counter, grade:'S' }, rewarded, '1-4-1');
     expect(repeat.completed.map(item => item.id)).not.toContain(target.id);
+  });
+
+  it('recovers a completed directive when its weekly reward key is missing', () => {
+    const directives = weeklyDirectives(1,4,1);
+    const target = directives[0];
+    const progress = Object.fromEntries(directives.map(item => [item.id, item.id === target.id ? target.target : 0]));
+    const result = advanceWeeklyDirectives(
+      directives,
+      progress,
+      { kind:'training', grade:'B' },
+      [],
+      '1-4-1',
+    );
+
+    expect(result.completed.map(item => item.id)).toContain(target.id);
+    expect(result.reward).toEqual(target.reward);
+  });
+
+  it('does not recover a completed directive after its weekly reward key exists', () => {
+    const directives = weeklyDirectives(1,4,1);
+    const target = directives[0];
+    const progress = Object.fromEntries(directives.map(item => [item.id, item.id === target.id ? target.target : 0]));
+    const result = advanceWeeklyDirectives(
+      directives,
+      progress,
+      { kind:'training', grade:'B' },
+      [`1-4-1:${target.id}`],
+      '1-4-1',
+    );
+
+    expect(result.completed.map(item => item.id)).not.toContain(target.id);
+    expect(result.reward).toEqual({ journeyPoints:0, tokens:0 });
   });
 });

--- a/src/weekly-directives.test.ts
+++ b/src/weekly-directives.test.ts
@@ -19,6 +19,17 @@ describe('weekly directives', () => {
     expect(weeklyDirectives(1,4,1).map(item => item.id)).not.toEqual(weeklyDirectives(1,4,2).map(item => item.id));
   });
 
+  it('never assigns two directives that reward the same action counter in one week', () => {
+    for (let year = 1; year <= 3; year += 1) {
+      for (let month = 1; month <= 12; month += 1) {
+        for (let week = 1; week <= 4; week += 1) {
+          const directives = weeklyDirectives(year,month,week);
+          expect(new Set(directives.map(item => item.counter)).size).toBe(directives.length);
+        }
+      }
+    }
+  });
+
   it('advances only matching directives and caps progress at targets', () => {
     const directives = weeklyDirectives(1,4,1);
     const expedition = directives.find(item => item.counter === 'expedition');

--- a/src/weekly-directives.test.ts
+++ b/src/weekly-directives.test.ts
@@ -30,6 +30,28 @@ describe('weekly directives', () => {
     }
   });
 
+  it('never lets one player action advance more than one assigned directive', () => {
+    const events = [
+      { kind:'training' as const, grade:'B' as const },
+      { kind:'outing' as const, grade:'B' as const },
+      { kind:'gift' as const, grade:'B' as const },
+      { kind:'expedition' as const, grade:'S' as const },
+    ];
+    for (let year = 1; year <= 3; year += 1) {
+      for (let month = 1; month <= 12; month += 1) {
+        for (let week = 1; week <= 4; week += 1) {
+          const directives = weeklyDirectives(year,month,week);
+          const progress = Object.fromEntries(directives.map(item => [item.id, 0]));
+          for (const event of events) {
+            const result = advanceWeeklyDirectives(directives,progress,event);
+            const advanced = directives.filter(item => (result.progress[item.id] ?? 0) > 0);
+            expect(advanced.length).toBeLessThanOrEqual(1);
+          }
+        }
+      }
+    }
+  });
+
   it('advances only matching directives and caps progress at targets', () => {
     const directives = weeklyDirectives(1,4,1);
     const expedition = directives.find(item => item.counter === 'expedition');

--- a/src/weekly-directives.ts
+++ b/src/weekly-directives.ts
@@ -37,13 +37,17 @@ export function weeklyDirectiveKey(year:number, month:number, week:number) {
   return `${Math.max(1,Math.floor(year))}-${Math.max(1,Math.min(12,Math.floor(month)))}-${Math.max(1,Math.min(4,Math.floor(week)))}` as const;
 }
 
+function directiveActionGroup(counter:WeeklyDirectiveCounter) {
+  return counter === 'high_grade' ? 'expedition' : counter;
+}
+
 export function weeklyDirectives(year:number, month:number, week:number): WeeklyDirective[] {
   const seed = Math.max(0,Math.floor(year * 37 + month * 11 + week * 5));
   const result: WeeklyDirective[] = [];
   let cursor = seed % directivePool.length;
   while (result.length < 3) {
     const candidate = directivePool[cursor % directivePool.length];
-    if (!result.some(item => item.id === candidate.id)) result.push(candidate);
+    if (!result.some(item => item.id === candidate.id || directiveActionGroup(item.counter) === directiveActionGroup(candidate.counter))) result.push(candidate);
     cursor += 3;
   }
   return result;
@@ -70,13 +74,16 @@ export function advanceWeeklyDirectives(
     const before = Math.max(0,Math.floor(next[directive.id] ?? 0));
     const after = matches(directive,event) ? Math.min(directive.target,before + 1) : before;
     next[directive.id] = after;
-    if (before < directive.target && after >= directive.target) {
-      const rewardKey = key ? `${key}:${directive.id}` : null;
-      if (!rewardKey || !rewardedKeys.includes(rewardKey)) {
-        completed.push(directive);
-        journeyPoints += directive.reward.journeyPoints;
-        tokens += directive.reward.tokens;
-      }
+    const reached = after >= directive.target;
+    const justCompleted = before < directive.target && reached;
+    const rewardKey = key ? `${key}:${directive.id}` : null;
+    const shouldReward = key
+      ? reached && !rewardedKeys.includes(rewardKey!)
+      : justCompleted;
+    if (shouldReward) {
+      completed.push(directive);
+      journeyPoints += directive.reward.journeyPoints;
+      tokens += directive.reward.tokens;
     }
   }
 

--- a/src/weekly-directives.ts
+++ b/src/weekly-directives.ts
@@ -70,13 +70,16 @@ export function advanceWeeklyDirectives(
     const before = Math.max(0,Math.floor(next[directive.id] ?? 0));
     const after = matches(directive,event) ? Math.min(directive.target,before + 1) : before;
     next[directive.id] = after;
-    if (before < directive.target && after >= directive.target) {
-      const rewardKey = key ? `${key}:${directive.id}` : null;
-      if (!rewardKey || !rewardedKeys.includes(rewardKey)) {
-        completed.push(directive);
-        journeyPoints += directive.reward.journeyPoints;
-        tokens += directive.reward.tokens;
-      }
+    const reached = after >= directive.target;
+    const justCompleted = before < directive.target && reached;
+    const rewardKey = key ? `${key}:${directive.id}` : null;
+    const shouldReward = key
+      ? reached && !rewardedKeys.includes(rewardKey!)
+      : justCompleted;
+    if (shouldReward) {
+      completed.push(directive);
+      journeyPoints += directive.reward.journeyPoints;
+      tokens += directive.reward.tokens;
     }
   }
 

--- a/src/weekly-directives.ts
+++ b/src/weekly-directives.ts
@@ -37,13 +37,17 @@ export function weeklyDirectiveKey(year:number, month:number, week:number) {
   return `${Math.max(1,Math.floor(year))}-${Math.max(1,Math.min(12,Math.floor(month)))}-${Math.max(1,Math.min(4,Math.floor(week)))}` as const;
 }
 
+function directiveActionGroup(counter:WeeklyDirectiveCounter) {
+  return counter === 'high_grade' ? 'expedition' : counter;
+}
+
 export function weeklyDirectives(year:number, month:number, week:number): WeeklyDirective[] {
   const seed = Math.max(0,Math.floor(year * 37 + month * 11 + week * 5));
   const result: WeeklyDirective[] = [];
   let cursor = seed % directivePool.length;
   while (result.length < 3) {
     const candidate = directivePool[cursor % directivePool.length];
-    if (!result.some(item => item.id === candidate.id || item.counter === candidate.counter)) result.push(candidate);
+    if (!result.some(item => item.id === candidate.id || directiveActionGroup(item.counter) === directiveActionGroup(candidate.counter))) result.push(candidate);
     cursor += 3;
   }
   return result;

--- a/src/weekly-directives.ts
+++ b/src/weekly-directives.ts
@@ -43,7 +43,7 @@ export function weeklyDirectives(year:number, month:number, week:number): Weekly
   let cursor = seed % directivePool.length;
   while (result.length < 3) {
     const candidate = directivePool[cursor % directivePool.length];
-    if (!result.some(item => item.id === candidate.id)) result.push(candidate);
+    if (!result.some(item => item.id === candidate.id || item.counter === candidate.counter)) result.push(candidate);
     cursor += 3;
   }
   return result;


### PR DESCRIPTION
Verification-only PR. Clean two-parent source state: integration/v2@db25f0e18471550cda2242021887051eb7c830e9 + work/season-meta@e2827e4e41a5f969a930a5f3b9a57c8c8fc59e19, plus the 06-owned Season Shop progression expectation update to the current 3/3/3 contract. Do not merge this verify PR. Ordered gate: Targeted Season -> Season suite -> Full test -> TypeScript -> Production build.