### PR TITLE
05 Hub UI next-wave: compact mobile UX

### DIFF
--- a/src/layered-home-mobile.css
+++ b/src/layered-home-mobile.css
@@ -16,6 +16,11 @@
   .layered-home .lh-dialogue{bottom:calc(17.2% + env(safe-area-inset-bottom)*.35)}
 }
 
+@media(max-width:390px) and (max-height:650px){
+  .layered-home .lh-primary-action{min-height:48px;padding:5px 10px}
+  .layered-home .lh-primary-action span{display:none}
+}
+
 @media(max-width:340px){
   .layered-home .lh-shortcuts{width:58%;gap:.5%}
   .layered-home .lh-goal{width:31%}

--- a/src/layered-home-ui.test.ts
+++ b/src/layered-home-ui.test.ts
@@ -56,6 +56,12 @@ describe('Layered Home mobile UI contract', () => {
     expect(mobileCss).toContain('.layered-home .lh-goal{width:31%}');
   });
 
+  it('keeps the primary CTA readable at 360x640 without three stacked text rows', () => {
+    expect(mobileCss).toContain('@media(max-width:390px) and (max-height:650px)');
+    expect(mobileCss).toContain('.layered-home .lh-primary-action span{display:none}');
+    expect(mobileCss).toContain('.layered-home .lh-primary-action{min-height:48px;padding:5px 10px}');
+  });
+
   it('keeps tap controls and panel scrolling on deliberate touch gestures', () => {
     expect(homeCss).toContain('touch-action:manipulation');
     expect(panelCss).toMatch(/\.lh-panel-list\{[^}]*touch-action:pan-y/);


### PR DESCRIPTION
Next-wave UI-only work from integration/v2@edd0ca99537ed92c7993969166b80c269f3aced8.

## Completed cycle 1 — 360x640 CTA compression
RED: f14285212a8a82e1025fb2b2d11d868f400aad25 / CI #1227 failed on the new compact-CTA contract.
GREEN: aee8ea43c7e4e67adac12af28781aaee4176aabd / CI #1230 success.

Change scope:
- src/layered-home-mobile.css: at <=390px and <=650px, keep the primary CTA at 48px minimum and hide tertiary detail text so Korean CTA labels do not become a cramped three-row block.
- src/layered-home-ui.test.ts: regression contract.

Verification:
- layered-home-ui: 21/21 GREEN
- full suite: 317 files / 1098 tests GREEN
- TypeScript via production build: GREEN
- production build: GREEN, 182 modules transformed

Reviewed without extra delta because existing coverage is already adequate: 390x844, 430px long-copy clipping, 100dvh fallback/override, Safe Area, 44px touch targets.

Next confirmed UI gap: major Raising/World/Season/Expedition overlays restore focus but do not currently provide a consistent ESC/back close path. This will be the next TDD target.

Constraints: no game rule/reward/unlock changes; preserve World logic in GuardianExpeditionOverlay and Tactical behavior in tactical-battle.css; no main merge; no production deploy.