### PR TITLE
verify: frozen World next after Season QA integration

### DIFF
--- a/src/GuardianExpeditionOverlay.tsx
+++ b/src/GuardianExpeditionOverlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { currentAdvancedTalents, masteryLevel, type ExpeditionActionCounts, type ExpeditionCraftingRecipeId, type ExpeditionRelicId, type ExpeditionStageId, type GameState } from './game';
-import { applyExpeditionAction, finishExpeditionBattle, startExpeditionBattle, type ExpeditionActionKind, type ExpeditionBattleState } from './expedition-combat';
+import { applyExpeditionAction, EXPEDITION_ACTION_LIMIT, finishExpeditionBattle, startExpeditionBattle, type ExpeditionActionKind, type ExpeditionBattleState } from './expedition-combat';
 import { canCraft, craftingRecipes } from './expedition-crafting';
 import { expeditionDiscoveryDefinitions } from './expedition-discoveries';
 import { expeditionRegionDefinitions, expeditionStageDefinitions, isExpeditionStageCleared, isExpeditionStageUnlocked, nextExpeditionStage } from './expedition-regions';
@@ -67,6 +67,7 @@ function Battle({ state, stageId, onFinish, onCancel }: {
     return () => window.clearInterval(timer);
   }, []);
   const accuracy = 1 - Math.min(1, Math.abs(0.5 - needle) * 2);
+  const actionLimitReached = battle.actionCount >= EXPEDITION_ACTION_LIMIT;
   const act = (kind: ExpeditionActionKind) => {
     setBattle(current => applyExpeditionAction(current, kind, accuracy, input));
     setFlash(accuracy > 0.72 ? 'PERFECT!' : accuracy > 0.45 ? 'GOOD!' : 'MISS');
@@ -83,11 +84,11 @@ function Battle({ state, stageId, onFinish, onCancel }: {
       <div className="expedition-timing"><i className="sweet"/><em style={{ transform: `rotate(${needle * 360}deg)` }}/>{flash && <img src="/assets/effects/success_burst.png" alt=""/>}<b>{flash}</b></div>
     </div>
     <div className="expedition-actions">
-      <button onClick={() => act('attack')}><b>공격</b><span>근력 · 사냥 숙련</span></button>
-      <button onClick={() => act('dodge')}><b>회피</b><span>침착함 · 휴식 숙련</span></button>
-      <button onClick={() => act('charge')}><b>기 모으기</b><span>마력 · 마법 숙련</span></button>
+      <button disabled={actionLimitReached} onClick={() => act('attack')}><b>공격</b><span>근력 · 사냥 숙련</span></button>
+      <button disabled={actionLimitReached} onClick={() => act('dodge')}><b>회피</b><span>침착함 · 휴식 숙련</span></button>
+      <button disabled={actionLimitReached} onClick={() => act('charge')}><b>기 모으기</b><span>마력 · 마법 숙련</span></button>
     </div>
-    <button className="expedition-finish" disabled={battle.actionCount < 3} onClick={() => onFinish(battle)}>원정 결과 확인</button>
+    <button className="expedition-finish" disabled={battle.actionCount < EXPEDITION_ACTION_LIMIT} onClick={() => onFinish(battle)}>원정 결과 확인</button>
   </section>;
 }
 

--- a/src/calling-depth-effects.test.ts
+++ b/src/calling-depth-effects.test.ts
@@ -9,6 +9,8 @@ import {
 describe('Calling depth effects', () => {
   it('builds stable monthly legend reward keys', () => {
     expect(legendRewardKey(2, 7, 'vanguard_legend')).toBe('2-7:vanguard_legend');
+    expect(legendRewardKey(0, 99, 'vanguard_legend')).toBe('1-12:vanguard_legend');
+    expect(legendRewardKey(Number.NaN, Number.POSITIVE_INFINITY, 'vanguard_legend')).toBe('1-1:vanguard_legend');
   });
 
   it('accelerates discovery eligibility only with Pathfinder eye', () => {

--- a/src/calling-depth-effects.test.ts
+++ b/src/calling-depth-effects.test.ts
@@ -18,6 +18,12 @@ describe('Calling depth effects', () => {
     expect(effectivePathfinderExplorationXp(3, 'vanguard', ['pathfinder_eye'])).toBe(3);
   });
 
+  it('sanitizes malformed exploration xp before applying Pathfinder eye', () => {
+    expect(effectivePathfinderExplorationXp(Number.NaN, 'pathfinder', ['pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(Number.POSITIVE_INFINITY, 'pathfinder', ['pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(-50, 'pathfinder', ['pathfinder_eye'])).toBe(3);
+  });
+
   it('detects specialist Calling mastery from expedition actions', () => {
     expect(specialistMasteryCalling('vanguard', { attack:2, dodge:0, charge:0 }, { stageId:'forest_path', grade:'A', discovery:null, materialReward:1 })).toBe('vanguard');
     expect(specialistMasteryCalling('arcanist', { attack:0, dodge:0, charge:1 }, { stageId:'forest_path', grade:'S', discovery:null, materialReward:2 })).toBe('arcanist');

--- a/src/calling-depth-effects.test.ts
+++ b/src/calling-depth-effects.test.ts
@@ -87,4 +87,15 @@ describe('Calling depth effects', () => {
     expect(result.stressDelta).toBe(4);
     expect(result.applied).toContain('heart_anchor');
   });
+
+  it('does not leak non-finite fatigue or stress deltas from expedition Calling rewards', () => {
+    const result = applyExpeditionCallingRewards({
+      year:1, month:4, calling:null, traits:[], signatures:[], legendRewardKeys:[],
+      stageId:'forest_path', grade:'A', firstClear:false, discovery:null, regionCompleted:null, materialReward:1,
+      fatigueDelta:Number.NaN, stressDelta:Number.POSITIVE_INFINITY,
+    });
+
+    expect(result.fatigueDelta).toBe(0);
+    expect(result.stressDelta).toBe(0);
+  });
 });

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -20,16 +20,20 @@ export function effectivePathfinderExplorationXp(
   return safeXp + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
 }
 
+function hasValidAction(value:number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
 export function specialistMasteryCalling(
   calling:GuardianCallingId | null,
   actions:ExpeditionActionCounts,
   summary:{ stageId:ExpeditionStageId; grade:ExpeditionGrade; discovery:string | null; materialReward:number },
 ): GuardianCallingId | null {
   if (!calling || summary.grade === 'C') return null;
-  if (calling === 'vanguard') return actions.attack > 0 ? calling : null;
-  if (calling === 'arcanist') return actions.charge > 0 ? calling : null;
-  if (calling === 'caretaker') return actions.dodge > 0 ? calling : null;
-  const acted = actions.attack + actions.dodge + actions.charge > 0;
+  if (calling === 'vanguard') return hasValidAction(actions.attack) ? calling : null;
+  if (calling === 'arcanist') return hasValidAction(actions.charge) ? calling : null;
+  if (calling === 'caretaker') return hasValidAction(actions.dodge) ? calling : null;
+  const acted = hasValidAction(actions.attack) || hasValidAction(actions.dodge) || hasValidAction(actions.charge);
   const explored = summary.discovery !== null || summary.materialReward > 0 || isBossStage(summary.stageId);
   return acted && explored ? calling : null;
 }

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -65,8 +65,9 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
   const applied:string[] = [];
   const signatures = new Set(input.signatures);
   const traits = new Set(input.traits);
+  const successful = input.grade !== 'C';
 
-  if (input.calling === 'pathfinder') {
+  if (successful && input.calling === 'pathfinder') {
     if (signatures.has('trail_reading') && input.firstClear && input.materialReward > 0) {
       extraMaterial += 1;
       applied.push('trail_reading');
@@ -82,7 +83,7 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
     applied.push('heart_anchor');
   }
 
-  if (input.calling === 'vanguard' && traits.has('vanguard_legend') && input.firstClear) {
+  if (successful && input.calling === 'vanguard' && traits.has('vanguard_legend') && input.firstClear) {
     const key = legendRewardKey(input.year, input.month, 'vanguard_legend');
     if (!legendRewardKeys.includes(key)) {
       fatigueDelta = Math.max(0, fatigueDelta - 2);

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -16,7 +16,8 @@ export function effectivePathfinderExplorationXp(
   calling:GuardianCallingId | null,
   traits:readonly GrowthTraitId[],
 ): number {
-  return Math.max(0, Math.floor(xp)) + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
+  const safeXp = Math.max(0, Math.floor(Number.isFinite(xp) ? xp : 0));
+  return safeXp + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
 }
 
 export function specialistMasteryCalling(

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -6,7 +6,9 @@ import type { GuardianCallingId } from './guardian-callings';
 import type { GrowthTraitId } from './growth-traits';
 
 export function legendRewardKey(year:number, month:number, effectId:string): string {
-  return `${Math.max(1, Math.floor(year))}-${Math.max(1, Math.min(12, Math.floor(month)))}:${effectId}`;
+  const safeYear = Math.max(1, Math.floor(Number.isFinite(year) ? year : 1));
+  const safeMonth = Math.max(1, Math.min(12, Math.floor(Number.isFinite(month) ? month : 1)));
+  return `${safeYear}-${safeMonth}:${effectId}`;
 }
 
 export function effectivePathfinderExplorationXp(

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -60,10 +60,14 @@ export type ExpeditionCallingRewardResult = {
   applied:string[];
 };
 
+function safeNonNegativeDelta(value:number): number {
+  return Math.max(0, Number.isFinite(value) ? value : 0);
+}
+
 export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput): ExpeditionCallingRewardResult {
   let extraMaterial = 0;
-  let fatigueDelta = Math.max(0, input.fatigueDelta);
-  let stressDelta = Math.max(0, input.stressDelta);
+  let fatigueDelta = safeNonNegativeDelta(input.fatigueDelta);
+  let stressDelta = safeNonNegativeDelta(input.stressDelta);
   let legendRewardKeys = [...input.legendRewardKeys];
   const applied:string[] = [];
   const signatures = new Set(input.signatures);

--- a/src/calling-mastery-sanitization.test.ts
+++ b/src/calling-mastery-sanitization.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { specialistMasteryCalling } from './calling-depth-effects';
+
+describe('Calling mastery action sanitation', () => {
+  it('does not treat non-finite or negative raw action counts as valid specialist actions', () => {
+    const summary = { stageId:'forest_path' as const, grade:'A' as const, discovery:null, materialReward:1 };
+
+    expect(specialistMasteryCalling('vanguard', {
+      attack:Number.POSITIVE_INFINITY,
+      dodge:0,
+      charge:0,
+    }, summary)).toBeNull();
+    expect(specialistMasteryCalling('arcanist', {
+      attack:0,
+      dodge:0,
+      charge:Number.NaN,
+    }, summary)).toBeNull();
+    expect(specialistMasteryCalling('caretaker', {
+      attack:0,
+      dodge:-1,
+      charge:0,
+    }, summary)).toBeNull();
+    expect(specialistMasteryCalling('pathfinder', {
+      attack:Number.POSITIVE_INFINITY,
+      dodge:Number.NaN,
+      charge:-1,
+    }, { ...summary, discovery:'forest_echo' })).toBeNull();
+  });
+});

--- a/src/calling-world-progression.test.ts
+++ b/src/calling-world-progression.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyExpeditionCallingRewards,
+  specialistMasteryCalling,
+} from './calling-depth-effects';
+
+const failedSummary = {
+  stageId:'forest_guardian' as const,
+  grade:'C' as const,
+  discovery:null,
+  materialReward:0,
+};
+
+describe('Calling effects on expedition world progression', () => {
+  it('never grants specialist mastery from a failed C expedition', () => {
+    expect(specialistMasteryCalling('pathfinder', { attack:1, dodge:1, charge:1 }, failedSummary)).toBeNull();
+    expect(specialistMasteryCalling('vanguard', { attack:3, dodge:0, charge:0 }, failedSummary)).toBeNull();
+    expect(specialistMasteryCalling('arcanist', { attack:0, dodge:0, charge:3 }, failedSummary)).toBeNull();
+  });
+
+  it('does not grant Pathfinder success rewards from stale success fields on a C expedition', () => {
+    const result = applyExpeditionCallingRewards({
+      year:1,
+      month:4,
+      calling:'pathfinder',
+      traits:['pathfinder_legend'],
+      signatures:['trail_reading','star_compass'],
+      legendRewardKeys:[],
+      stageId:'forest_guardian',
+      grade:'C',
+      firstClear:true,
+      discovery:null,
+      regionCompleted:'starlight_forest',
+      materialReward:2,
+      fatigueDelta:8,
+      stressDelta:6,
+    });
+
+    expect(result.extraMaterial).toBe(0);
+    expect(result.legendRewardKeys).toEqual([]);
+    expect(result.applied).toEqual([]);
+  });
+
+  it('does not consume the Vanguard monthly legend reward from a stale firstClear on C', () => {
+    const result = applyExpeditionCallingRewards({
+      year:1,
+      month:4,
+      calling:'vanguard',
+      traits:['vanguard_legend'],
+      signatures:[],
+      legendRewardKeys:[],
+      stageId:'forest_guardian',
+      grade:'C',
+      firstClear:true,
+      discovery:null,
+      regionCompleted:null,
+      materialReward:0,
+      fatigueDelta:8,
+      stressDelta:6,
+    });
+
+    expect(result.fatigueDelta).toBe(8);
+    expect(result.legendRewardKeys).toEqual([]);
+    expect(result.applied).toEqual([]);
+  });
+
+  it('does not consume the Arcanist monthly legend reward on C even with stale discovery data', () => {
+    const result = applyExpeditionCallingRewards({
+      year:1,
+      month:4,
+      calling:'arcanist',
+      traits:['arcanist_legend'],
+      signatures:[],
+      legendRewardKeys:[],
+      stageId:'city_square',
+      grade:'C',
+      firstClear:true,
+      discovery:'city_square_discovery',
+      regionCompleted:null,
+      materialReward:2,
+      fatigueDelta:8,
+      stressDelta:6,
+    });
+
+    expect(result.stressDelta).toBe(6);
+    expect(result.legendRewardKeys).toEqual([]);
+    expect(result.applied).toEqual([]);
+  });
+});

--- a/src/expedition-attempt-boundaries.test.ts
+++ b/src/expedition-attempt-boundaries.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { expeditionStageDefinitions } from './expedition-regions';
+import { resolveExpeditionFinish } from './expedition-rewards';
+import { emptyExpeditionPersistentState } from './expedition-state';
+
+const base = () => ({
+  ...emptyExpeditionPersistentState(),
+  gold: 1000,
+  gems: 10,
+  affection: 50,
+  inventory: { star_cookie: 0, herb_tea: 0, fox_charm: 0 },
+});
+
+describe('expedition accepted / cleared boundary matrix', () => {
+  it('rejects every stage except the first when its prerequisite is missing', () => {
+    for (const stage of expeditionStageDefinitions.slice(1)) {
+      const before = base();
+      const result = resolveExpeditionFinish(before, stage.id, stage.target * 2);
+
+      expect(result.summary.accepted, stage.id).toBe(false);
+      expect(result.summary.cleared, stage.id).toBe(false);
+      expect(result.summary.firstClear, stage.id).toBe(false);
+      expect(result.state, stage.id).toEqual(before);
+    }
+  });
+
+  it('keeps C failure separate from exact-B clear across all nine sequential stages', () => {
+    let state = base();
+
+    for (const stage of expeditionStageDefinitions) {
+      const bThreshold = Math.ceil(stage.target * 0.8);
+      const cScore = bThreshold - 1;
+      const beforeFailure = state;
+      const failed = resolveExpeditionFinish(beforeFailure, stage.id, cScore);
+
+      expect(failed.summary.accepted, `${stage.id}: C accepted`).toBe(true);
+      expect(failed.summary.grade, `${stage.id}: C grade`).toBe('C');
+      expect(failed.summary.cleared, `${stage.id}: C cleared`).toBe(false);
+      expect(failed.summary.firstClear, `${stage.id}: C firstClear`).toBe(false);
+      expect(failed.summary.materialReward, `${stage.id}: C material`).toBe(0);
+      expect(failed.summary.discovery, `${stage.id}: C discovery`).toBeNull();
+      expect(failed.summary.storyUnlocked, `${stage.id}: C story`).toBe(false);
+      expect(failed.summary.bossBadge, `${stage.id}: C badge`).toBe(false);
+      expect(failed.summary.regionCompleted, `${stage.id}: C region`).toBeNull();
+      expect(failed.state.rewardedExpeditionStages, `${stage.id}: C reward marker`).toEqual(beforeFailure.rewardedExpeditionStages);
+      expect(failed.state.expeditionStoryEntries, `${stage.id}: C story marker`).toEqual(beforeFailure.expeditionStoryEntries);
+      expect(failed.state.expeditionDiscoveries, `${stage.id}: C discovery marker`).toEqual(beforeFailure.expeditionDiscoveries);
+      expect(failed.state.gold, `${stage.id}: C gold`).toBe(beforeFailure.gold);
+      expect(failed.state.gems, `${stage.id}: C gems`).toBe(beforeFailure.gems);
+
+      const cleared = resolveExpeditionFinish(failed.state, stage.id, bThreshold);
+      expect(cleared.summary.accepted, `${stage.id}: B accepted`).toBe(true);
+      expect(cleared.summary.grade, `${stage.id}: B grade`).toBe('B');
+      expect(cleared.summary.cleared, `${stage.id}: B cleared`).toBe(true);
+      expect(cleared.summary.firstClear, `${stage.id}: B firstClear`).toBe(true);
+      expect(cleared.state.expeditionRecords[stage.id].cleared, `${stage.id}: durable clear`).toBe(true);
+
+      const failedReplay = resolveExpeditionFinish(cleared.state, stage.id, cScore);
+      expect(failedReplay.summary.accepted, `${stage.id}: failed replay accepted`).toBe(true);
+      expect(failedReplay.summary.cleared, `${stage.id}: failed replay cleared`).toBe(false);
+      expect(failedReplay.summary.firstClear, `${stage.id}: failed replay firstClear`).toBe(false);
+      expect(failedReplay.summary.materialReward, `${stage.id}: failed replay material`).toBe(0);
+      expect(failedReplay.state.expeditionRecords[stage.id].cleared, `${stage.id}: failed replay durable clear`).toBe(true);
+      expect(failedReplay.state.gold, `${stage.id}: failed replay gold`).toBe(cleared.state.gold);
+      expect(failedReplay.state.gems, `${stage.id}: failed replay gems`).toBe(cleared.state.gems);
+
+      state = cleared.state;
+    }
+  });
+});

--- a/src/expedition-boss-retry.test.ts
+++ b/src/expedition-boss-retry.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { resolveExpeditionFinish } from './expedition-rewards';
+import { isExpeditionStageUnlocked } from './expedition-regions';
+import { emptyExpeditionPersistentState } from './expedition-state';
+
+const base = () => ({
+  ...emptyExpeditionPersistentState(),
+  gold: 1000,
+  gems: 10,
+  affection: 50,
+  inventory: { star_cookie: 0, herb_tea: 0, fox_charm: 0 },
+});
+
+describe('expedition boss failure and retry', () => {
+  it('keeps the next region locked on failure, then unlocks and rewards exactly once on retry clear', () => {
+    let state = base();
+    state = resolveExpeditionFinish(state, 'forest_path', 700).state;
+    state = resolveExpeditionFinish(state, 'forest_glade', 850).state;
+
+    const beforeBoss = state;
+    const failed = resolveExpeditionFinish(beforeBoss, 'forest_guardian', 100);
+
+    expect(failed.summary.accepted).toBe(true);
+    expect(failed.summary.cleared).toBe(false);
+    expect(failed.summary.firstClear).toBe(false);
+    expect(failed.summary.bossBadge).toBe(false);
+    expect(failed.summary.regionCompleted).toBeNull();
+    expect(failed.summary.relicsUnlocked).toEqual([]);
+    expect(failed.state.gold).toBe(beforeBoss.gold);
+    expect(failed.state.gems).toBe(beforeBoss.gems);
+    expect(failed.state.rewardedExpeditionStages).not.toContain('forest_guardian');
+    expect(failed.state.rewardedExpeditionRegions).not.toContain('starlight_forest');
+    expect(failed.state.ownedExpeditionRelics).not.toContain('bond_locket');
+    expect(failed.state.ownedExpeditionRelics).not.toContain('moonfang_charm');
+    expect(isExpeditionStageUnlocked('city_square', failed.state.expeditionRecords)).toBe(false);
+
+    const cleared = resolveExpeditionFinish(failed.state, 'forest_guardian', 840);
+
+    expect(cleared.summary.grade).toBe('B');
+    expect(cleared.summary.cleared).toBe(true);
+    expect(cleared.summary.firstClear).toBe(true);
+    expect(cleared.summary.bossBadge).toBe(true);
+    expect(cleared.summary.regionCompleted).toBe('starlight_forest');
+    expect(cleared.state.gold).toBe(failed.state.gold + 500);
+    expect(cleared.state.gems).toBe(failed.state.gems + 2);
+    expect(cleared.state.rewardedExpeditionStages.filter(id => id === 'forest_guardian')).toHaveLength(1);
+    expect(cleared.state.rewardedExpeditionRegions.filter(id => id === 'starlight_forest')).toHaveLength(1);
+    expect(cleared.state.ownedExpeditionRelics).toEqual(expect.arrayContaining(['bond_locket', 'moonfang_charm']));
+    expect(isExpeditionStageUnlocked('city_square', cleared.state.expeditionRecords)).toBe(true);
+
+    const replay = resolveExpeditionFinish(cleared.state, 'forest_guardian', 1050);
+
+    expect(replay.summary.cleared).toBe(true);
+    expect(replay.summary.firstClear).toBe(false);
+    expect(replay.summary.bossBadge).toBe(false);
+    expect(replay.summary.regionCompleted).toBeNull();
+    expect(replay.state.gold).toBe(cleared.state.gold);
+    expect(replay.state.gems).toBe(cleared.state.gems);
+    expect(replay.state.rewardedExpeditionStages.filter(id => id === 'forest_guardian')).toHaveLength(1);
+    expect(replay.state.rewardedExpeditionRegions.filter(id => id === 'starlight_forest')).toHaveLength(1);
+    expect(replay.state.ownedExpeditionRelics.filter(id => id === 'bond_locket')).toHaveLength(1);
+    expect(replay.state.ownedExpeditionRelics.filter(id => id === 'moonfang_charm')).toHaveLength(1);
+    expect(isExpeditionStageUnlocked('city_square', replay.state.expeditionRecords)).toBe(true);
+  });
+});

--- a/src/expedition-combat.test.ts
+++ b/src/expedition-combat.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { applyExpeditionAction, finishExpeditionBattle, startExpeditionBattle } from './expedition-combat';
+import {
+  applyExpeditionAction,
+  EXPEDITION_ACTION_LIMIT,
+  finishExpeditionBattle,
+  startExpeditionBattle,
+} from './expedition-combat';
 
 const base = {
   strength: 40,
@@ -56,6 +61,23 @@ describe('expedition combat', () => {
     expect(attackTalented.score).toBeGreaterThan(attackPlain.score);
     expect(chargeTalented.score).toBeGreaterThan(chargePlain.score);
     expect(dodgeTalented.pressureGuard).toBeGreaterThan(dodgePlain.pressureGuard);
+  });
+
+  it('stops accepting actions after the fixed expedition action limit', () => {
+    let battle = startExpeditionBattle('forest_path');
+    for (let index = 0; index < EXPEDITION_ACTION_LIMIT; index += 1) {
+      battle = applyExpeditionAction(battle, 'attack', 1, base);
+    }
+
+    const capped = battle;
+    const overflow = applyExpeditionAction(capped, 'charge', 1, {
+      ...base,
+      magic: 999,
+      magicMastery: 99,
+    });
+
+    expect(capped.actionCount).toBe(EXPEDITION_ACTION_LIMIT);
+    expect(overflow).toEqual(capped);
   });
 
   it('finishes with stage pressure converted to fatigue and stress deltas', () => {

--- a/src/expedition-combat.test.ts
+++ b/src/expedition-combat.test.ts
@@ -19,6 +19,18 @@ const base = {
   relics: { attack: 0, charge: 0, dodge: 0, all: 0 },
 };
 
+function runActions(
+  stageId: Parameters<typeof startExpeditionBattle>[0],
+  kind: 'attack' | 'charge',
+  input: Parameters<typeof applyExpeditionAction>[3],
+) {
+  let battle = startExpeditionBattle(stageId);
+  for (let index = 0; index < EXPEDITION_ACTION_LIMIT; index += 1) {
+    battle = applyExpeditionAction(battle, kind, 1, input);
+  }
+  return finishExpeditionBattle(battle);
+}
+
 describe('expedition combat', () => {
   it('makes attack respond strongly to strength and hunt mastery', () => {
     const low = applyExpeditionAction(startExpeditionBattle('forest_path'), 'attack', 0.8, base);
@@ -78,6 +90,45 @@ describe('expedition combat', () => {
 
     expect(capped.actionCount).toBe(EXPEDITION_ACTION_LIMIT);
     expect(overflow).toEqual(capped);
+  });
+
+  it('keeps the final boss gated from a low-growth build', () => {
+    const result = runActions('lake_tempest', 'attack', {
+      ...base,
+      strength: 40,
+      huntMastery: 2,
+    });
+    expect(result.grade).toBe('C');
+  });
+
+  it('lets a developed expedition specialist reach A on the final boss', () => {
+    const result = runActions('lake_tempest', 'attack', {
+      ...base,
+      strength: 80,
+      huntMastery: 5,
+      condition: 'energetic',
+      talents: ['hunter_instinct', 'guardian_strike'],
+      relics: { attack: 0.10, charge: 0, dodge: 0, all: 0.05 },
+      identity: { attack: 0.10, dodge: 0, charge: 0 },
+      signatures: ['rally_strike', 'guardian_breaker'],
+      boss: true,
+    });
+    expect(result.grade).toMatch(/^[SA]$/);
+  });
+
+  it('lets a fully developed expedition specialist reach S on the final boss', () => {
+    const result = runActions('lake_tempest', 'attack', {
+      ...base,
+      strength: 100,
+      huntMastery: 5,
+      condition: 'energetic',
+      talents: ['hunter_instinct', 'guardian_strike'],
+      relics: { attack: 0.10, charge: 0, dodge: 0, all: 0.05 },
+      identity: { attack: 0.10, dodge: 0, charge: 0 },
+      signatures: ['rally_strike', 'guardian_breaker'],
+      boss: true,
+    });
+    expect(result.grade).toBe('S');
   });
 
   it('finishes with stage pressure converted to fatigue and stress deltas', () => {

--- a/src/expedition-combat.test.ts
+++ b/src/expedition-combat.test.ts
@@ -125,6 +125,28 @@ describe('expedition combat', () => {
     expect(overflow).toEqual(finalLegalAction);
   });
 
+  it('does not leak non-finite combat inputs into transient battle or result state', () => {
+    const malformed = applyExpeditionAction(startExpeditionBattle('forest_path'), 'attack', Number.NaN, {
+      ...base,
+      strength: Number.POSITIVE_INFINITY,
+      fatigue: Number.NaN,
+      huntMastery: Number.NaN,
+      relics: { attack: Number.NaN, charge: 0, dodge: 0, all: Number.POSITIVE_INFINITY },
+    });
+    const result = finishExpeditionBattle({
+      ...malformed,
+      pressureGuard: Number.POSITIVE_INFINITY,
+    });
+
+    expect(Number.isFinite(malformed.score)).toBe(true);
+    expect(Number.isFinite(malformed.pressureGuard)).toBe(true);
+    expect(malformed.actionCount).toBe(1);
+    expect(Number.isFinite(result.score)).toBe(true);
+    expect(Number.isFinite(result.fatigueDelta)).toBe(true);
+    expect(Number.isFinite(result.stressDelta)).toBe(true);
+    expect(result.grade).toBe('C');
+  });
+
   it('keeps the final boss gated from a low-growth build', () => {
     const result = runActions('lake_tempest', 'attack', {
       ...base,

--- a/src/expedition-combat.test.ts
+++ b/src/expedition-combat.test.ts
@@ -109,6 +109,22 @@ describe('expedition combat', () => {
     expect(overflow).toEqual(staleReloadedBattle);
   });
 
+  it('repairs a stale low actionCount when one legal action remains', () => {
+    const staleReloadedBattle = {
+      ...startExpeditionBattle('forest_path'),
+      score: 300,
+      actionCount: 0,
+      actionKinds: { attack: 1, dodge: 1, charge: 0 },
+    };
+
+    const finalLegalAction = applyExpeditionAction(staleReloadedBattle, 'charge', 1, base);
+    const overflow = applyExpeditionAction(finalLegalAction, 'attack', 1, base);
+
+    expect(finalLegalAction.actionCount).toBe(EXPEDITION_ACTION_LIMIT);
+    expect(finalLegalAction.actionKinds).toEqual({ attack: 1, dodge: 1, charge: 1 });
+    expect(overflow).toEqual(finalLegalAction);
+  });
+
   it('keeps the final boss gated from a low-growth build', () => {
     const result = runActions('lake_tempest', 'attack', {
       ...base,

--- a/src/expedition-combat.test.ts
+++ b/src/expedition-combat.test.ts
@@ -122,6 +122,24 @@ describe('expedition combat', () => {
     expect(overflow).toEqual(malformedReloadedBattle);
   });
 
+  it('fails closed when reloaded action counters contain positive infinity', () => {
+    const malformedActionCount = {
+      ...startExpeditionBattle('forest_path'),
+      score: 500,
+      actionCount: Number.POSITIVE_INFINITY,
+      actionKinds: { attack: 0, dodge: 0, charge: 0 },
+    };
+    const malformedActionKinds = {
+      ...startExpeditionBattle('forest_path'),
+      score: 500,
+      actionCount: 0,
+      actionKinds: { attack: Number.POSITIVE_INFINITY, dodge: 0, charge: 0 },
+    };
+
+    expect(applyExpeditionAction(malformedActionCount, 'charge', 1, base)).toEqual(malformedActionCount);
+    expect(applyExpeditionAction(malformedActionKinds, 'charge', 1, base)).toEqual(malformedActionKinds);
+  });
+
   it('repairs a stale low actionCount when one legal action remains', () => {
     const staleReloadedBattle = {
       ...startExpeditionBattle('forest_path'),

--- a/src/expedition-combat.test.ts
+++ b/src/expedition-combat.test.ts
@@ -109,6 +109,19 @@ describe('expedition combat', () => {
     expect(overflow).toEqual(staleReloadedBattle);
   });
 
+  it('cannot bypass the action cap when a reloaded actionCount is NaN', () => {
+    const malformedReloadedBattle = {
+      ...startExpeditionBattle('forest_path'),
+      score: 500,
+      actionCount: Number.NaN,
+      actionKinds: { attack: 2, dodge: 1, charge: 0 },
+    };
+
+    const overflow = applyExpeditionAction(malformedReloadedBattle, 'charge', 1, base);
+
+    expect(overflow).toEqual(malformedReloadedBattle);
+  });
+
   it('repairs a stale low actionCount when one legal action remains', () => {
     const staleReloadedBattle = {
       ...startExpeditionBattle('forest_path'),

--- a/src/expedition-combat.test.ts
+++ b/src/expedition-combat.test.ts
@@ -92,6 +92,23 @@ describe('expedition combat', () => {
     expect(overflow).toEqual(capped);
   });
 
+  it('cannot bypass the action cap when a reloaded battle has a stale actionCount', () => {
+    const staleReloadedBattle = {
+      ...startExpeditionBattle('forest_path'),
+      score: 500,
+      actionCount: 0,
+      actionKinds: { attack: 2, dodge: 1, charge: 0 },
+    };
+
+    const overflow = applyExpeditionAction(staleReloadedBattle, 'charge', 1, {
+      ...base,
+      magic: 999,
+      magicMastery: 99,
+    });
+
+    expect(overflow).toEqual(staleReloadedBattle);
+  });
+
   it('keeps the final boss gated from a low-growth build', () => {
     const result = runActions('lake_tempest', 'attack', {
       ...base,

--- a/src/expedition-combat.ts
+++ b/src/expedition-combat.ts
@@ -50,8 +50,12 @@ const conditionMultiplier: Record<ExpeditionCombatCondition, number> = {
   tired: 0.86,
 };
 
+function finite(value: number, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
 function clamp(value: number, min: number, max: number) {
-  return Math.min(max, Math.max(min, value));
+  return Math.min(max, Math.max(min, finite(value, min)));
 }
 
 function stageFor(id: ExpeditionStageId) {
@@ -120,43 +124,47 @@ export function applyExpeditionAction(
   if (currentActionCount >= EXPEDITION_ACTION_LIMIT) return battle;
 
   const quality = 0.35 + clamp(accuracy, 0, 1) * 0.65;
-  const fatiguePenalty = clamp((Math.max(0, input.fatigue) - 25) / 220, 0, 0.28);
+  const fatiguePenalty = clamp((Math.max(0, finite(input.fatigue)) - 25) / 220, 0, 0.28);
   const readiness = conditionMultiplier[input.condition] * (1 - fatiguePenalty);
   const allBonus = clamp(input.relics.all, 0, 0.15);
   const advancedBonus = clamp(talentBonus(input.talents, kind), 0, 0.1);
   const identityBonus = clamp(input.identity?.[kind] ?? 0, 0, 0.1);
   const callingBonus = signatureBonus(battle, kind, input);
   const counts = withActionCount(battle, kind, currentActionCount);
+  const baseScore = Math.max(0, finite(battle.score));
+  const baseGuard = Math.max(0, finite(battle.pressureGuard));
 
   if (kind === 'dodge') {
     const dodgeBonus = clamp(input.relics.dodge, 0, 0.2);
-    const guard = (18 + input.calmness * 0.34 + input.restMastery * 4.5) * quality * readiness * (1 + allBonus + dodgeBonus + advancedBonus + identityBonus + callingBonus);
+    const guard = (18 + finite(input.calmness) * 0.34 + finite(input.restMastery) * 4.5) * quality * readiness * (1 + allBonus + dodgeBonus + advancedBonus + identityBonus + callingBonus);
     return {
       ...battle,
-      pressureGuard: battle.pressureGuard + Math.max(0, guard),
-      score: battle.score + Math.round(Math.max(0, guard) * 0.55),
+      pressureGuard: baseGuard + Math.max(0, finite(guard)),
+      score: baseScore + Math.round(Math.max(0, finite(guard)) * 0.55),
       ...counts,
     };
   }
 
   if (kind === 'attack') {
     const bonus = clamp(input.relics.attack, 0, 0.15);
-    const value = (70 + input.strength * 3.1 + input.huntMastery * 18) * quality * readiness * (1 + allBonus + bonus + advancedBonus + identityBonus + callingBonus);
-    return { ...battle, score: battle.score + Math.max(0, Math.round(value)), ...counts };
+    const value = (70 + finite(input.strength) * 3.1 + finite(input.huntMastery) * 18) * quality * readiness * (1 + allBonus + bonus + advancedBonus + identityBonus + callingBonus);
+    return { ...battle, pressureGuard: baseGuard, score: baseScore + Math.max(0, Math.round(finite(value))), ...counts };
   }
 
   const bonus = clamp(input.relics.charge, 0, 0.15);
-  const value = (68 + input.magic * 3.15 + input.magicMastery * 18) * quality * readiness * (1 + allBonus + bonus + advancedBonus + identityBonus + callingBonus);
-  return { ...battle, score: battle.score + Math.max(0, Math.round(value)), ...counts };
+  const value = (68 + finite(input.magic) * 3.15 + finite(input.magicMastery) * 18) * quality * readiness * (1 + allBonus + bonus + advancedBonus + identityBonus + callingBonus);
+  return { ...battle, pressureGuard: baseGuard, score: baseScore + Math.max(0, Math.round(finite(value))), ...counts };
 }
 
 export function finishExpeditionBattle(battle: ExpeditionBattleState): ExpeditionBattleResult {
   const stage = stageFor(battle.stageId);
-  const mitigatedPressure = Math.max(0, stage.pressure - battle.pressureGuard / 18);
+  const score = Math.max(0, Math.floor(finite(battle.score)));
+  const pressureGuard = Math.max(0, finite(battle.pressureGuard));
+  const mitigatedPressure = Math.max(0, stage.pressure - pressureGuard / 18);
   return {
     stageId: battle.stageId,
-    score: Math.max(0, Math.floor(battle.score)),
-    grade: expeditionGrade(battle.score, stage.target),
+    score,
+    grade: expeditionGrade(score, stage.target),
     fatigueDelta: Math.max(0, Math.round(mitigatedPressure * 0.72)),
     stressDelta: Math.max(0, Math.round(mitigatedPressure * 0.48)),
     actionKinds: { ...battle.actionKinds },

--- a/src/expedition-combat.ts
+++ b/src/expedition-combat.ts
@@ -54,6 +54,10 @@ function finite(value: number, fallback = 0) {
   return Number.isFinite(value) ? value : fallback;
 }
 
+function nonNegativeCount(value: number) {
+  return Math.max(0, Math.floor(finite(value)));
+}
+
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, finite(value, min)));
 }
@@ -92,11 +96,13 @@ function signatureBonus(battle: ExpeditionBattleState, kind: ExpeditionActionKin
 }
 
 function recordedActionCount(battle: ExpeditionBattleState): number {
-  return battle.actionKinds.attack + battle.actionKinds.dodge + battle.actionKinds.charge;
+  return nonNegativeCount(battle.actionKinds.attack)
+    + nonNegativeCount(battle.actionKinds.dodge)
+    + nonNegativeCount(battle.actionKinds.charge);
 }
 
 function usedActionCount(battle: ExpeditionBattleState): number {
-  return Math.max(battle.actionCount, recordedActionCount(battle));
+  return Math.max(nonNegativeCount(battle.actionCount), recordedActionCount(battle));
 }
 
 function withActionCount(
@@ -106,7 +112,7 @@ function withActionCount(
 ): Pick<ExpeditionBattleState, 'actionCount' | 'actionKinds'> {
   return {
     actionCount: currentActionCount + 1,
-    actionKinds: { ...battle.actionKinds, [kind]: battle.actionKinds[kind] + 1 },
+    actionKinds: { ...battle.actionKinds, [kind]: nonNegativeCount(battle.actionKinds[kind]) + 1 },
   };
 }
 

--- a/src/expedition-combat.ts
+++ b/src/expedition-combat.ts
@@ -41,6 +41,8 @@ export type ExpeditionBattleResult = {
   actionKinds: ExpeditionActionCounts;
 };
 
+export const EXPEDITION_ACTION_LIMIT = 3;
+
 const conditionMultiplier: Record<ExpeditionCombatCondition, number> = {
   energetic: 1.08,
   normal: 1,
@@ -102,6 +104,8 @@ export function applyExpeditionAction(
   accuracy: number,
   input: ExpeditionCombatInput,
 ): ExpeditionBattleState {
+  if (battle.actionCount >= EXPEDITION_ACTION_LIMIT) return battle;
+
   const quality = 0.35 + clamp(accuracy, 0, 1) * 0.65;
   const fatiguePenalty = clamp((Math.max(0, input.fatigue) - 25) / 220, 0, 0.28);
   const readiness = conditionMultiplier[input.condition] * (1 - fatiguePenalty);

--- a/src/expedition-combat.ts
+++ b/src/expedition-combat.ts
@@ -128,12 +128,12 @@ export function applyExpeditionAction(
 
   if (kind === 'attack') {
     const bonus = clamp(input.relics.attack, 0, 0.15);
-    const value = (70 + input.strength * 2.15 + input.huntMastery * 18) * quality * readiness * (1 + allBonus + bonus + advancedBonus + identityBonus + callingBonus);
+    const value = (70 + input.strength * 3.1 + input.huntMastery * 18) * quality * readiness * (1 + allBonus + bonus + advancedBonus + identityBonus + callingBonus);
     return { ...battle, score: battle.score + Math.max(0, Math.round(value)), ...counts };
   }
 
   const bonus = clamp(input.relics.charge, 0, 0.15);
-  const value = (68 + input.magic * 2.2 + input.magicMastery * 18) * quality * readiness * (1 + allBonus + bonus + advancedBonus + identityBonus + callingBonus);
+  const value = (68 + input.magic * 3.15 + input.magicMastery * 18) * quality * readiness * (1 + allBonus + bonus + advancedBonus + identityBonus + callingBonus);
   return { ...battle, score: battle.score + Math.max(0, Math.round(value)), ...counts };
 }
 

--- a/src/expedition-combat.ts
+++ b/src/expedition-combat.ts
@@ -87,9 +87,21 @@ function signatureBonus(battle: ExpeditionBattleState, kind: ExpeditionActionKin
   return clamp(bonus, 0, 0.16);
 }
 
-function withActionCount(battle: ExpeditionBattleState, kind: ExpeditionActionKind): Pick<ExpeditionBattleState, 'actionCount' | 'actionKinds'> {
+function recordedActionCount(battle: ExpeditionBattleState): number {
+  return battle.actionKinds.attack + battle.actionKinds.dodge + battle.actionKinds.charge;
+}
+
+function usedActionCount(battle: ExpeditionBattleState): number {
+  return Math.max(battle.actionCount, recordedActionCount(battle));
+}
+
+function withActionCount(
+  battle: ExpeditionBattleState,
+  kind: ExpeditionActionKind,
+  currentActionCount: number,
+): Pick<ExpeditionBattleState, 'actionCount' | 'actionKinds'> {
   return {
-    actionCount: battle.actionCount + 1,
+    actionCount: currentActionCount + 1,
     actionKinds: { ...battle.actionKinds, [kind]: battle.actionKinds[kind] + 1 },
   };
 }
@@ -104,7 +116,8 @@ export function applyExpeditionAction(
   accuracy: number,
   input: ExpeditionCombatInput,
 ): ExpeditionBattleState {
-  if (battle.actionCount >= EXPEDITION_ACTION_LIMIT) return battle;
+  const currentActionCount = usedActionCount(battle);
+  if (currentActionCount >= EXPEDITION_ACTION_LIMIT) return battle;
 
   const quality = 0.35 + clamp(accuracy, 0, 1) * 0.65;
   const fatiguePenalty = clamp((Math.max(0, input.fatigue) - 25) / 220, 0, 0.28);
@@ -113,7 +126,7 @@ export function applyExpeditionAction(
   const advancedBonus = clamp(talentBonus(input.talents, kind), 0, 0.1);
   const identityBonus = clamp(input.identity?.[kind] ?? 0, 0, 0.1);
   const callingBonus = signatureBonus(battle, kind, input);
-  const counts = withActionCount(battle, kind);
+  const counts = withActionCount(battle, kind, currentActionCount);
 
   if (kind === 'dodge') {
     const dodgeBonus = clamp(input.relics.dodge, 0, 0.2);

--- a/src/expedition-combat.ts
+++ b/src/expedition-combat.ts
@@ -59,6 +59,20 @@ function nonNegativeCount(value: number) {
   return Math.max(0, Math.floor(finite(value)));
 }
 
+function sanitizeResultActionKinds(actionKinds: ExpeditionActionCounts): ExpeditionActionCounts {
+  let remaining = EXPEDITION_ACTION_LIMIT;
+  const take = (value:number) => {
+    const count = Math.min(remaining, Math.max(0, Math.floor(Number.isFinite(value) ? value : 0)));
+    remaining -= count;
+    return count;
+  };
+  return {
+    attack:take(actionKinds.attack),
+    dodge:take(actionKinds.dodge),
+    charge:take(actionKinds.charge),
+  };
+}
+
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, finite(value, min)));
 }
@@ -174,6 +188,6 @@ export function finishExpeditionBattle(battle: ExpeditionBattleState): Expeditio
     grade: expeditionGrade(score, stage.target),
     fatigueDelta: Math.max(0, Math.round(mitigatedPressure * 0.72)),
     stressDelta: Math.max(0, Math.round(mitigatedPressure * 0.48)),
-    actionKinds: { ...battle.actionKinds },
+    actionKinds:sanitizeResultActionKinds(battle.actionKinds),
   };
 }

--- a/src/expedition-combat.ts
+++ b/src/expedition-combat.ts
@@ -55,6 +55,7 @@ function finite(value: number, fallback = 0) {
 }
 
 function nonNegativeCount(value: number) {
+  if (value === Number.POSITIVE_INFINITY) return EXPEDITION_ACTION_LIMIT;
   return Math.max(0, Math.floor(finite(value)));
 }
 

--- a/src/expedition-crafting.test.ts
+++ b/src/expedition-crafting.test.ts
@@ -87,4 +87,18 @@ describe('expedition crafting', () => {
     const materials = { star_bark: 4, arcane_shard: 0, wind_pearl: 0 };
     expect(canCraft('star_cookie_recipe', materials, { craftingMilestones:['crafted_star_cookie'] })).toBe(true);
   });
+
+  it('rejects non-finite material balances instead of enabling infinite crafting', () => {
+    const materials = { star_bark: Number.POSITIVE_INFINITY, arcane_shard: 3, wind_pearl: 3 };
+
+    expect(canCraft('star_cookie_recipe', materials)).toBe(false);
+    expect(applyCrafting('star_cookie_recipe', materials)).toEqual({
+      crafted: false,
+      materials,
+      gift: null,
+      relic: null,
+      milestone: null,
+    });
+    expect(canCraft('guardian_thread_recipe', materials)).toBe(false);
+  });
 });

--- a/src/expedition-crafting.test.ts
+++ b/src/expedition-crafting.test.ts
@@ -43,6 +43,46 @@ describe('expedition crafting', () => {
     })).toBe(false);
   });
 
+  it('blocks guardian thread recrafting from the milestone even if relic ownership is stale', () => {
+    const materials = { star_bark: 3, arcane_shard: 3, wind_pearl: 3 };
+    const result = applyCrafting('guardian_thread_recipe', materials, {
+      craftingMilestones:['crafted_guardian_thread'],
+      ownedRelics:[],
+    });
+
+    expect(result.crafted).toBe(false);
+    expect(result.materials).toEqual(materials);
+    expect(result.relic).toBeNull();
+    expect(result.milestone).toBeNull();
+  });
+
+  it('blocks guardian thread recrafting from relic ownership even if the milestone is stale', () => {
+    const materials = { star_bark: 3, arcane_shard: 3, wind_pearl: 3 };
+    const result = applyCrafting('guardian_thread_recipe', materials, {
+      craftingMilestones:[],
+      ownedRelics:['guardian_thread'],
+    });
+
+    expect(result.crafted).toBe(false);
+    expect(result.materials).toEqual(materials);
+    expect(result.relic).toBeNull();
+    expect(result.milestone).toBeNull();
+  });
+
+  it('fails guardian thread crafting atomically when any one material is short', () => {
+    const materials = { star_bark: 3, arcane_shard: 2, wind_pearl: 3 };
+    const result = applyCrafting('guardian_thread_recipe', materials);
+
+    expect(result).toEqual({
+      crafted: false,
+      materials,
+      gift: null,
+      relic: null,
+      milestone: null,
+    });
+    expect(materials).toEqual({ star_bark: 3, arcane_shard: 2, wind_pearl: 3 });
+  });
+
   it('keeps gift recipes repeatable after their milestone was recorded', () => {
     const materials = { star_bark: 4, arcane_shard: 0, wind_pearl: 0 };
     expect(canCraft('star_cookie_recipe', materials, { craftingMilestones:['crafted_star_cookie'] })).toBe(true);

--- a/src/expedition-crafting.ts
+++ b/src/expedition-crafting.ts
@@ -41,13 +41,17 @@ function isOneTimeRecipeCompleted(recipe: ExpeditionCraftingRecipe, progress: Ex
   ));
 }
 
+function hasValidMaterialBalances(materials: ExpeditionMaterials): boolean {
+  return expeditionMaterialIds.every(id => Number.isFinite(materials[id]) && materials[id] >= 0);
+}
+
 export function canCraft(
   recipeId: ExpeditionCraftingRecipeId,
   materials: ExpeditionMaterials,
   progress: ExpeditionCraftingProgress = {},
 ): boolean {
   const recipe = craftingRecipes.find(item => item.id === recipeId);
-  if (!recipe || isOneTimeRecipeCompleted(recipe, progress)) return false;
+  if (!recipe || isOneTimeRecipeCompleted(recipe, progress) || !hasValidMaterialBalances(materials)) return false;
   return expeditionMaterialIds.every(id => materials[id] >= (recipe.costs[id] ?? 0));
 }
 

--- a/src/expedition-failure-progression.test.ts
+++ b/src/expedition-failure-progression.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import { initialState, reducer } from './game';
 import { resolveExpeditionFinish } from './expedition-rewards';
+import { emptyExpeditionPersistentState } from './expedition-state';
+
+const rewardState = () => ({
+  ...emptyExpeditionPersistentState(),
+  gold: 1000,
+  gems: 10,
+  affection: 50,
+  inventory: { star_cookie: 0, herb_tea: 0, fox_charm: 0 },
+});
 
 describe('failed expedition progression semantics', () => {
   it('keeps accepted separate from cleared and does not emit success rewards for a C attempt', () => {
-    const resolved = resolveExpeditionFinish(initialState, 'forest_path', 100);
+    const before = rewardState();
+    const resolved = resolveExpeditionFinish(before, 'forest_path', 100);
 
     expect(resolved.summary.accepted).toBe(true);
     expect(resolved.summary.cleared).toBe(false);
@@ -17,12 +27,12 @@ describe('failed expedition progression semantics', () => {
     expect(resolved.summary.relicsUnlocked).toEqual([]);
     expect(resolved.summary.fullCompleted).toBe(false);
     expect(resolved.state.expeditionRecords.forest_path?.cleared).toBe(false);
-    expect(resolved.state.rewardedExpeditionStages).toEqual(initialState.rewardedExpeditionStages);
-    expect(resolved.state.expeditionStoryEntries).toEqual(initialState.expeditionStoryEntries);
-    expect(resolved.state.expeditionDiscoveries).toEqual(initialState.expeditionDiscoveries);
-    expect(resolved.state.expeditionMaterials).toEqual(initialState.expeditionMaterials);
-    expect(resolved.state.gold).toBe(initialState.gold);
-    expect(resolved.state.gems).toBe(initialState.gems);
+    expect(resolved.state.rewardedExpeditionStages).toEqual(before.rewardedExpeditionStages);
+    expect(resolved.state.expeditionStoryEntries).toEqual(before.expeditionStoryEntries);
+    expect(resolved.state.expeditionDiscoveries).toEqual(before.expeditionDiscoveries);
+    expect(resolved.state.expeditionMaterials).toEqual(before.expeditionMaterials);
+    expect(resolved.state.gold).toBe(before.gold);
+    expect(resolved.state.gems).toBe(before.gems);
   });
 
   it('does not record an accepted C attempt as successful world progression', () => {

--- a/src/expedition-failure-progression.test.ts
+++ b/src/expedition-failure-progression.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { initialState, reducer } from './game';
+import { resolveExpeditionFinish } from './expedition-rewards';
+
+describe('failed expedition progression semantics', () => {
+  it('keeps accepted separate from cleared and does not emit success rewards for a C attempt', () => {
+    const resolved = resolveExpeditionFinish(initialState, 'forest_path', 100);
+
+    expect(resolved.summary.accepted).toBe(true);
+    expect(resolved.summary.cleared).toBe(false);
+    expect(resolved.summary.firstClear).toBe(false);
+    expect(resolved.summary.materialReward).toBe(0);
+    expect(resolved.summary.discovery).toBeNull();
+    expect(resolved.summary.storyUnlocked).toBe(false);
+    expect(resolved.summary.bossBadge).toBe(false);
+    expect(resolved.summary.regionCompleted).toBeNull();
+    expect(resolved.summary.relicsUnlocked).toEqual([]);
+    expect(resolved.summary.fullCompleted).toBe(false);
+    expect(resolved.state.expeditionRecords.forest_path?.cleared).toBe(false);
+    expect(resolved.state.rewardedExpeditionStages).toEqual(initialState.rewardedExpeditionStages);
+    expect(resolved.state.expeditionStoryEntries).toEqual(initialState.expeditionStoryEntries);
+    expect(resolved.state.expeditionDiscoveries).toEqual(initialState.expeditionDiscoveries);
+    expect(resolved.state.expeditionMaterials).toEqual(initialState.expeditionMaterials);
+    expect(resolved.state.gold).toBe(initialState.gold);
+    expect(resolved.state.gems).toBe(initialState.gems);
+  });
+
+  it('does not record an accepted C attempt as successful world progression', () => {
+    const next = reducer(initialState, {
+      type: 'FINISH_EXPEDITION_STAGE',
+      stageId: 'forest_path',
+      score: 100,
+      actionKinds: { attack: 1, dodge: 1, charge: 1 },
+    });
+
+    expect(next.expeditionRecords.forest_path?.bestGrade).toBe('C');
+    expect(next.expeditionRecords.forest_path?.cleared).toBe(false);
+    expect(next.regionalRenown).toEqual(initialState.regionalRenown);
+    expect(next.expeditionSeasonScores).toEqual(initialState.expeditionSeasonScores);
+    expect(next.worldContractProgress).toEqual(initialState.worldContractProgress);
+    expect(next.rewardedWorldContracts).toEqual(initialState.rewardedWorldContracts);
+    expect(next.lastWorldProgress).toBeNull();
+  });
+});

--- a/src/expedition-partial-record-safety.test.ts
+++ b/src/expedition-partial-record-safety.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isExpeditionStageCleared,
+  isExpeditionStageUnlocked,
+  nextExpeditionStage,
+} from './expedition-regions';
+
+describe('partial expedition record safety', () => {
+  it('treats a missing stage record as uncleared instead of throwing', () => {
+    expect(isExpeditionStageCleared(undefined as any)).toBe(false);
+  });
+
+  it('keeps progression queries safe when the record map is partially missing after re-entry', () => {
+    const records = {} as any;
+
+    expect(isExpeditionStageUnlocked('forest_glade', records)).toBe(false);
+    expect(nextExpeditionStage(records)).toBe('forest_path');
+  });
+});

--- a/src/expedition-record-state-sanitization.test.ts
+++ b/src/expedition-record-state-sanitization.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { emptyExpeditionRecords, updateExpeditionRecord } from './expedition-regions';
+
+describe('expedition record state sanitation', () => {
+  it('repairs a malformed current record before applying a valid successful result', () => {
+    const records = emptyExpeditionRecords();
+    records.forest_path = {
+      bestScore: Number.NaN,
+      bestGrade: 'Z' as any,
+      cleared: false,
+    };
+
+    const next = updateExpeditionRecord(records, 'forest_path', 700, 700);
+
+    expect(next.forest_path).toEqual({
+      bestScore: 700,
+      bestGrade: 'A',
+      cleared: true,
+    });
+  });
+
+  it('does not let a malformed positive-infinity best score survive a worse valid replay', () => {
+    const records = emptyExpeditionRecords();
+    records.forest_path = {
+      bestScore: Number.POSITIVE_INFINITY,
+      bestGrade: 'B',
+      cleared: true,
+    };
+
+    const next = updateExpeditionRecord(records, 'forest_path', 600, 700);
+
+    expect(next.forest_path.bestScore).toBe(600);
+    expect(Number.isFinite(next.forest_path.bestScore)).toBe(true);
+    expect(next.forest_path.bestGrade).toBe('B');
+    expect(next.forest_path.cleared).toBe(true);
+  });
+});

--- a/src/expedition-regions.test.ts
+++ b/src/expedition-regions.test.ts
@@ -25,6 +25,14 @@ describe('guardian expedition world progression', () => {
     expect(expeditionGrade(799, 1000)).toBe('C');
   });
 
+  it('rejects non-finite scores instead of letting them grant or corrupt progression', () => {
+    expect(expeditionGrade(Number.POSITIVE_INFINITY, 1000)).toBe('C');
+    expect(expeditionGrade(Number.NaN, 1000)).toBe('C');
+
+    const records = updateExpeditionRecord(emptyExpeditionRecords(), 'forest_path', Number.NaN, 1000);
+    expect(records.forest_path).toEqual({ bestScore: 0, bestGrade: 'C', cleared: false });
+  });
+
   it('counts only B or better as a clear', () => {
     expect(isExpeditionStageCleared({ bestScore: 799, bestGrade: 'C', cleared: false })).toBe(false);
     expect(isExpeditionStageCleared({ bestScore: 800, bestGrade: 'B', cleared: true })).toBe(true);

--- a/src/expedition-regions.ts
+++ b/src/expedition-regions.ts
@@ -53,6 +53,11 @@ export const expeditionRegionDefinitions: ExpeditionRegionDefinition[] = [
 const stageOrder = expeditionStageDefinitions.map(stage => stage.id);
 const gradeRank: Record<ExpeditionGrade, number> = { C: 0, B: 1, A: 2, S: 3 };
 const safeScore = (score: number) => Number.isFinite(score) ? Math.max(0, score) : 0;
+const safeGrade = (grade: unknown): ExpeditionGrade => (
+  typeof grade === 'string' && Object.prototype.hasOwnProperty.call(gradeRank, grade)
+    ? grade as ExpeditionGrade
+    : 'C'
+);
 
 export function emptyExpeditionRecords(): Record<ExpeditionStageId, ExpeditionStageRecord> {
   return Object.fromEntries(stageOrder.map(id => [id, { bestScore: 0, bestGrade: 'C', cleared: false }])) as Record<ExpeditionStageId, ExpeditionStageRecord>;
@@ -83,17 +88,20 @@ export function updateExpeditionRecord(
   score: number,
   target: number,
 ): Record<ExpeditionStageId, ExpeditionStageRecord> {
-  const current = records[stageId];
+  const stored = records[stageId] ?? { bestScore: 0, bestGrade: 'C', cleared: false };
+  const currentScore = Math.floor(safeScore(stored.bestScore));
+  const currentGrade = safeGrade(stored.bestGrade);
+  const currentCleared = stored.cleared === true || gradeRank[currentGrade] >= gradeRank.B;
   const normalizedScore = safeScore(score);
   const grade = expeditionGrade(normalizedScore, target);
-  const betterScore = Math.max(current.bestScore, Math.floor(normalizedScore));
-  const betterGrade = gradeRank[grade] > gradeRank[current.bestGrade] ? grade : current.bestGrade;
+  const betterScore = Math.max(currentScore, Math.floor(normalizedScore));
+  const betterGrade = gradeRank[grade] > gradeRank[currentGrade] ? grade : currentGrade;
   return {
     ...records,
     [stageId]: {
       bestScore: betterScore,
       bestGrade: betterGrade,
-      cleared: current.cleared || gradeRank[grade] >= gradeRank.B,
+      cleared: currentCleared || gradeRank[grade] >= gradeRank.B,
     },
   };
 }

--- a/src/expedition-regions.ts
+++ b/src/expedition-regions.ts
@@ -52,14 +52,15 @@ export const expeditionRegionDefinitions: ExpeditionRegionDefinition[] = [
 
 const stageOrder = expeditionStageDefinitions.map(stage => stage.id);
 const gradeRank: Record<ExpeditionGrade, number> = { C: 0, B: 1, A: 2, S: 3 };
+const safeScore = (score: number) => Number.isFinite(score) ? Math.max(0, score) : 0;
 
 export function emptyExpeditionRecords(): Record<ExpeditionStageId, ExpeditionStageRecord> {
   return Object.fromEntries(stageOrder.map(id => [id, { bestScore: 0, bestGrade: 'C', cleared: false }])) as Record<ExpeditionStageId, ExpeditionStageRecord>;
 }
 
 export function expeditionGrade(score: number, target: number): ExpeditionGrade {
-  const safeTarget = Math.max(1, target);
-  const ratio = Math.max(0, score) / safeTarget;
+  const safeTarget = Math.max(1, Number.isFinite(target) ? target : 1);
+  const ratio = safeScore(score) / safeTarget;
   if (ratio >= 1.2) return 'S';
   if (ratio >= 1) return 'A';
   if (ratio >= 0.8) return 'B';
@@ -83,8 +84,9 @@ export function updateExpeditionRecord(
   target: number,
 ): Record<ExpeditionStageId, ExpeditionStageRecord> {
   const current = records[stageId];
-  const grade = expeditionGrade(score, target);
-  const betterScore = Math.max(current.bestScore, Math.max(0, Math.floor(score)));
+  const normalizedScore = safeScore(score);
+  const grade = expeditionGrade(normalizedScore, target);
+  const betterScore = Math.max(current.bestScore, Math.floor(normalizedScore));
   const betterGrade = gradeRank[grade] > gradeRank[current.bestGrade] ? grade : current.bestGrade;
   return {
     ...records,

--- a/src/expedition-regions.ts
+++ b/src/expedition-regions.ts
@@ -72,8 +72,9 @@ export function expeditionGrade(score: number, target: number): ExpeditionGrade 
   return 'C';
 }
 
-export function isExpeditionStageCleared(record: ExpeditionStageRecord): boolean {
-  return record.cleared || gradeRank[record.bestGrade] >= gradeRank.B;
+export function isExpeditionStageCleared(record: ExpeditionStageRecord | undefined): boolean {
+  if (!record) return false;
+  return record.cleared === true || gradeRank[safeGrade(record.bestGrade)] >= gradeRank.B;
 }
 
 export function isExpeditionStageUnlocked(stageId: ExpeditionStageId, records: Record<ExpeditionStageId, ExpeditionStageRecord>): boolean {

--- a/src/expedition-relic-hydration-evidence.test.ts
+++ b/src/expedition-relic-hydration-evidence.test.ts
@@ -16,6 +16,19 @@ describe('expedition relic hydration evidence', () => {
     expect(isExpeditionStageUnlocked('city_square', state.expeditionRecords)).toBe(true);
   });
 
+  it('uses the forest boss bond locket as durable evidence that the forest chain was cleared', () => {
+    const state = hydrateExpeditionPersistentState({
+      expeditionRecords: {},
+      ownedExpeditionRelics: ['bond_locket'],
+      rewardedExpeditionRegions: [],
+    });
+
+    for (const stageId of expeditionRegionDefinitions[0].stages) {
+      expect(state.expeditionRecords[stageId].cleared).toBe(true);
+    }
+    expect(isExpeditionStageUnlocked('city_square', state.expeditionRecords)).toBe(true);
+  });
+
   it('uses the full-completion relic as durable evidence that all expedition stages were cleared', () => {
     const state = hydrateExpeditionPersistentState({
       expeditionRecords: {},

--- a/src/expedition-relic-hydration-evidence.test.ts
+++ b/src/expedition-relic-hydration-evidence.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { expeditionRegionDefinitions, isExpeditionStageUnlocked } from './expedition-regions';
+import { hydrateExpeditionPersistentState } from './expedition-state';
+
+describe('expedition relic hydration evidence', () => {
+  it('uses a region completion relic as durable evidence that its region stages were cleared', () => {
+    const state = hydrateExpeditionPersistentState({
+      expeditionRecords: {},
+      ownedExpeditionRelics: ['moonfang_charm'],
+      rewardedExpeditionRegions: [],
+    });
+
+    for (const stageId of expeditionRegionDefinitions[0].stages) {
+      expect(state.expeditionRecords[stageId].cleared).toBe(true);
+    }
+    expect(isExpeditionStageUnlocked('city_square', state.expeditionRecords)).toBe(true);
+  });
+
+  it('uses the full-completion relic as durable evidence that all expedition stages were cleared', () => {
+    const state = hydrateExpeditionPersistentState({
+      expeditionRecords: {},
+      ownedExpeditionRelics: ['explorer_compass'],
+      rewardedExpeditionRegions: [],
+      rewardedExpeditionStages: [],
+    });
+
+    for (const region of expeditionRegionDefinitions) {
+      for (const stageId of region.stages) {
+        expect(state.expeditionRecords[stageId].cleared).toBe(true);
+      }
+    }
+  });
+});

--- a/src/expedition-result-reentry.test.ts
+++ b/src/expedition-result-reentry.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { resolveExpeditionFinish } from './expedition-rewards';
+import { emptyExpeditionPersistentState, hydrateExpeditionPersistentState } from './expedition-state';
+
+const base = () => ({
+  ...emptyExpeditionPersistentState(),
+  gold: 1000,
+  gems: 10,
+  affection: 50,
+  inventory: { star_cookie: 0, herb_tea: 0, fox_charm: 0 },
+});
+
+describe('expedition result reload and re-entry', () => {
+  it('does not replay boss or region one-time rewards after persistent-state hydration', () => {
+    let state = base();
+    state = resolveExpeditionFinish(state, 'forest_path', 700).state;
+    state = resolveExpeditionFinish(state, 'forest_glade', 850).state;
+    const first = resolveExpeditionFinish(state, 'forest_guardian', 1050);
+
+    const persisted = hydrateExpeditionPersistentState(JSON.parse(JSON.stringify(first.state)));
+    const reloaded = { ...first.state, ...persisted };
+    const replay = resolveExpeditionFinish(reloaded, 'forest_guardian', 1260);
+
+    expect(replay.summary.accepted).toBe(true);
+    expect(replay.summary.cleared).toBe(true);
+    expect(replay.summary.firstClear).toBe(false);
+    expect(replay.summary.bossBadge).toBe(false);
+    expect(replay.summary.regionCompleted).toBeNull();
+    expect(replay.state.gold).toBe(first.state.gold);
+    expect(replay.state.gems).toBe(first.state.gems);
+    expect(replay.state.rewardedExpeditionStages.filter(id => id === 'forest_guardian')).toHaveLength(1);
+    expect(replay.state.rewardedExpeditionRegions.filter(id => id === 'starlight_forest')).toHaveLength(1);
+    expect(replay.state.expeditionStoryEntries.filter(id => id === 'forest_guardian')).toHaveLength(1);
+    expect(replay.state.ownedExpeditionRelics.filter(id => id === 'bond_locket')).toHaveLength(1);
+    expect(replay.state.ownedExpeditionRelics.filter(id => id === 'moonfang_charm')).toHaveLength(1);
+  });
+});

--- a/src/expedition-result-sanitization.test.ts
+++ b/src/expedition-result-sanitization.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { specialistMasteryCalling } from './calling-depth-effects';
+import { finishExpeditionBattle, startExpeditionBattle } from './expedition-combat';
+
+describe('expedition result action sanitization', () => {
+  it('does not leak malformed action counts into Calling mastery decisions', () => {
+    const result = finishExpeditionBattle({
+      ...startExpeditionBattle('forest_path'),
+      score: 700,
+      actionCount: Number.POSITIVE_INFINITY,
+      actionKinds: {
+        attack: Number.POSITIVE_INFINITY,
+        dodge: Number.NaN,
+        charge: -4,
+      },
+    });
+
+    expect(result.grade).toBe('A');
+    expect(result.actionKinds).toEqual({ attack:0, dodge:0, charge:0 });
+    expect(specialistMasteryCalling('vanguard', result.actionKinds, {
+      stageId:result.stageId,
+      grade:result.grade,
+      discovery:null,
+      materialReward:1,
+    })).toBeNull();
+  });
+});

--- a/src/expedition-reward-material-sanitization.test.ts
+++ b/src/expedition-reward-material-sanitization.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { resolveExpeditionFinish } from './expedition-rewards';
+import { emptyExpeditionPersistentState } from './expedition-state';
+
+function base() {
+  return {
+    ...emptyExpeditionPersistentState(),
+    gold: 0,
+    gems: 0,
+    affection: 0,
+    inventory: { star_cookie: 0, herb_tea: 0, fox_charm: 0 },
+  };
+}
+
+describe('expedition reward material sanitation', () => {
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    -100,
+  ])('repairs malformed material balance %s before adding a clear reward', malformed => {
+    const state = base();
+    state.expeditionMaterials.star_bark = malformed;
+
+    const result = resolveExpeditionFinish(state, 'forest_path', 700);
+
+    expect(result.summary.cleared).toBe(true);
+    expect(result.summary.materialReward).toBe(1);
+    expect(result.state.expeditionMaterials.star_bark).toBe(1);
+    expect(Number.isFinite(result.state.expeditionMaterials.star_bark)).toBe(true);
+  });
+});

--- a/src/expedition-rewards.test.ts
+++ b/src/expedition-rewards.test.ts
@@ -103,6 +103,24 @@ describe('expedition finish reward pipeline', () => {
     expect(worldReplay.state.ownedExpeditionRelics).toContain('explorer_compass');
   });
 
+  it('does not replay world-completion gems when a rewarded legacy save repairs its final record', () => {
+    const worldState = base();
+    const stageIds = Object.keys(worldState.expeditionRecords) as Array<keyof typeof worldState.expeditionRecords>;
+    for (const id of stageIds) {
+      if (id !== 'lake_tempest') worldState.expeditionRecords[id] = { bestScore:9999, bestGrade:'A', cleared:true };
+    }
+    worldState.rewardedExpeditionStages = [...stageIds];
+    worldState.rewardedExpeditionRegions = ['starlight_forest', 'ancient_city', 'wind_lakes'];
+
+    const repaired = resolveExpeditionFinish(worldState, 'lake_tempest', 1750);
+
+    expect(repaired.summary.cleared).toBe(true);
+    expect(repaired.summary.firstClear).toBe(false);
+    expect(repaired.summary.fullCompleted).toBe(false);
+    expect(repaired.state.gems).toBe(worldState.gems);
+    expect(repaired.state.ownedExpeditionRelics).toContain('explorer_compass');
+  });
+
   it('does not repair the world-completion relic on a failed replay', () => {
     const worldState = base();
     for (const id of Object.keys(worldState.expeditionRecords) as Array<keyof typeof worldState.expeditionRecords>) {

--- a/src/expedition-rewards.ts
+++ b/src/expedition-rewards.ts
@@ -69,6 +69,10 @@ function allStagesCleared(records: ExpeditionPersistentState['expeditionRecords'
   return expeditionStageDefinitions.every(stage => isExpeditionStageCleared(records[stage.id]));
 }
 
+function allStageRewardsPaid(state: ExpeditionPersistentState): boolean {
+  return expeditionStageDefinitions.every(stage => state.rewardedExpeditionStages.includes(stage.id));
+}
+
 export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: ExpeditionStageId, score: number): { state: ExpeditionRewardState; summary: ExpeditionFinishSummary } {
   const stage = stageDefinition(stageId);
   const grade = expeditionGrade(score, stage.target);
@@ -94,6 +98,7 @@ export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: E
   const wasStageRewarded = state.rewardedExpeditionStages.includes(stageId);
   const regionWasComplete = regionNowComplete(stage.region, state.expeditionRecords);
   const fullWasComplete = allStagesCleared(state.expeditionRecords);
+  const worldRewardWasPaid = allStageRewardsPaid(state);
   const firstClear = clearedNow && !wasCleared && !wasStageRewarded;
   const expeditionRecords = updateExpeditionRecord(state.expeditionRecords, stageId, score, stage.target);
   let next: ExpeditionRewardState = { ...state, expeditionRecords };
@@ -161,7 +166,7 @@ export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: E
 
   let fullCompleted = false;
   if (clearedNow && allStagesCleared(next.expeditionRecords) && !next.ownedExpeditionRelics.includes('explorer_compass')) {
-    fullCompleted = !fullWasComplete;
+    fullCompleted = !fullWasComplete && !worldRewardWasPaid;
     next = {
       ...next,
       gems: next.gems + (fullCompleted ? 5 : 0),

--- a/src/expedition-rewards.ts
+++ b/src/expedition-rewards.ts
@@ -73,6 +73,10 @@ function allStageRewardsPaid(state: ExpeditionPersistentState): boolean {
   return expeditionStageDefinitions.every(stage => state.rewardedExpeditionStages.includes(stage.id));
 }
 
+function safeMaterialBalance(value: number): number {
+  return Math.max(0, Math.floor(Number.isFinite(value) ? value : 0));
+}
+
 export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: ExpeditionStageId, score: number): { state: ExpeditionRewardState; summary: ExpeditionFinishSummary } {
   const stage = stageDefinition(stageId);
   const grade = expeditionGrade(score, stage.target);
@@ -113,7 +117,7 @@ export function resolveExpeditionFinish(state: ExpeditionRewardState, stageId: E
       ...next,
       expeditionMaterials: {
         ...next.expeditionMaterials,
-        [material]: next.expeditionMaterials[material] + materialReward,
+        [material]: safeMaterialBalance(next.expeditionMaterials[material]) + materialReward,
       },
     };
   }

--- a/src/expedition-state.test.ts
+++ b/src/expedition-state.test.ts
@@ -12,6 +12,16 @@ describe('expedition persistent state repair', () => {
     expect(state.ownedExpeditionRelics).toContain('guardian_thread');
   });
 
+  it('restores the guardian thread crafting milestone when relic ownership survived', () => {
+    const state = hydrateExpeditionPersistentState({
+      craftingMilestones:[],
+      ownedExpeditionRelics:['guardian_thread'],
+    });
+
+    expect(state.ownedExpeditionRelics).toContain('guardian_thread');
+    expect(state.craftingMilestones).toContain('crafted_guardian_thread');
+  });
+
   it('keeps only owned relics equipped after hydration', () => {
     const state = hydrateExpeditionPersistentState({
       ownedExpeditionRelics:['moonfang_charm'],

--- a/src/expedition-state.test.ts
+++ b/src/expedition-state.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { isExpeditionStageUnlocked } from './expedition-regions';
 import { emptyExpeditionPersistentState, hydrateExpeditionPersistentState } from './expedition-state';
 
 describe('expedition persistent state repair', () => {
@@ -91,5 +92,15 @@ describe('expedition persistent state repair', () => {
     expect(state.expeditionDiscoveries).toEqual(['forest_path_discovery']);
     expect(state.expeditionStoryEntries).toEqual(['forest_path']);
     expect(state.craftingMilestones).toEqual(['crafted_star_cookie']);
+  });
+
+  it('uses a paid stage reward as durable clear evidence so old saves cannot soft-lock progression', () => {
+    const state = hydrateExpeditionPersistentState({
+      expeditionRecords: {},
+      rewardedExpeditionStages: ['forest_path'],
+    });
+
+    expect(state.expeditionRecords.forest_path.cleared).toBe(true);
+    expect(isExpeditionStageUnlocked('forest_glade', state.expeditionRecords)).toBe(true);
   });
 });

--- a/src/expedition-state.test.ts
+++ b/src/expedition-state.test.ts
@@ -103,4 +103,26 @@ describe('expedition persistent state repair', () => {
     expect(state.expeditionRecords.forest_path.cleared).toBe(true);
     expect(isExpeditionStageUnlocked('forest_glade', state.expeditionRecords)).toBe(true);
   });
+
+  it('uses unlocked expedition story entries as clear evidence when reward markers are missing', () => {
+    const state = hydrateExpeditionPersistentState({
+      expeditionRecords: {},
+      expeditionStoryEntries: ['forest_path'],
+    });
+
+    expect(state.expeditionRecords.forest_path.cleared).toBe(true);
+    expect(isExpeditionStageUnlocked('forest_glade', state.expeditionRecords)).toBe(true);
+  });
+
+  it('uses a paid region reward as evidence that its whole stage chain was cleared', () => {
+    const state = hydrateExpeditionPersistentState({
+      expeditionRecords: {},
+      rewardedExpeditionRegions: ['starlight_forest'],
+    });
+
+    expect(state.expeditionRecords.forest_path.cleared).toBe(true);
+    expect(state.expeditionRecords.forest_glade.cleared).toBe(true);
+    expect(state.expeditionRecords.forest_guardian.cleared).toBe(true);
+    expect(isExpeditionStageUnlocked('city_square', state.expeditionRecords)).toBe(true);
+  });
 });

--- a/src/expedition-state.test.ts
+++ b/src/expedition-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hydrateExpeditionPersistentState } from './expedition-state';
+import { emptyExpeditionPersistentState, hydrateExpeditionPersistentState } from './expedition-state';
 
 describe('expedition persistent state repair', () => {
   it('restores guardian thread ownership when its crafting milestone exists', () => {
@@ -17,5 +17,79 @@ describe('expedition persistent state repair', () => {
       equippedExpeditionRelics:['moonfang_charm','mana_prism'],
     });
     expect(state.equippedExpeditionRelics).toEqual(['moonfang_charm']);
+  });
+
+  it('drops stale and duplicate relic ids and keeps at most three valid equipped relics', () => {
+    const state = hydrateExpeditionPersistentState({
+      ownedExpeditionRelics:[
+        'moonfang_charm',
+        'moonfang_charm',
+        'stale_relic',
+        'mana_prism',
+        'wind_feather',
+        'guardian_thread',
+      ],
+      equippedExpeditionRelics:[
+        'stale_relic',
+        'mana_prism',
+        'mana_prism',
+        'wind_feather',
+        'guardian_thread',
+        'moonfang_charm',
+      ],
+    });
+
+    expect(state.ownedExpeditionRelics).toEqual([
+      'moonfang_charm',
+      'mana_prism',
+      'wind_feather',
+      'guardian_thread',
+    ]);
+    expect(state.equippedExpeditionRelics).toEqual([
+      'mana_prism',
+      'wind_feather',
+      'guardian_thread',
+    ]);
+  });
+
+  it('recovers an old save with missing expedition fields to exact safe defaults', () => {
+    expect(hydrateExpeditionPersistentState({})).toEqual(emptyExpeditionPersistentState());
+    expect(hydrateExpeditionPersistentState(null)).toEqual(emptyExpeditionPersistentState());
+  });
+
+  it('sanitizes malformed record scores, grades, clears and material counts', () => {
+    const state = hydrateExpeditionPersistentState({
+      expeditionRecords: {
+        forest_path: { bestScore: Number.POSITIVE_INFINITY, bestGrade: 'Z', cleared: false },
+        forest_glade: { bestScore: -42.8, bestGrade: 'B', cleared: false },
+        forest_guardian: { bestScore: 1050.9, bestGrade: 'C', cleared: true },
+      },
+      expeditionMaterials: {
+        star_bark: Number.NaN,
+        arcane_shard: -3,
+        wind_pearl: 7.9,
+      },
+    });
+
+    expect(state.expeditionRecords.forest_path).toEqual({ bestScore: 0, bestGrade: 'C', cleared: false });
+    expect(state.expeditionRecords.forest_glade).toEqual({ bestScore: 0, bestGrade: 'B', cleared: true });
+    expect(state.expeditionRecords.forest_guardian).toEqual({ bestScore: 1050, bestGrade: 'C', cleared: true });
+    expect(state.expeditionMaterials).toEqual({ star_bark: 0, arcane_shard: 0, wind_pearl: 7 });
+  });
+
+  it('deduplicates durable marker lists and removes stale ids', () => {
+    const state = hydrateExpeditionPersistentState({
+      rewardedExpeditionStages:['forest_path','forest_path','stale_stage'],
+      rewardedExpeditionRegions:['starlight_forest','starlight_forest','stale_region'],
+      expeditionDiscoveries:['forest_path_discovery','forest_path_discovery','stale_discovery'],
+      expeditionStoryEntries:['forest_path','forest_path','stale_stage'],
+      craftingMilestones:['crafted_star_cookie','crafted_star_cookie','stale_milestone'],
+    });
+
+    expect(state.rewardedExpeditionStages).toEqual(['forest_path']);
+    expect(state.rewardedExpeditionRegions).toEqual(['starlight_forest']);
+    expect(state.expeditionDiscoveries).toEqual(['forest_path_discovery']);
+    expect(state.expeditionStoryEntries).toEqual(['forest_path']);
+    expect(state.craftingMilestones).toEqual(['crafted_star_cookie']);
   });
 });

--- a/src/expedition-state.ts
+++ b/src/expedition-state.ts
@@ -72,12 +72,17 @@ export function hydrateExpeditionPersistentState(raw: unknown): ExpeditionPersis
     ? [...storedOwned, 'guardian_thread']
     : storedOwned;
   const equipped = uniqueAllowed(source.equippedExpeditionRelics, expeditionRelicIds).filter(id => owned.includes(id)).slice(0, 3);
+  const rewardedExpeditionStages = uniqueAllowed(source.rewardedExpeditionStages, stageIds);
+  const expeditionRecords = hydrateRecords(source.expeditionRecords);
+  for (const stageId of rewardedExpeditionStages) {
+    expeditionRecords[stageId] = { ...expeditionRecords[stageId], cleared: true };
+  }
   return {
-    expeditionRecords: hydrateRecords(source.expeditionRecords),
+    expeditionRecords,
     expeditionMaterials: hydrateMaterials(source.expeditionMaterials),
     ownedExpeditionRelics: owned,
     equippedExpeditionRelics: equipped,
-    rewardedExpeditionStages: uniqueAllowed(source.rewardedExpeditionStages, stageIds),
+    rewardedExpeditionStages,
     rewardedExpeditionRegions: uniqueAllowed(source.rewardedExpeditionRegions, regionIds),
     expeditionDiscoveries: uniqueAllowed(source.expeditionDiscoveries, expeditionDiscoveryIds),
     expeditionStoryEntries: uniqueAllowed(source.expeditionStoryEntries, stageIds),

--- a/src/expedition-state.ts
+++ b/src/expedition-state.ts
@@ -18,6 +18,11 @@ export type ExpeditionPersistentState = {
 const stageIds = expeditionStageDefinitions.map(stage => stage.id);
 const regionIds = expeditionRegionDefinitions.map(region => region.id);
 const validGrades: ExpeditionGrade[] = ['S', 'A', 'B', 'C'];
+const regionCompletionRelics: Partial<Record<ExpeditionRelicId, ExpeditionRegionId>> = {
+  moonfang_charm: 'starlight_forest',
+  mana_prism: 'ancient_city',
+  wind_feather: 'wind_lakes',
+};
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
 const finite = (value: unknown, fallback = 0) => typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 
@@ -82,6 +87,14 @@ export function hydrateExpeditionPersistentState(raw: unknown): ExpeditionPersis
   for (const regionId of rewardedExpeditionRegions) {
     const region = expeditionRegionDefinitions.find(item => item.id === regionId);
     for (const stageId of region?.stages ?? []) clearEvidence.add(stageId);
+  }
+  for (const relicId of owned) {
+    const regionId = regionCompletionRelics[relicId];
+    const region = regionId ? expeditionRegionDefinitions.find(item => item.id === regionId) : null;
+    for (const stageId of region?.stages ?? []) clearEvidence.add(stageId);
+  }
+  if (owned.includes('explorer_compass')) {
+    for (const stageId of stageIds) clearEvidence.add(stageId);
   }
   const expeditionRecords = hydrateRecords(source.expeditionRecords);
   for (const stageId of clearEvidence) {

--- a/src/expedition-state.ts
+++ b/src/expedition-state.ts
@@ -73,8 +73,15 @@ export function hydrateExpeditionPersistentState(raw: unknown): ExpeditionPersis
     : storedOwned;
   const equipped = uniqueAllowed(source.equippedExpeditionRelics, expeditionRelicIds).filter(id => owned.includes(id)).slice(0, 3);
   const rewardedExpeditionStages = uniqueAllowed(source.rewardedExpeditionStages, stageIds);
+  const rewardedExpeditionRegions = uniqueAllowed(source.rewardedExpeditionRegions, regionIds);
+  const expeditionStoryEntries = uniqueAllowed(source.expeditionStoryEntries, stageIds);
+  const clearEvidence = new Set<ExpeditionStageId>([...rewardedExpeditionStages, ...expeditionStoryEntries]);
+  for (const regionId of rewardedExpeditionRegions) {
+    const region = expeditionRegionDefinitions.find(item => item.id === regionId);
+    for (const stageId of region?.stages ?? []) clearEvidence.add(stageId);
+  }
   const expeditionRecords = hydrateRecords(source.expeditionRecords);
-  for (const stageId of rewardedExpeditionStages) {
+  for (const stageId of clearEvidence) {
     expeditionRecords[stageId] = { ...expeditionRecords[stageId], cleared: true };
   }
   return {
@@ -83,9 +90,9 @@ export function hydrateExpeditionPersistentState(raw: unknown): ExpeditionPersis
     ownedExpeditionRelics: owned,
     equippedExpeditionRelics: equipped,
     rewardedExpeditionStages,
-    rewardedExpeditionRegions: uniqueAllowed(source.rewardedExpeditionRegions, regionIds),
+    rewardedExpeditionRegions,
     expeditionDiscoveries: uniqueAllowed(source.expeditionDiscoveries, expeditionDiscoveryIds),
-    expeditionStoryEntries: uniqueAllowed(source.expeditionStoryEntries, stageIds),
+    expeditionStoryEntries,
     craftingMilestones: milestones,
   };
 }

--- a/src/expedition-state.ts
+++ b/src/expedition-state.ts
@@ -22,6 +22,7 @@ const regionCompletionRelics: Partial<Record<ExpeditionRelicId, ExpeditionRegion
   moonfang_charm: 'starlight_forest',
   mana_prism: 'ancient_city',
   wind_feather: 'wind_lakes',
+  bond_locket: 'starlight_forest',
 };
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
 const finite = (value: unknown, fallback = 0) => typeof value === 'number' && Number.isFinite(value) ? value : fallback;

--- a/src/expedition-state.ts
+++ b/src/expedition-state.ts
@@ -66,8 +66,11 @@ function hydrateMaterials(raw: unknown): ExpeditionMaterials {
 
 export function hydrateExpeditionPersistentState(raw: unknown): ExpeditionPersistentState {
   const source = isRecord(raw) ? raw : {};
-  const milestones = uniqueAllowed(source.craftingMilestones, craftingMilestoneIds);
+  let milestones = uniqueAllowed(source.craftingMilestones, craftingMilestoneIds);
   const storedOwned = uniqueAllowed(source.ownedExpeditionRelics, expeditionRelicIds);
+  if (storedOwned.includes('guardian_thread') && !milestones.includes('crafted_guardian_thread')) {
+    milestones = [...milestones, 'crafted_guardian_thread'];
+  }
   const owned: ExpeditionRelicId[] = milestones.includes('crafted_guardian_thread') && !storedOwned.includes('guardian_thread')
     ? [...storedOwned, 'guardian_thread']
     : storedOwned;

--- a/src/expedition-stress.test.ts
+++ b/src/expedition-stress.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { resolveExpeditionFinish } from './expedition-rewards';
+import { expeditionStageDefinitions } from './expedition-regions';
+import { emptyExpeditionPersistentState, hydrateExpeditionPersistentState } from './expedition-state';
+
+const base = () => ({
+  ...emptyExpeditionPersistentState(),
+  gold:0,
+  gems:0,
+  affection:0,
+  inventory:{ star_cookie:0, herb_tea:0, fox_charm:0 },
+});
+
+function clearWorld() {
+  let state = base();
+  for (const stage of expeditionStageDefinitions) {
+    state = resolveExpeditionFinish(state, stage.id, stage.target).state;
+  }
+  return state;
+}
+
+function expectUnique(items:readonly string[]) {
+  expect(new Set(items).size).toBe(items.length);
+}
+
+describe('expedition long-run stress invariants', () => {
+  it('does not leak success progression through one thousand failed attempts', () => {
+    let state = base();
+
+    for (let index = 0; index < 1000; index += 1) {
+      const result = resolveExpeditionFinish(state, 'forest_path', 100);
+      expect(result.summary.accepted).toBe(true);
+      expect(result.summary.cleared).toBe(false);
+      state = result.state;
+    }
+
+    expect(state.expeditionRecords.forest_path).toEqual({ bestScore:100, bestGrade:'C', cleared:false });
+    expect(state.rewardedExpeditionStages).toEqual([]);
+    expect(state.rewardedExpeditionRegions).toEqual([]);
+    expect(state.expeditionStoryEntries).toEqual([]);
+    expect(state.expeditionDiscoveries).toEqual([]);
+    expect(state.expeditionMaterials).toEqual({ star_bark:0, arcane_shard:0, wind_pearl:0 });
+    expect(state.ownedExpeditionRelics).toEqual([]);
+    expect(state.gold).toBe(0);
+    expect(state.gems).toBe(0);
+  });
+
+  it('keeps one-time world and boss rewards idempotent across repeated hydrate and re-entry', () => {
+    let state = clearWorld();
+    const baseline = {
+      gold:state.gold,
+      gems:state.gems,
+      rewardedStages:[...state.rewardedExpeditionStages],
+      rewardedRegions:[...state.rewardedExpeditionRegions],
+      story:[...state.expeditionStoryEntries],
+      discoveries:[...state.expeditionDiscoveries],
+      relics:[...state.ownedExpeditionRelics],
+    };
+
+    for (let index = 0; index < 500; index += 1) {
+      state = resolveExpeditionFinish(state, 'lake_tempest', 1750).state;
+      const hydrated = hydrateExpeditionPersistentState(JSON.parse(JSON.stringify(state)));
+      state = { ...state, ...hydrated };
+    }
+
+    expect(state.gold).toBe(baseline.gold);
+    expect(state.gems).toBe(baseline.gems);
+    expect(state.rewardedExpeditionStages).toEqual(baseline.rewardedStages);
+    expect(state.rewardedExpeditionRegions).toEqual(baseline.rewardedRegions);
+    expect(state.expeditionStoryEntries).toEqual(baseline.story);
+    expect(state.expeditionDiscoveries).toEqual(baseline.discoveries);
+    expect(state.ownedExpeditionRelics).toEqual(baseline.relics);
+    expectUnique(state.rewardedExpeditionStages);
+    expectUnique(state.rewardedExpeditionRegions);
+    expectUnique(state.expeditionStoryEntries);
+    expectUnique(state.expeditionDiscoveries);
+    expectUnique(state.ownedExpeditionRelics);
+  });
+
+  it('keeps repeatable compass material rewards exactly linear without replaying one-time currency', () => {
+    let state = clearWorld();
+    state = { ...state, equippedExpeditionRelics:['explorer_compass'] };
+    const baselineGold = state.gold;
+    const baselineGems = state.gems;
+    const baselineBark = state.expeditionMaterials.star_bark;
+
+    for (let index = 0; index < 1000; index += 1) {
+      const result = resolveExpeditionFinish(state, 'forest_path', 840);
+      expect(result.summary.grade).toBe('S');
+      expect(result.summary.firstClear).toBe(false);
+      expect(result.summary.materialReward).toBe(3);
+      state = result.state;
+    }
+
+    expect(state.expeditionMaterials.star_bark).toBe(baselineBark + 3000);
+    expect(state.gold).toBe(baselineGold);
+    expect(state.gems).toBe(baselineGems);
+    expect(state.rewardedExpeditionStages.filter(id => id === 'forest_path')).toHaveLength(1);
+    expect(state.expeditionStoryEntries.filter(id => id === 'forest_path')).toHaveLength(1);
+    expect(state.expeditionDiscoveries.filter(id => id === 'forest_path_discovery')).toHaveLength(1);
+  });
+});

--- a/src/expedition-stress.test.ts
+++ b/src/expedition-stress.test.ts
@@ -99,4 +99,43 @@ describe('expedition long-run stress invariants', () => {
     expect(state.expeditionStoryEntries.filter(id => id === 'forest_path')).toHaveLength(1);
     expect(state.expeditionDiscoveries.filter(id => id === 'forest_path_discovery')).toHaveLength(1);
   });
+
+  it('keeps one-time economy flat across one hundred full nine-stage replay cycles with hydration', () => {
+    let state = clearWorld();
+    const baselineGold = state.gold;
+    const baselineGems = state.gems;
+    const baselineMaterials = { ...state.expeditionMaterials };
+    const baselineStages = [...state.rewardedExpeditionStages];
+    const baselineRegions = [...state.rewardedExpeditionRegions];
+    const baselineStory = [...state.expeditionStoryEntries];
+    const baselineRelics = [...state.ownedExpeditionRelics];
+
+    for (let cycle = 0; cycle < 100; cycle += 1) {
+      for (const stage of expeditionStageDefinitions) {
+        const replay = resolveExpeditionFinish(state, stage.id, stage.target);
+        expect(replay.summary.accepted, `${cycle}:${stage.id}`).toBe(true);
+        expect(replay.summary.cleared, `${cycle}:${stage.id}`).toBe(true);
+        expect(replay.summary.firstClear, `${cycle}:${stage.id}`).toBe(false);
+        state = replay.state;
+      }
+      const hydrated = hydrateExpeditionPersistentState(JSON.parse(JSON.stringify(state)));
+      state = { ...state, ...hydrated };
+    }
+
+    expect(state.gold).toBe(baselineGold);
+    expect(state.gems).toBe(baselineGems);
+    expect(state.expeditionMaterials).toEqual({
+      star_bark: baselineMaterials.star_bark + 200,
+      arcane_shard: baselineMaterials.arcane_shard + 200,
+      wind_pearl: baselineMaterials.wind_pearl + 200,
+    });
+    expect(state.rewardedExpeditionStages).toEqual(baselineStages);
+    expect(state.rewardedExpeditionRegions).toEqual(baselineRegions);
+    expect(state.expeditionStoryEntries).toEqual(baselineStory);
+    expect(state.ownedExpeditionRelics).toEqual(baselineRelics);
+    expectUnique(state.rewardedExpeditionStages);
+    expectUnique(state.rewardedExpeditionRegions);
+    expectUnique(state.expeditionStoryEntries);
+    expectUnique(state.ownedExpeditionRelics);
+  });
 });

--- a/src/regional-renown-progression.test.ts
+++ b/src/regional-renown-progression.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { initialState, reducer } from './game';
+
+const clearForestPathA = (state: typeof initialState) => reducer(state, {
+  type:'FINISH_EXPEDITION_STAGE',
+  stageId:'forest_path',
+  score:700,
+  actionKinds:{ attack:3, dodge:0, charge:0 },
+});
+
+describe('regional renown progression integration', () => {
+  it('adds repeatable renown only to the cleared stage region and claims level rewards once', () => {
+    const first = clearForestPathA(initialState);
+    const second = clearForestPathA(first);
+    const third = clearForestPathA(second);
+    const fourth = clearForestPathA(third);
+
+    expect(first.regionalRenown).toEqual({ starlight_forest:2, ancient_city:0, wind_lakes:0 });
+    expect(second.regionalRenown).toEqual({ starlight_forest:4, ancient_city:0, wind_lakes:0 });
+    expect(third.regionalRenown).toEqual({ starlight_forest:6, ancient_city:0, wind_lakes:0 });
+    expect(fourth.regionalRenown).toEqual({ starlight_forest:8, ancient_city:0, wind_lakes:0 });
+
+    expect(third.rewardedRenownLevels.filter(key => key === 'starlight_forest:2')).toHaveLength(1);
+    expect(fourth.rewardedRenownLevels.filter(key => key === 'starlight_forest:2')).toHaveLength(1);
+    expect(fourth.rewardedRenownLevels.some(key => key.startsWith('ancient_city:'))).toBe(false);
+    expect(fourth.rewardedRenownLevels.some(key => key.startsWith('wind_lakes:'))).toBe(false);
+  });
+});

--- a/src/regional-renown.test.ts
+++ b/src/regional-renown.test.ts
@@ -19,16 +19,23 @@ describe('regional renown', () => {
     expect(renownGainForExpedition('B', false)).toBe(1);
     expect(renownGainForExpedition('A', false)).toBe(2);
     expect(renownGainForExpedition('S', false)).toBe(3);
+    expect(renownGainForExpedition('B', true)).toBe(3);
+    expect(renownGainForExpedition('A', true)).toBe(4);
     expect(renownGainForExpedition('S', true)).toBe(5);
     expect(renownGainForExpedition('C', true)).toBe(0);
   });
 
-  it('maps persistent renown to five reputation levels', () => {
+  it('maps exact threshold boundaries to five reputation levels', () => {
+    expect(regionalRenownLevel(-1)).toBe(1);
+    expect(regionalRenownLevel(Number.NaN)).toBe(1);
     expect(regionalRenownLevel(0)).toBe(1);
     expect(regionalRenownLevel(4)).toBe(1);
     expect(regionalRenownLevel(5)).toBe(2);
+    expect(regionalRenownLevel(11)).toBe(2);
     expect(regionalRenownLevel(12)).toBe(3);
+    expect(regionalRenownLevel(21)).toBe(3);
     expect(regionalRenownLevel(22)).toBe(4);
+    expect(regionalRenownLevel(34)).toBe(4);
     expect(regionalRenownLevel(35)).toBe(5);
     expect(regionalRenownLevel(999)).toBe(5);
   });

--- a/src/regional-renown.test.ts
+++ b/src/regional-renown.test.ts
@@ -40,6 +40,11 @@ describe('regional renown', () => {
     expect(regionalRenownLevel(999)).toBe(5);
   });
 
+  it('fails high on positive overflow instead of regressing max renown to level one', () => {
+    expect(regionalRenownLevel(Number.POSITIVE_INFINITY)).toBe(5);
+    expect(regionalRenownLevel(Number.NEGATIVE_INFINITY)).toBe(1);
+  });
+
   it('defines one-time rewards for levels two through five', () => {
     expect(regionalRenownReward(1)).toEqual({ gold:0, gems:0 });
     expect(regionalRenownReward(2)).toEqual({ gold:100, gems:0 });

--- a/src/regional-renown.ts
+++ b/src/regional-renown.ts
@@ -20,6 +20,7 @@ export function renownGainForExpedition(grade: ExpeditionGrade, firstBossClear: 
 }
 
 export function regionalRenownLevel(renown: number): RegionalRenownLevel {
+  if (renown === Number.POSITIVE_INFINITY) return 5;
   const safe = Math.max(0, Math.floor(Number.isFinite(renown) ? renown : 0));
   if (safe >= regionalRenownThresholds[4]) return 5;
   if (safe >= regionalRenownThresholds[3]) return 4;

--- a/src/world-contract-calendar-sanitization.test.ts
+++ b/src/world-contract-calendar-sanitization.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { monthlyWorldContracts, worldContractRewardKey } from './world-contracts';
+
+describe('world contract calendar sanitation', () => {
+  it.each([
+    [Number.NaN, Number.NaN],
+    [0, 0],
+    [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY],
+  ])('uses the same canonical month for contract conditions and reward keys: %s/%s', (year, month) => {
+    const contracts = monthlyWorldContracts(year, month);
+    const featured = contracts.find(contract => contract.id === 'featured_region');
+
+    expect(worldContractRewardKey(year, month, 'featured_region')).toBe('1-1:featured_region');
+    expect(featured?.region).toBe('starlight_forest');
+  });
+});

--- a/src/world-contracts.test.ts
+++ b/src/world-contracts.test.ts
@@ -67,6 +67,22 @@ describe('world contracts', () => {
     expect(result.reward).toEqual({ gold:0, gems:0 });
   });
 
+  it('repairs malformed stored counters before advancing a successful clear', () => {
+    const result = advanceWorldContracts({
+      year:1,
+      month:1,
+      event:worldEvent(1, 1),
+      progress:{ expedition_clear:Number.NaN, high_grade:-5, featured_region:Number.POSITIVE_INFINITY },
+      rewardedKeys:[],
+      region:'starlight_forest',
+      grade:'A',
+    });
+
+    expect(result.progress).toEqual({ expedition_clear:1, high_grade:1, featured_region:1 });
+    expect(result.reward).toEqual({ gold:0, gems:0 });
+    expect(result.newlyCompleted).toEqual([]);
+  });
+
   it('auto-pays newly completed contracts once and caps completed counters', () => {
     const result = advanceWorldContracts({
       year:1,

--- a/src/world-contracts.test.ts
+++ b/src/world-contracts.test.ts
@@ -35,6 +35,24 @@ describe('world contracts', () => {
     expect(result.reward).toEqual({ gold:0, gems:0 });
   });
 
+  it('does not count B as high grade and does not count a non-featured region', () => {
+    const event = worldEvent(1, 1);
+    const result = advanceWorldContracts({
+      year:1,
+      month:1,
+      event,
+      progress:emptyWorldContractProgress(),
+      rewardedKeys:[],
+      region:'ancient_city',
+      grade:'B',
+    });
+
+    expect(event.region).toBe('starlight_forest');
+    expect(result.progress).toEqual({ expedition_clear:1, high_grade:0, featured_region:0 });
+    expect(result.reward).toEqual({ gold:0, gems:0 });
+    expect(result.newlyCompleted).toEqual([]);
+  });
+
   it('does not advance failed C-grade attempts', () => {
     const result = advanceWorldContracts({
       year:1,
@@ -79,7 +97,42 @@ describe('world contracts', () => {
     expect(repeat.progress).toEqual({ expedition_clear:3, high_grade:2, featured_region:2 });
   });
 
+  it('keeps completed counters capped and rewards fixed through long successful replay', () => {
+    const event = worldEvent(1, 1);
+    let progress = emptyWorldContractProgress();
+    let rewardedKeys:string[] = [];
+    let totalGold = 0;
+    let totalGems = 0;
+
+    for (let index = 0; index < 500; index += 1) {
+      const result = advanceWorldContracts({
+        year:1,
+        month:1,
+        event,
+        progress,
+        rewardedKeys,
+        region:'starlight_forest',
+        grade:'S',
+      });
+      progress = result.progress;
+      rewardedKeys = result.rewardedKeys;
+      totalGold += result.reward.gold;
+      totalGems += result.reward.gems;
+    }
+
+    expect(progress).toEqual({ expedition_clear:3, high_grade:2, featured_region:2 });
+    expect(rewardedKeys).toEqual([
+      '1-1:high_grade',
+      '1-1:featured_region',
+      '1-1:expedition_clear',
+    ]);
+    expect(totalGold).toBe(250);
+    expect(totalGems).toBe(1);
+  });
+
   it('creates stable monthly reward keys', () => {
     expect(worldContractRewardKey(2, 8, 'high_grade')).toBe('2-8:high_grade');
+    expect(worldContractRewardKey(0, 99, 'high_grade')).toBe('1-12:high_grade');
+    expect(worldContractRewardKey(Number.NaN, Number.NaN, 'high_grade')).toBe('1-1:high_grade');
   });
 });

--- a/src/world-contracts.ts
+++ b/src/world-contracts.ts
@@ -48,16 +48,26 @@ export function advanceWorldContracts(input:AdvanceInput): {
   reward:{ gold:number; gems:number };
   newlyCompleted:WorldContractId[];
 } {
-  if (input.grade === 'C') {
-    return { progress:{ ...input.progress }, rewardedKeys:[...input.rewardedKeys], reward:{ gold:0, gems:0 }, newlyCompleted:[] };
-  }
-
   const contracts = monthlyWorldContracts(input.year, input.month, input.event);
   const targetFor = (id:WorldContractId) => contracts.find(contract => contract.id === id)?.target ?? Number.MAX_SAFE_INTEGER;
+  const storedProgress = (id:WorldContractId) => {
+    const value = input.progress[id];
+    return Math.min(targetFor(id), Math.max(0, Math.floor(Number.isFinite(value) ? value : 0)));
+  };
+  const current:WorldContractProgress = {
+    expedition_clear:storedProgress('expedition_clear'),
+    high_grade:storedProgress('high_grade'),
+    featured_region:storedProgress('featured_region'),
+  };
+
+  if (input.grade === 'C') {
+    return { progress:current, rewardedKeys:[...input.rewardedKeys], reward:{ gold:0, gems:0 }, newlyCompleted:[] };
+  }
+
   const progress:WorldContractProgress = {
-    expedition_clear:Math.min(targetFor('expedition_clear'),input.progress.expedition_clear + 1),
-    high_grade:Math.min(targetFor('high_grade'),input.progress.high_grade + (input.grade === 'A' || input.grade === 'S' ? 1 : 0)),
-    featured_region:Math.min(targetFor('featured_region'),input.progress.featured_region + (input.region === input.event.region ? 1 : 0)),
+    expedition_clear:Math.min(targetFor('expedition_clear'),current.expedition_clear + 1),
+    high_grade:Math.min(targetFor('high_grade'),current.high_grade + (input.grade === 'A' || input.grade === 'S' ? 1 : 0)),
+    featured_region:Math.min(targetFor('featured_region'),current.featured_region + (input.region === input.event.region ? 1 : 0)),
   };
   const rewardedKeys = [...input.rewardedKeys];
   const newlyCompleted:WorldContractId[] = [];

--- a/src/world-contracts.ts
+++ b/src/world-contracts.ts
@@ -13,12 +13,17 @@ export type WorldContractDefinition = {
   reward: { gold:number; gems:number };
 };
 
+const safeYear = (year:number) => Math.max(1, Math.floor(Number.isFinite(year) ? year : 1));
+const safeMonth = (month:number) => Math.max(1, Math.min(12, Math.floor(Number.isFinite(month) ? month : 1)));
+
 export function emptyWorldContractProgress(): WorldContractProgress {
   return { expedition_clear:0, high_grade:0, featured_region:0 };
 }
 
 export function monthlyWorldContracts(year:number, month:number, event?:WorldEventDefinition): WorldContractDefinition[] {
-  const featured = event?.region ?? (month % 3 === 1 ? 'starlight_forest' : month % 3 === 2 ? 'ancient_city' : 'wind_lakes');
+  void year;
+  const canonicalMonth = safeMonth(month);
+  const featured = event?.region ?? (canonicalMonth % 3 === 1 ? 'starlight_forest' : canonicalMonth % 3 === 2 ? 'ancient_city' : 'wind_lakes');
   return [
     { id:'expedition_clear', label:'원정대의 발걸음', description:'이번 달 원정을 3회 성공하세요.', target:3, region:null, reward:{ gold:100, gems:0 } },
     { id:'high_grade', label:'빛나는 기록', description:'A 또는 S등급 원정을 2회 달성하세요.', target:2, region:null, reward:{ gold:0, gems:1 } },
@@ -27,9 +32,7 @@ export function monthlyWorldContracts(year:number, month:number, event?:WorldEve
 }
 
 export function worldContractRewardKey(year:number, month:number, id:WorldContractId): string {
-  const safeYear = Math.max(1, Math.floor(Number.isFinite(year) ? year : 1));
-  const safeMonth = Math.max(1, Math.min(12, Math.floor(Number.isFinite(month) ? month : 1)));
-  return `${safeYear}-${safeMonth}:${id}`;
+  return `${safeYear(year)}-${safeMonth(month)}:${id}`;
 }
 
 type AdvanceInput = {

--- a/src/world-event.test.ts
+++ b/src/world-event.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { monthlyWorldContracts } from './world-contracts';
 import { worldEvent, worldEventExpeditionBonus } from './world-event';
 
 describe('monthly world events', () => {
@@ -16,11 +17,26 @@ describe('monthly world events', () => {
     expect(worldEvent(1, 3).region).toBe('wind_lakes');
   });
 
-  it('adds event season points only in the featured region', () => {
+  it('keeps the monthly contract recommended region aligned with the world event', () => {
+    for (let month = 1; month <= 12; month += 1) {
+      const event = worldEvent(1, month);
+      const featuredContract = monthlyWorldContracts(1, month, event).find(contract => contract.id === 'featured_region');
+      expect(featuredContract?.region).toBe(event.region);
+    }
+  });
+
+  it('adds event points for B-or-better in the featured region and material only for S', () => {
     const event = worldEvent(1, 1);
+    expect(worldEventExpeditionBonus(event, 'starlight_forest', 'B')).toEqual({ seasonPoints:5, materialBonus:0 });
     expect(worldEventExpeditionBonus(event, 'starlight_forest', 'A')).toEqual({ seasonPoints:5, materialBonus:0 });
     expect(worldEventExpeditionBonus(event, 'starlight_forest', 'S')).toEqual({ seasonPoints:5, materialBonus:1 });
     expect(worldEventExpeditionBonus(event, 'ancient_city', 'S')).toEqual({ seasonPoints:0, materialBonus:0 });
     expect(worldEventExpeditionBonus(event, 'starlight_forest', 'C')).toEqual({ seasonPoints:0, materialBonus:0 });
+  });
+
+  it('sanitizes invalid calendar inputs to a deterministic event', () => {
+    expect(worldEvent(0, 0)).toEqual(worldEvent(1, 1));
+    expect(worldEvent(Number.NaN, Number.NaN)).toEqual(worldEvent(1, 1));
+    expect(worldEvent(1, 99)).toEqual(worldEvent(1, 12));
   });
 });


### PR DESCRIPTION
Verification-only frozen World gate.

Base: verify/world-next-after-season-base @ 690e29efbe588091041fcace9f5dc9d8b211201d (current integration/v2)
Head: verify/world-next-snapshot-477f @ 477f65480875bbee011497912cb6f24f9662b742

Purpose:
- verify World next-wave correctness/save hardening against the latest Season-integrated Global QA baseline
- preserve Hub focus restoration in GuardianExpeditionOverlay
- validate World targeted, save/old-save/malformed/global RC, full suite, TypeScript and production build on the actual merge ref

Frozen verification only. Do not merge this PR to integration/v2 or main. No production deploy.