### PR TITLE
verify: Raising next after Season + World Global QA

### DIFF
--- a/src/advanced-talents-boundary.test.ts
+++ b/src/advanced-talents-boundary.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { advancedTalents, applyAdvancedTalentBonuses } from './advanced-talents';
+
+const stats = { strength:50, intelligence:50, magic:50, morality:50, affection:50, stress:50, fatigue:50 };
+const personality = { courage:50, kindness:50, curiosity:50, calmness:50 };
+
+describe('advanced talent corruption boundaries', () => {
+  it('applies a duplicated talent only once', () => {
+    const result = applyAdvancedTalentBonuses(stats, personality, ['hunter_instinct','hunter_instinct'], ['hunt']);
+    expect(result.stats.strength).toBe(52);
+  });
+
+  it('sanitizes non-finite stats and personality before applying bonuses', () => {
+    const result = applyAdvancedTalentBonuses(
+      { ...stats, strength:Number.NaN, fatigue:Number.POSITIVE_INFINITY },
+      { ...personality, courage:Number.NEGATIVE_INFINITY },
+      ['hunter_instinct','steady_recovery','guardian_strike'],
+      ['hunt','rest'],
+    );
+    expect(result.stats.strength).toBe(2);
+    expect(result.stats.fatigue).toBe(0);
+    expect(result.personality.courage).toBe(1);
+    expect(Object.values(result.stats).every(Number.isFinite)).toBe(true);
+    expect(Object.values(result.personality).every(Number.isFinite)).toBe(true);
+  });
+
+  it('does not unlock talents from NaN or Infinity mastery levels', () => {
+    expect(advancedTalents({ hunt:Number.POSITIVE_INFINITY, magic:Number.NaN, rest:0, herb:0 })).toEqual([]);
+  });
+});

--- a/src/advanced-talents.ts
+++ b/src/advanced-talents.ts
@@ -33,11 +33,12 @@ export type MasteryLevels = Record<ActivityId, number>;
 
 export function advancedTalents(levels: MasteryLevels): AdvancedTalentId[] {
   return talentDefinitions
-    .filter(talent => levels[talent.activity] >= talent.requiredLevel)
+    .filter(talent => Number.isFinite(levels[talent.activity]) && levels[talent.activity] >= talent.requiredLevel)
     .map(talent => talent.id);
 }
 
 const clamp = (value: number) => Math.max(0, Math.min(100, value));
+const safe = (value: number) => Number.isFinite(value) ? clamp(value) : 0;
 
 export function applyAdvancedTalentBonuses(
   stats: Stats,
@@ -45,11 +46,16 @@ export function applyAdvancedTalentBonuses(
   talents: AdvancedTalentId[],
   schedule: ActivityId[],
 ) {
-  const nextStats = { ...stats };
-  const nextPersonality = { ...personality };
+  const nextStats: Stats = {
+    strength:safe(stats.strength), intelligence:safe(stats.intelligence), magic:safe(stats.magic), morality:safe(stats.morality),
+    affection:safe(stats.affection), stress:safe(stats.stress), fatigue:safe(stats.fatigue),
+  };
+  const nextPersonality: Personality = {
+    courage:safe(personality.courage), kindness:safe(personality.kindness), curiosity:safe(personality.curiosity), calmness:safe(personality.calmness),
+  };
   const active = new Set(schedule);
 
-  for (const id of talents) {
+  for (const id of new Set(talents)) {
     const definition = talentDefinitions.find(item => item.id === id);
     if (!definition || !active.has(definition.activity)) continue;
     if (id === 'hunter_instinct') nextStats.strength = clamp(nextStats.strength + 2);

--- a/src/bond-hydration-replay.test.ts
+++ b/src/bond-hydration-replay.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { hydrateRaisingDepthState } from './raising-depth-state';
+import { reconcileBondSceneRewards } from './raising-depth-rewards';
+
+describe('bond reward claim hydration', () => {
+  it('preserves a rewarded scene as proof when the unlock marker is damaged', () => {
+    const hydrated = hydrateRaisingDepthState({
+      unlockedBondScenes: [],
+      rewardedBondScenes: ['first_trust'],
+    });
+
+    expect(hydrated.unlockedBondScenes).toEqual(['first_trust']);
+    expect(hydrated.rewardedBondScenes).toEqual(['first_trust']);
+  });
+
+  it('does not pay a preserved historical reward again after hydration', () => {
+    const hydrated = hydrateRaisingDepthState({
+      unlockedBondScenes: [],
+      rewardedBondScenes: ['first_trust'],
+    });
+    const progress = {
+      affection:55,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+      unlocked:hydrated.unlockedBondScenes,
+      rewarded:hydrated.rewardedBondScenes,
+      gold:500,
+      gems:2,
+    };
+
+    const reconciled = reconcileBondSceneRewards(progress, progress);
+    expect(reconciled.changed).toBe(false);
+    expect(reconciled.gold).toBe(500);
+    expect(reconciled.gems).toBe(2);
+  });
+});

--- a/src/bond-scenes.test.ts
+++ b/src/bond-scenes.test.ts
@@ -27,4 +27,17 @@ describe('Runa bond scenes', () => {
     expect(eligibleBondScenes({ affection:94, outings:3, trainings:20, gifts:5, guardianRank:'guardian', bossClears:3, annualRecords:1, alreadyUnlocked:[...prior] })).not.toContain('precious_partner');
     expect(eligibleBondScenes({ affection:95, outings:3, trainings:20, gifts:5, guardianRank:'guardian', bossClears:3, annualRecords:1, alreadyUnlocked:[...prior] })).toContain('precious_partner');
   });
+
+  it('does not unlock scenes from non-finite progress counters', () => {
+    expect(eligibleBondScenes({
+      affection:Number.POSITIVE_INFINITY,
+      outings:Number.POSITIVE_INFINITY,
+      trainings:Number.POSITIVE_INFINITY,
+      gifts:Number.POSITIVE_INFINITY,
+      guardianRank:'trainee',
+      bossClears:Number.POSITIVE_INFINITY,
+      annualRecords:Number.POSITIVE_INFINITY,
+      alreadyUnlocked:[],
+    })).toEqual([]);
+  });
 });

--- a/src/bond-scenes.test.ts
+++ b/src/bond-scenes.test.ts
@@ -40,4 +40,18 @@ describe('Runa bond scenes', () => {
       alreadyUnlocked:[],
     })).toEqual([]);
   });
+
+  it('does not count unknown saved scene ids toward precious partner', () => {
+    const malformed = ['bad_1','bad_2','bad_3','bad_4','bad_5','bad_6','bad_7','bad_8'] as never[];
+    expect(eligibleBondScenes({
+      affection:95,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee',
+      bossClears:0,
+      annualRecords:0,
+      alreadyUnlocked:malformed,
+    })).not.toContain('precious_partner');
+  });
 });

--- a/src/bond-scenes.ts
+++ b/src/bond-scenes.ts
@@ -26,6 +26,8 @@ export const bondSceneDefinitions: BondSceneDefinition[] = [
 
 export const bondSceneIds = bondSceneDefinitions.map(item => item.id);
 const rankOrder: GuardianRankId[] = ['trainee','junior','guardian','veteran','starlight'];
+const safeCount = (value:number):number => Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+const safeAffection = (value:number):number => Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 0;
 
 export type BondSceneProgress = {
   affection: number;
@@ -39,17 +41,24 @@ export type BondSceneProgress = {
 };
 
 export function eligibleBondScenes(progress: BondSceneProgress): BondSceneId[] {
+  const affection = safeAffection(progress.affection);
+  const outings = safeCount(progress.outings);
+  const trainings = safeCount(progress.trainings);
+  const gifts = safeCount(progress.gifts);
+  const bossClears = safeCount(progress.bossClears);
+  const annualRecords = safeCount(progress.annualRecords);
+  const provenUnlocks = bondSceneIds.filter(id => progress.alreadyUnlocked.includes(id));
   const eligible = new Set<BondSceneId>();
-  if (progress.affection >= 55) eligible.add('first_trust');
-  if (progress.affection >= 65 && progress.outings >= 1) eligible.add('favorite_place');
-  if (progress.affection >= 75) eligible.add('shared_secret');
-  if (progress.affection >= 75 && progress.trainings >= 10) eligible.add('training_promise');
-  if (progress.affection >= 80 && progress.gifts >= 5) eligible.add('gift_memory');
-  if (progress.affection >= 85 && rankOrder.indexOf(progress.guardianRank) >= rankOrder.indexOf('guardian')) eligible.add('guardian_confession');
-  if (progress.bossClears >= 1) eligible.add('first_boss_together');
-  if (progress.bossClears >= 3) eligible.add('three_regions_together');
-  if (progress.annualRecords >= 1) eligible.add('year_together');
-  const prior = new Set([...progress.alreadyUnlocked, ...eligible]);
-  if (progress.affection >= 95 && prior.size >= 8) eligible.add('precious_partner');
+  if (affection >= 55) eligible.add('first_trust');
+  if (affection >= 65 && outings >= 1) eligible.add('favorite_place');
+  if (affection >= 75) eligible.add('shared_secret');
+  if (affection >= 75 && trainings >= 10) eligible.add('training_promise');
+  if (affection >= 80 && gifts >= 5) eligible.add('gift_memory');
+  if (affection >= 85 && rankOrder.indexOf(progress.guardianRank) >= rankOrder.indexOf('guardian')) eligible.add('guardian_confession');
+  if (bossClears >= 1) eligible.add('first_boss_together');
+  if (bossClears >= 3) eligible.add('three_regions_together');
+  if (annualRecords >= 1) eligible.add('year_together');
+  const prior = new Set([...provenUnlocks, ...eligible]);
+  if (affection >= 95 && prior.size >= 8) eligible.add('precious_partner');
   return bondSceneIds.filter(id => eligible.has(id));
 }

--- a/src/bond-story-same-action.test.ts
+++ b/src/bond-story-same-action.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { currentStoryChapters, initialState, reducer } from './game-base';
+
+describe('Bond -> Story same-action ordering', () => {
+  it('lets a gift unlock shared-secret bond and dependent story chapters in the same reducer action', () => {
+    const ready = {
+      ...initialState,
+      stats:{ ...initialState.stats, affection:69 },
+      memories:['first_training'] as typeof initialState.memories,
+      visitedOutings:['forest','village','lakeside'] as typeof initialState.visitedOutings,
+      careerRecords:{ ...initialState.careerRecords, outings:3 },
+      mastery:{ hunt:{xp:18}, magic:{xp:18}, rest:{xp:18}, herb:{xp:18} },
+      activeCalling:'caretaker' as const,
+      callingHistory:['caretaker' as const],
+    };
+
+    const after = reducer(ready, { type:'GIVE_GIFT', item:'star_cookie' });
+
+    expect(after.stats.affection).toBe(75);
+    expect(after.unlockedBondScenes).toContain('shared_secret');
+    expect(currentStoryChapters(after)).toContain('trusted_bond');
+    expect(currentStoryChapters(after)).toContain('guardian_oath');
+    expect(after.rewardedStoryChapters).toContain('trusted_bond');
+    expect(after.rewardedStoryChapters).toContain('guardian_oath');
+  });
+
+  it('does not pay Bond or Story rewards again on a replay reconciliation', () => {
+    const ready = {
+      ...initialState,
+      stats:{ ...initialState.stats, affection:69 },
+      memories:['first_training'] as typeof initialState.memories,
+      visitedOutings:['forest','village','lakeside'] as typeof initialState.visitedOutings,
+      careerRecords:{ ...initialState.careerRecords, outings:3 },
+      mastery:{ hunt:{xp:18}, magic:{xp:18}, rest:{xp:18}, herb:{xp:18} },
+      activeCalling:'caretaker' as const,
+      callingHistory:['caretaker' as const],
+    };
+    const first = reducer(ready, { type:'GIVE_GIFT', item:'star_cookie' });
+    const replay = reducer(first, { type:'SET_MONTHLY_FOCUS', focus:'balanced' });
+
+    expect(replay.gold).toBe(first.gold);
+    expect(replay.gems).toBe(first.gems);
+    expect(replay.unlockedBondScenes).toEqual(first.unlockedBondScenes);
+    expect(replay.rewardedBondScenes).toEqual(first.rewardedBondScenes);
+    expect(replay.rewardedStoryChapters).toEqual(first.rewardedStoryChapters);
+  });
+});

--- a/src/calling-depth-effects.test.ts
+++ b/src/calling-depth-effects.test.ts
@@ -9,11 +9,13 @@ import {
 describe('Calling depth effects', () => {
   it('builds stable monthly legend reward keys', () => {
     expect(legendRewardKey(2, 7, 'vanguard_legend')).toBe('2-7:vanguard_legend');
+    expect(legendRewardKey(Number.NaN, Number.POSITIVE_INFINITY, 'vanguard_legend')).toBe('1-1:vanguard_legend');
   });
 
   it('accelerates discovery eligibility only with Pathfinder eye', () => {
     expect(effectivePathfinderExplorationXp(3, 'pathfinder', ['pathfinder_eye'])).toBe(6);
     expect(effectivePathfinderExplorationXp(3, 'vanguard', ['pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(Number.NaN, 'pathfinder', ['pathfinder_eye'])).toBe(3);
   });
 
   it('detects specialist Calling mastery from expedition actions', () => {
@@ -78,5 +80,17 @@ describe('Calling depth effects', () => {
     });
     expect(result.stressDelta).toBe(4);
     expect(result.applied).toContain('heart_anchor');
+  });
+
+  it('sanitizes non-finite expedition burden deltas instead of returning NaN', () => {
+    const result = applyExpeditionCallingRewards({
+      year:1, month:4, calling:'caretaker', traits:[], signatures:['heart_anchor'], legendRewardKeys:[],
+      stageId:'lake_channel', grade:'A', firstClear:false, discovery:null, regionCompleted:null, materialReward:1,
+      fatigueDelta:Number.NaN, stressDelta:Number.POSITIVE_INFINITY,
+    });
+    expect(result.fatigueDelta).toBe(0);
+    expect(result.stressDelta).toBe(0);
+    expect(Number.isFinite(result.fatigueDelta)).toBe(true);
+    expect(Number.isFinite(result.stressDelta)).toBe(true);
   });
 });

--- a/src/calling-depth-effects.test.ts
+++ b/src/calling-depth-effects.test.ts
@@ -14,9 +14,10 @@ describe('Calling depth effects', () => {
   });
 
   it('accelerates discovery eligibility only with Pathfinder eye', () => {
-    expect(effectivePathfinderExplorationXp(3, 'pathfinder', ['pathfinder_eye'])).toBe(6);
-    expect(effectivePathfinderExplorationXp(3, 'vanguard', ['pathfinder_eye'])).toBe(3);
-    expect(effectivePathfinderExplorationXp(Number.NaN, 'pathfinder', ['pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(3, 'pathfinder', ['pathfinder_herb','pathfinder_eye'])).toBe(6);
+    expect(effectivePathfinderExplorationXp(3, 'pathfinder', ['pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(3, 'vanguard', ['pathfinder_herb','pathfinder_eye'])).toBe(3);
+    expect(effectivePathfinderExplorationXp(Number.NaN, 'pathfinder', ['pathfinder_herb','pathfinder_eye'])).toBe(3);
   });
 
   it('detects specialist Calling mastery from expedition actions', () => {
@@ -43,7 +44,7 @@ describe('Calling depth effects', () => {
   it('applies Pathfinder signature rewards without duplicating the existing supply trait', () => {
     const first = applyExpeditionCallingRewards({
       year:1, month:4, calling:'pathfinder',
-      traits:['pathfinder_eye','pathfinder_supply','pathfinder_legend'],
+      traits:['pathfinder_herb','pathfinder_eye','pathfinder_supply','pathfinder_legend'],
       signatures:['trail_reading','star_compass'], legendRewardKeys:[],
       stageId:'forest_glade', grade:'S', firstClear:true, discovery:'forest_echo',
       regionCompleted:'starlight_forest', materialReward:2, fatigueDelta:8, stressDelta:6,
@@ -55,28 +56,45 @@ describe('Calling depth effects', () => {
 
   it('applies Vanguard and Arcanist monthly Legend effects once', () => {
     const vanguard = applyExpeditionCallingRewards({
-      year:1, month:4, calling:'vanguard', traits:['vanguard_legend'], signatures:[], legendRewardKeys:[],
+      year:1, month:4, calling:'vanguard',
+      traits:['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'], signatures:[], legendRewardKeys:[],
       stageId:'forest_path', grade:'A', firstClear:true, discovery:null, regionCompleted:null, materialReward:1, fatigueDelta:8, stressDelta:6,
     });
     expect(vanguard.fatigueDelta).toBe(6);
     expect(vanguard.legendRewardKeys).toContain('1-4:vanguard_legend');
     const repeat = applyExpeditionCallingRewards({
-      year:1, month:4, calling:'vanguard', traits:['vanguard_legend'], signatures:[], legendRewardKeys:vanguard.legendRewardKeys,
+      year:1, month:4, calling:'vanguard',
+      traits:['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'], signatures:[], legendRewardKeys:vanguard.legendRewardKeys,
       stageId:'forest_glade', grade:'A', firstClear:true, discovery:null, regionCompleted:null, materialReward:1, fatigueDelta:8, stressDelta:6,
     });
     expect(repeat.fatigueDelta).toBe(8);
 
     const arcanist = applyExpeditionCallingRewards({
-      year:1, month:4, calling:'arcanist', traits:['arcanist_legend'], signatures:[], legendRewardKeys:[],
+      year:1, month:4, calling:'arcanist',
+      traits:['arcanist_mana','arcanist_insight','arcanist_channel','arcanist_legend'], signatures:[], legendRewardKeys:[],
       stageId:'city_square', grade:'S', firstClear:true, discovery:'city_rune', regionCompleted:null, materialReward:2, fatigueDelta:8, stressDelta:6,
     });
     expect(arcanist.stressDelta).toBe(4);
     expect(arcanist.legendRewardKeys).toContain('1-4:arcanist_legend');
   });
 
+  it('does not apply Legend effects from orphan traits', () => {
+    const vanguard = applyExpeditionCallingRewards({
+      year:1, month:4, calling:'vanguard', traits:['vanguard_legend'], signatures:[], legendRewardKeys:[],
+      stageId:'forest_path', grade:'A', firstClear:true, discovery:null, regionCompleted:null, materialReward:1, fatigueDelta:8, stressDelta:6,
+    });
+    expect(vanguard.fatigueDelta).toBe(8);
+    expect(vanguard.legendRewardKeys).toEqual([]);
+
+    const pathfinder = applyPathfinderOutingLegend(1, 4, 'pathfinder', ['pathfinder_legend'], true, []);
+    expect(pathfinder.goldBonus).toBe(0);
+    expect(pathfinder.legendRewardKeys).toEqual([]);
+  });
+
   it('treats zero-padded legend claims as the same month for once-only rewards', () => {
     const vanguard = applyExpeditionCallingRewards({
-      year:2, month:6, calling:'vanguard', traits:['vanguard_legend'], signatures:[],
+      year:2, month:6, calling:'vanguard',
+      traits:['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'], signatures:[],
       legendRewardKeys:['2-06:vanguard_legend'],
       stageId:'forest_path', grade:'A', firstClear:true, discovery:null, regionCompleted:null,
       materialReward:1, fatigueDelta:8, stressDelta:6,
@@ -94,7 +112,8 @@ describe('Calling depth effects', () => {
 
   it('applies heart anchor stress protection whenever its signature is active', () => {
     const result = applyExpeditionCallingRewards({
-      year:1, month:4, calling:'caretaker', traits:['caretaker_legend'], signatures:['heart_anchor'], legendRewardKeys:[],
+      year:1, month:4, calling:'caretaker',
+      traits:['caretaker_rest','caretaker_bond','caretaker_guard','caretaker_legend'], signatures:['heart_anchor'], legendRewardKeys:[],
       stageId:'lake_channel', grade:'A', firstClear:false, discovery:null, regionCompleted:null, materialReward:1, fatigueDelta:8, stressDelta:6,
     });
     expect(result.stressDelta).toBe(4);

--- a/src/calling-depth-effects.test.ts
+++ b/src/calling-depth-effects.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyExpeditionCallingRewards,
+  applyPathfinderOutingLegend,
   effectivePathfinderExplorationXp,
   legendRewardKey,
   specialistMasteryCalling,
@@ -71,6 +72,24 @@ describe('Calling depth effects', () => {
     });
     expect(arcanist.stressDelta).toBe(4);
     expect(arcanist.legendRewardKeys).toContain('1-4:arcanist_legend');
+  });
+
+  it('treats zero-padded legend claims as the same month for once-only rewards', () => {
+    const vanguard = applyExpeditionCallingRewards({
+      year:2, month:6, calling:'vanguard', traits:['vanguard_legend'], signatures:[],
+      legendRewardKeys:['2-06:vanguard_legend'],
+      stageId:'forest_path', grade:'A', firstClear:true, discovery:null, regionCompleted:null,
+      materialReward:1, fatigueDelta:8, stressDelta:6,
+    });
+    expect(vanguard.fatigueDelta).toBe(8);
+    expect(vanguard.legendRewardKeys).toEqual(['2-6:vanguard_legend']);
+
+    const pathfinder = applyPathfinderOutingLegend(
+      2, 6, 'pathfinder', ['pathfinder_herb','pathfinder_eye','pathfinder_supply','pathfinder_legend'], true,
+      ['2-06:pathfinder_legend'],
+    );
+    expect(pathfinder.goldBonus).toBe(0);
+    expect(pathfinder.legendRewardKeys).toEqual(['2-6:pathfinder_legend']);
   });
 
   it('applies heart anchor stress protection whenever its signature is active', () => {

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -5,8 +5,18 @@ import type { ExpeditionGrade, ExpeditionRegionId, ExpeditionStageId } from './e
 import type { GuardianCallingId } from './guardian-callings';
 import type { GrowthTraitId } from './growth-traits';
 
+function safeNonNegativeInt(value:number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function safePositiveInt(value:number): number {
+  return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1;
+}
+
 export function legendRewardKey(year:number, month:number, effectId:string): string {
-  return `${Math.max(1, Math.floor(year))}-${Math.max(1, Math.min(12, Math.floor(month)))}:${effectId}`;
+  const safeYear = safePositiveInt(year);
+  const safeMonth = Number.isFinite(month) ? Math.max(1, Math.min(12, Math.floor(month))) : 1;
+  return `${safeYear}-${safeMonth}:${effectId}`;
 }
 
 export function effectivePathfinderExplorationXp(
@@ -14,7 +24,7 @@ export function effectivePathfinderExplorationXp(
   calling:GuardianCallingId | null,
   traits:readonly GrowthTraitId[],
 ): number {
-  return Math.max(0, Math.floor(xp)) + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
+  return safeNonNegativeInt(xp) + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
 }
 
 export function specialistMasteryCalling(
@@ -26,8 +36,8 @@ export function specialistMasteryCalling(
   if (calling === 'vanguard') return actions.attack > 0 ? calling : null;
   if (calling === 'arcanist') return actions.charge > 0 ? calling : null;
   if (calling === 'caretaker') return actions.dodge > 0 ? calling : null;
-  const acted = actions.attack + actions.dodge + actions.charge > 0;
-  const explored = summary.discovery !== null || summary.materialReward > 0 || isBossStage(summary.stageId);
+  const acted = safeNonNegativeInt(actions.attack) + safeNonNegativeInt(actions.dodge) + safeNonNegativeInt(actions.charge) > 0;
+  const explored = summary.discovery !== null || safeNonNegativeInt(summary.materialReward) > 0 || isBossStage(summary.stageId);
   return acted && explored ? calling : null;
 }
 
@@ -59,15 +69,15 @@ export type ExpeditionCallingRewardResult = {
 
 export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput): ExpeditionCallingRewardResult {
   let extraMaterial = 0;
-  let fatigueDelta = Math.max(0, input.fatigueDelta);
-  let stressDelta = Math.max(0, input.stressDelta);
-  let legendRewardKeys = [...input.legendRewardKeys];
+  let fatigueDelta = safeNonNegativeInt(input.fatigueDelta);
+  let stressDelta = safeNonNegativeInt(input.stressDelta);
+  let legendRewardKeys = [...new Set(input.legendRewardKeys)];
   const applied:string[] = [];
   const signatures = new Set(input.signatures);
   const traits = new Set(input.traits);
 
   if (input.calling === 'pathfinder') {
-    if (signatures.has('trail_reading') && input.firstClear && input.materialReward > 0) {
+    if (signatures.has('trail_reading') && input.firstClear && safeNonNegativeInt(input.materialReward) > 0) {
       extraMaterial += 1;
       applied.push('trail_reading');
     }
@@ -111,10 +121,11 @@ export function applyPathfinderOutingLegend(
   discovered:boolean,
   existingKeys:string[],
 ): { goldBonus:number; legendRewardKeys:string[]; applied:boolean } {
+  const canonicalKeys = [...new Set(existingKeys)];
   if (calling !== 'pathfinder' || !traits.includes('pathfinder_legend') || !discovered) {
-    return { goldBonus:0, legendRewardKeys:existingKeys, applied:false };
+    return { goldBonus:0, legendRewardKeys:canonicalKeys, applied:false };
   }
   const key = legendRewardKey(year, month, 'pathfinder_legend');
-  if (existingKeys.includes(key)) return { goldBonus:0, legendRewardKeys:existingKeys, applied:false };
-  return { goldBonus:100, legendRewardKeys:[...existingKeys, key], applied:true };
+  if (canonicalKeys.includes(key)) return { goldBonus:0, legendRewardKeys:canonicalKeys, applied:false };
+  return { goldBonus:100, legendRewardKeys:[...canonicalKeys, key], applied:true };
 }

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -3,7 +3,7 @@ import type { ExpeditionActionCounts } from './expedition-combat';
 import { isBossStage } from './expedition-bosses';
 import type { ExpeditionGrade, ExpeditionRegionId, ExpeditionStageId } from './expedition-regions';
 import type { GuardianCallingId } from './guardian-callings';
-import type { GrowthTraitId } from './growth-traits';
+import { activeCallingTraits, type GrowthTraitId } from './growth-traits';
 
 const legendEffects = ['vanguard_legend','arcanist_legend','pathfinder_legend'] as const;
 
@@ -41,7 +41,8 @@ export function effectivePathfinderExplorationXp(
   calling:GuardianCallingId | null,
   traits:readonly GrowthTraitId[],
 ): number {
-  return safeNonNegativeInt(xp) + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
+  const active = new Set(activeCallingTraits(calling, [...traits]));
+  return safeNonNegativeInt(xp) + (active.has('pathfinder_eye') ? 3 : 0);
 }
 
 export function specialistMasteryCalling(
@@ -91,7 +92,7 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
   let legendRewardKeys = canonicalLegendRewardKeys(input.legendRewardKeys);
   const applied:string[] = [];
   const signatures = new Set(input.signatures);
-  const traits = new Set(input.traits);
+  const traits = new Set(activeCallingTraits(input.calling, [...input.traits]));
 
   if (input.calling === 'pathfinder') {
     if (signatures.has('trail_reading') && input.firstClear && safeNonNegativeInt(input.materialReward) > 0) {
@@ -139,7 +140,8 @@ export function applyPathfinderOutingLegend(
   existingKeys:string[],
 ): { goldBonus:number; legendRewardKeys:string[]; applied:boolean } {
   const canonicalKeys = canonicalLegendRewardKeys(existingKeys);
-  if (calling !== 'pathfinder' || !traits.includes('pathfinder_legend') || !discovered) {
+  const active = new Set(activeCallingTraits(calling, [...traits]));
+  if (!active.has('pathfinder_legend') || !discovered) {
     return { goldBonus:0, legendRewardKeys:canonicalKeys, applied:false };
   }
   const key = legendRewardKey(year, month, 'pathfinder_legend');

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -5,12 +5,29 @@ import type { ExpeditionGrade, ExpeditionRegionId, ExpeditionStageId } from './e
 import type { GuardianCallingId } from './guardian-callings';
 import type { GrowthTraitId } from './growth-traits';
 
+const legendEffects = ['vanguard_legend','arcanist_legend','pathfinder_legend'] as const;
+
 function safeNonNegativeInt(value:number): number {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 
 function safePositiveInt(value:number): number {
   return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1;
+}
+
+function canonicalLegendRewardKeys(raw:readonly string[]): string[] {
+  const result:string[] = [];
+  for (const value of raw) {
+    const match = /^(\d+)-(\d+):([a-z0-9_]+)$/.exec(value);
+    if (!match) continue;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const effect = match[3];
+    if (year < 1 || month < 1 || month > 12 || !legendEffects.includes(effect as typeof legendEffects[number])) continue;
+    const key = `${year}-${month}:${effect}`;
+    if (!result.includes(key)) result.push(key);
+  }
+  return result;
 }
 
 export function legendRewardKey(year:number, month:number, effectId:string): string {
@@ -33,9 +50,9 @@ export function specialistMasteryCalling(
   summary:{ stageId:ExpeditionStageId; grade:ExpeditionGrade; discovery:string | null; materialReward:number },
 ): GuardianCallingId | null {
   if (!calling || summary.grade === 'C') return null;
-  if (calling === 'vanguard') return actions.attack > 0 ? calling : null;
-  if (calling === 'arcanist') return actions.charge > 0 ? calling : null;
-  if (calling === 'caretaker') return actions.dodge > 0 ? calling : null;
+  if (calling === 'vanguard') return safeNonNegativeInt(actions.attack) > 0 ? calling : null;
+  if (calling === 'arcanist') return safeNonNegativeInt(actions.charge) > 0 ? calling : null;
+  if (calling === 'caretaker') return safeNonNegativeInt(actions.dodge) > 0 ? calling : null;
   const acted = safeNonNegativeInt(actions.attack) + safeNonNegativeInt(actions.dodge) + safeNonNegativeInt(actions.charge) > 0;
   const explored = summary.discovery !== null || safeNonNegativeInt(summary.materialReward) > 0 || isBossStage(summary.stageId);
   return acted && explored ? calling : null;
@@ -71,7 +88,7 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
   let extraMaterial = 0;
   let fatigueDelta = safeNonNegativeInt(input.fatigueDelta);
   let stressDelta = safeNonNegativeInt(input.stressDelta);
-  let legendRewardKeys = [...new Set(input.legendRewardKeys)];
+  let legendRewardKeys = canonicalLegendRewardKeys(input.legendRewardKeys);
   const applied:string[] = [];
   const signatures = new Set(input.signatures);
   const traits = new Set(input.traits);
@@ -121,7 +138,7 @@ export function applyPathfinderOutingLegend(
   discovered:boolean,
   existingKeys:string[],
 ): { goldBonus:number; legendRewardKeys:string[]; applied:boolean } {
-  const canonicalKeys = [...new Set(existingKeys)];
+  const canonicalKeys = canonicalLegendRewardKeys(existingKeys);
   if (calling !== 'pathfinder' || !traits.includes('pathfinder_legend') || !discovered) {
     return { goldBonus:0, legendRewardKeys:canonicalKeys, applied:false };
   }

--- a/src/calling-mastery-signature-e2e.test.ts
+++ b/src/calling-mastery-signature-e2e.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { emptyCallingMastery } from './calling-mastery';
+import { callingSignaturesForMastery } from './calling-signatures';
+import { incrementCallingMonthMastery } from './raising-depth-rewards';
+
+describe('Calling -> Mastery -> Signature', () => {
+  it('does not unlock a tier-two signature before Calling mastery level 2', () => {
+    const traits = ['vanguard_power', 'vanguard_focus'] as const;
+    expect(callingSignaturesForMastery('vanguard', 0, [...traits])).toEqual([]);
+    expect(callingSignaturesForMastery('vanguard', 2, [...traits])).toEqual([]);
+    expect(callingSignaturesForMastery('vanguard', 3, [...traits])).toEqual(['rally_strike']);
+  });
+
+  it('reaches the first signature through real monthly mastery progression', () => {
+    let mastery = emptyCallingMastery();
+    mastery = incrementCallingMonthMastery(mastery, 'vanguard');
+    mastery = incrementCallingMonthMastery(mastery, 'vanguard');
+    expect(callingSignaturesForMastery('vanguard', mastery.vanguard, ['vanguard_power','vanguard_focus'])).toEqual([]);
+    mastery = incrementCallingMonthMastery(mastery, 'vanguard');
+    expect(callingSignaturesForMastery('vanguard', mastery.vanguard, ['vanguard_power','vanguard_focus'])).toEqual(['rally_strike']);
+  });
+
+  it('requires mastery level 4 for the tier-four signature', () => {
+    const traits = ['vanguard_power','vanguard_focus','vanguard_assault','vanguard_legend'] as const;
+    expect(callingSignaturesForMastery('vanguard', 11, [...traits])).toEqual(['rally_strike']);
+    expect(callingSignaturesForMastery('vanguard', 12, [...traits])).toEqual(['rally_strike','guardian_breaker']);
+  });
+});

--- a/src/calling-mastery-signature-e2e.test.ts
+++ b/src/calling-mastery-signature-e2e.test.ts
@@ -25,4 +25,9 @@ describe('Calling -> Mastery -> Signature', () => {
     expect(callingSignaturesForMastery('vanguard', 11, [...traits])).toEqual(['rally_strike']);
     expect(callingSignaturesForMastery('vanguard', 12, [...traits])).toEqual(['rally_strike','guardian_breaker']);
   });
+
+  it('does not unlock a signature from an orphan required trait', () => {
+    expect(callingSignaturesForMastery('vanguard', 18, ['vanguard_focus'])).toEqual([]);
+    expect(callingSignaturesForMastery('vanguard', 18, ['vanguard_power','vanguard_legend'])).toEqual([]);
+  });
 });

--- a/src/calling-signatures.ts
+++ b/src/calling-signatures.ts
@@ -1,3 +1,4 @@
+import { callingMasteryLevel } from './calling-mastery';
 import type { GuardianCallingId } from './guardian-callings';
 import type { GrowthTraitId } from './growth-traits';
 
@@ -11,24 +12,37 @@ export type CallingSignatureDefinition = {
   id: CallingSignatureId;
   calling: GuardianCallingId;
   requiredTrait: GrowthTraitId;
+  requiredMasteryLevel: 2 | 4;
   label: string;
   description: string;
 };
 
 export const callingSignatureDefinitions: CallingSignatureDefinition[] = [
-  { id:'rally_strike', calling:'vanguard', requiredTrait:'vanguard_focus', label:'집결 일격', description:'원정 첫 공격 +8%.' },
-  { id:'guardian_breaker', calling:'vanguard', requiredTrait:'vanguard_legend', label:'수호자 파쇄', description:'보스전 공격 +6%.' },
-  { id:'mana_echo', calling:'arcanist', requiredTrait:'arcanist_insight', label:'마력 메아리', description:'원정 첫 기 모으기 +8%.' },
-  { id:'astral_core', calling:'arcanist', requiredTrait:'arcanist_legend', label:'성운 핵', description:'보스전 기 모으기 +6%.' },
-  { id:'gentle_guard', calling:'caretaker', requiredTrait:'caretaker_bond', label:'다정한 방벽', description:'원정 첫 회피 압박 방어 +10%.' },
-  { id:'heart_anchor', calling:'caretaker', requiredTrait:'caretaker_legend', label:'마음의 닻', description:'원정 종료 스트레스 부담 -2.' },
-  { id:'trail_reading', calling:'pathfinder', requiredTrait:'pathfinder_eye', label:'길 읽기', description:'일반 원정 첫 클리어 재료 +1.' },
-  { id:'star_compass', calling:'pathfinder', requiredTrait:'pathfinder_legend', label:'별의 나침반', description:'지역 완주 시 해당 지역 재료 +1.' },
+  { id:'rally_strike', calling:'vanguard', requiredTrait:'vanguard_focus', requiredMasteryLevel:2, label:'집결 일격', description:'원정 첫 공격 +8%.' },
+  { id:'guardian_breaker', calling:'vanguard', requiredTrait:'vanguard_legend', requiredMasteryLevel:4, label:'수호자 파쇄', description:'보스전 공격 +6%.' },
+  { id:'mana_echo', calling:'arcanist', requiredTrait:'arcanist_insight', requiredMasteryLevel:2, label:'마력 메아리', description:'원정 첫 기 모으기 +8%.' },
+  { id:'astral_core', calling:'arcanist', requiredTrait:'arcanist_legend', requiredMasteryLevel:4, label:'성운 핵', description:'보스전 기 모으기 +6%.' },
+  { id:'gentle_guard', calling:'caretaker', requiredTrait:'caretaker_bond', requiredMasteryLevel:2, label:'다정한 방벽', description:'원정 첫 회피 압박 방어 +10%.' },
+  { id:'heart_anchor', calling:'caretaker', requiredTrait:'caretaker_legend', requiredMasteryLevel:4, label:'마음의 닻', description:'원정 종료 스트레스 부담 -2.' },
+  { id:'trail_reading', calling:'pathfinder', requiredTrait:'pathfinder_eye', requiredMasteryLevel:2, label:'길 읽기', description:'일반 원정 첫 클리어 재료 +1.' },
+  { id:'star_compass', calling:'pathfinder', requiredTrait:'pathfinder_legend', requiredMasteryLevel:4, label:'별의 나침반', description:'지역 완주 시 해당 지역 재료 +1.' },
 ];
 
 export function callingSignatures(calling: GuardianCallingId | null, purchasedTraits: GrowthTraitId[]): CallingSignatureId[] {
   if (!calling) return [];
   return callingSignatureDefinitions
     .filter(item => item.calling === calling && purchasedTraits.includes(item.requiredTrait))
+    .map(item => item.id);
+}
+
+export function callingSignaturesForMastery(
+  calling: GuardianCallingId | null,
+  masteryXp: number,
+  purchasedTraits: GrowthTraitId[],
+): CallingSignatureId[] {
+  if (!calling) return [];
+  const masteryLevel = callingMasteryLevel(masteryXp);
+  return callingSignatureDefinitions
+    .filter(item => item.calling === calling && masteryLevel >= item.requiredMasteryLevel && purchasedTraits.includes(item.requiredTrait))
     .map(item => item.id);
 }

--- a/src/calling-signatures.ts
+++ b/src/calling-signatures.ts
@@ -1,6 +1,6 @@
 import { callingMasteryLevel } from './calling-mastery';
 import type { GuardianCallingId } from './guardian-callings';
-import type { GrowthTraitId } from './growth-traits';
+import { canonicalGrowthTraits, type GrowthTraitId } from './growth-traits';
 
 export type CallingSignatureId =
   | 'rally_strike' | 'guardian_breaker'
@@ -30,8 +30,9 @@ export const callingSignatureDefinitions: CallingSignatureDefinition[] = [
 
 export function callingSignatures(calling: GuardianCallingId | null, purchasedTraits: GrowthTraitId[]): CallingSignatureId[] {
   if (!calling) return [];
+  const validTraits = canonicalGrowthTraits(purchasedTraits);
   return callingSignatureDefinitions
-    .filter(item => item.calling === calling && purchasedTraits.includes(item.requiredTrait))
+    .filter(item => item.calling === calling && validTraits.includes(item.requiredTrait))
     .map(item => item.id);
 }
 
@@ -42,7 +43,8 @@ export function callingSignaturesForMastery(
 ): CallingSignatureId[] {
   if (!calling) return [];
   const masteryLevel = callingMasteryLevel(masteryXp);
+  const validTraits = canonicalGrowthTraits(purchasedTraits);
   return callingSignatureDefinitions
-    .filter(item => item.calling === calling && masteryLevel >= item.requiredMasteryLevel && purchasedTraits.includes(item.requiredTrait))
+    .filter(item => item.calling === calling && masteryLevel >= item.requiredMasteryLevel && validTraits.includes(item.requiredTrait))
     .map(item => item.id);
 }

--- a/src/career-records-boundary.test.ts
+++ b/src/career-records-boundary.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { careerTitles, recordCareerAction } from './career-records';
+
+describe('career record corruption boundaries', () => {
+  it('repairs malformed lifetime counters before recording an action', () => {
+    const next = recordCareerAction({
+      trainings:Number.NaN,
+      bestScore:Number.POSITIVE_INFINITY,
+      sGrades:-5,
+      outings:Number.NaN,
+      gifts:-2,
+      monthsCompleted:Number.POSITIVE_INFINITY,
+    }, { type:'training', score:920, grade:'S' });
+
+    expect(next).toEqual({
+      trainings:1,
+      bestScore:920,
+      sGrades:1,
+      outings:0,
+      gifts:0,
+      monthsCompleted:0,
+    });
+  });
+
+  it('does not unlock career titles from non-finite story or record progress', () => {
+    const titles = careerTitles({
+      records:{
+        trainings:Number.POSITIVE_INFINITY,
+        bestScore:Number.NaN,
+        sGrades:0,
+        outings:Number.POSITIVE_INFINITY,
+        gifts:Number.POSITIVE_INFINITY,
+        monthsCompleted:0,
+      },
+      guardianRank:'trainee',
+      openedStories:Number.POSITIVE_INFINITY,
+      openedRaisingStories:Number.NaN,
+    });
+    expect(titles).toEqual([]);
+  });
+});

--- a/src/career-records.ts
+++ b/src/career-records.ts
@@ -35,6 +35,21 @@ export const emptyCareerRecords = (): CareerRecords => ({
   monthsCompleted: 0,
 });
 
+function safeNonNegativeInt(value:number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function canonicalCareerRecords(records:CareerRecords): CareerRecords {
+  return {
+    trainings:safeNonNegativeInt(records.trainings),
+    bestScore:safeNonNegativeInt(records.bestScore),
+    sGrades:safeNonNegativeInt(records.sGrades),
+    outings:safeNonNegativeInt(records.outings),
+    gifts:safeNonNegativeInt(records.gifts),
+    monthsCompleted:safeNonNegativeInt(records.monthsCompleted),
+  };
+}
+
 export type CareerAction =
   | { type: 'training'; score: number; grade: 'S' | 'A' | 'B' | 'C' }
   | { type: 'outing' }
@@ -42,18 +57,19 @@ export type CareerAction =
   | { type: 'month' };
 
 export function recordCareerAction(records: CareerRecords, action: CareerAction): CareerRecords {
+  const current = canonicalCareerRecords(records);
   if (action.type === 'training') {
-    const score = Number.isFinite(action.score) ? Math.max(0, Math.floor(action.score)) : 0;
+    const score = safeNonNegativeInt(action.score);
     return {
-      ...records,
-      trainings: records.trainings + 1,
-      bestScore: Math.max(records.bestScore, score),
-      sGrades: records.sGrades + (action.grade === 'S' ? 1 : 0),
+      ...current,
+      trainings: current.trainings + 1,
+      bestScore: Math.max(current.bestScore, score),
+      sGrades: current.sGrades + (action.grade === 'S' ? 1 : 0),
     };
   }
-  if (action.type === 'outing') return { ...records, outings: records.outings + 1 };
-  if (action.type === 'gift') return { ...records, gifts: records.gifts + 1 };
-  return { ...records, monthsCompleted: records.monthsCompleted + 1 };
+  if (action.type === 'outing') return { ...current, outings: current.outings + 1 };
+  if (action.type === 'gift') return { ...current, gifts: current.gifts + 1 };
+  return { ...current, monthsCompleted: current.monthsCompleted + 1 };
 }
 
 const guardianOrder: GuardianRankId[] = ['trainee', 'junior', 'guardian', 'veteran', 'starlight'];
@@ -67,11 +83,12 @@ export type CareerTitleProgress = {
 
 export function careerTitles(input: CareerTitleProgress): CareerTitleId[] {
   const unlocked = new Set<CareerTitleId>();
-  const relevantStories = input.openedRaisingStories ?? input.openedStories;
-  if (input.records.trainings >= 10) unlocked.add('steady_trainer');
-  if (input.records.bestScore >= 900) unlocked.add('perfect_chaser');
-  if (input.records.outings >= 10) unlocked.add('seasoned_explorer');
-  if (input.records.gifts >= 5) unlocked.add('warm_giver');
+  const records = canonicalCareerRecords(input.records);
+  const relevantStories = safeNonNegativeInt(input.openedRaisingStories ?? input.openedStories);
+  if (records.trainings >= 10) unlocked.add('steady_trainer');
+  if (records.bestScore >= 900) unlocked.add('perfect_chaser');
+  if (records.outings >= 10) unlocked.add('seasoned_explorer');
+  if (records.gifts >= 5) unlocked.add('warm_giver');
   if (relevantStories >= 4) unlocked.add('story_witness');
   if (guardianOrder.indexOf(input.guardianRank) >= guardianOrder.indexOf('veteran')) unlocked.add('veteran_guardian');
   return careerTitleDefinitions.map(item => item.id).filter(id => unlocked.has(id));

--- a/src/growth-trait-orphan.test.ts
+++ b/src/growth-trait-orphan.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { activeCallingTraits } from './growth-traits';
+import { hydrateRaisingDepthState } from './raising-depth-state';
+
+describe('growth trait prerequisite integrity', () => {
+  it('does not activate an orphan trait when its prerequisite chain is missing', () => {
+    expect(activeCallingTraits('vanguard', ['vanguard_focus'])).toEqual([]);
+    expect(activeCallingTraits('vanguard', ['vanguard_power','vanguard_assault'])).toEqual(['vanguard_power']);
+  });
+
+  it('drops orphan traits while hydrating damaged Raising state', () => {
+    const hydrated = hydrateRaisingDepthState({
+      activeCalling: 'vanguard',
+      purchasedTraits: ['vanguard_focus','vanguard_legend','arcanist_mana','arcanist_insight'],
+    });
+
+    expect(hydrated.purchasedTraits).toEqual(['arcanist_mana','arcanist_insight']);
+  });
+});

--- a/src/growth-traits.test.ts
+++ b/src/growth-traits.test.ts
@@ -25,6 +25,12 @@ describe('growth trait board', () => {
     expect(duplicate).toEqual({ purchased:false, traits:['vanguard_power'], points:2 });
   });
 
+  it('rejects non-finite growth points and repairs them to zero', () => {
+    expect(canPurchaseGrowthTrait('vanguard_power', [], Number.POSITIVE_INFINITY)).toBe(false);
+    expect(canPurchaseGrowthTrait('vanguard_power', [], Number.NaN)).toBe(false);
+    expect(purchaseGrowthTrait('vanguard_power', [], Number.POSITIVE_INFINITY)).toEqual({ purchased:false, traits:[], points:0 });
+  });
+
   it('keeps all purchased traits while only activating the current calling path', () => {
     const owned = ['vanguard_power','arcanist_mana','arcanist_insight'] as const;
     expect(activeCallingTraits('arcanist', [...owned])).toEqual(['arcanist_mana','arcanist_insight']);

--- a/src/growth-traits.ts
+++ b/src/growth-traits.ts
@@ -37,6 +37,10 @@ export const growthTraitDefinitions: GrowthTraitDefinition[] = [
 
 export const growthTraitIds = growthTraitDefinitions.map(item => item.id);
 
+function canonicalGrowthPoints(points:number): number {
+  return Number.isFinite(points) ? Math.max(0, Math.floor(points)) : 0;
+}
+
 export function canonicalGrowthTraits(purchased: readonly GrowthTraitId[]): GrowthTraitId[] {
   const requested = new Set(purchased);
   const accepted = new Set<GrowthTraitId>();
@@ -51,15 +55,18 @@ export function canonicalGrowthTraits(purchased: readonly GrowthTraitId[]): Grow
 export function canPurchaseGrowthTrait(id: GrowthTraitId, purchased: GrowthTraitId[], points: number): boolean {
   if (purchased.includes(id)) return false;
   const definition = growthTraitDefinitions.find(item => item.id === id);
-  if (!definition || points < definition.cost) return false;
+  const validPoints = canonicalGrowthPoints(points);
+  if (!definition || !Number.isFinite(points) || validPoints < definition.cost) return false;
   const validPurchased = canonicalGrowthTraits(purchased);
   return definition.prerequisite === null || validPurchased.includes(definition.prerequisite);
 }
 
 export function purchaseGrowthTrait(id: GrowthTraitId, purchased: GrowthTraitId[], points: number) {
-  if (!canPurchaseGrowthTrait(id, purchased, points)) return { purchased:false, traits:purchased, points };
+  const validPurchased = canonicalGrowthTraits(purchased);
+  const validPoints = canonicalGrowthPoints(points);
+  if (!canPurchaseGrowthTrait(id, validPurchased, points)) return { purchased:false, traits:validPurchased, points:validPoints };
   const definition = growthTraitDefinitions.find(item => item.id === id)!;
-  return { purchased:true, traits:[...canonicalGrowthTraits(purchased), id], points:points - definition.cost };
+  return { purchased:true, traits:[...validPurchased, id], points:validPoints - definition.cost };
 }
 
 export function activeCallingTraits(calling: GuardianCallingId | null, purchased: GrowthTraitId[]): GrowthTraitId[] {

--- a/src/growth-traits.ts
+++ b/src/growth-traits.ts
@@ -37,20 +37,33 @@ export const growthTraitDefinitions: GrowthTraitDefinition[] = [
 
 export const growthTraitIds = growthTraitDefinitions.map(item => item.id);
 
+export function canonicalGrowthTraits(purchased: readonly GrowthTraitId[]): GrowthTraitId[] {
+  const requested = new Set(purchased);
+  const accepted = new Set<GrowthTraitId>();
+  for (const definition of growthTraitDefinitions) {
+    if (!requested.has(definition.id)) continue;
+    if (definition.prerequisite !== null && !accepted.has(definition.prerequisite)) continue;
+    accepted.add(definition.id);
+  }
+  return growthTraitIds.filter(id => accepted.has(id));
+}
+
 export function canPurchaseGrowthTrait(id: GrowthTraitId, purchased: GrowthTraitId[], points: number): boolean {
   if (purchased.includes(id)) return false;
   const definition = growthTraitDefinitions.find(item => item.id === id);
   if (!definition || points < definition.cost) return false;
-  return definition.prerequisite === null || purchased.includes(definition.prerequisite);
+  const validPurchased = canonicalGrowthTraits(purchased);
+  return definition.prerequisite === null || validPurchased.includes(definition.prerequisite);
 }
 
 export function purchaseGrowthTrait(id: GrowthTraitId, purchased: GrowthTraitId[], points: number) {
   if (!canPurchaseGrowthTrait(id, purchased, points)) return { purchased:false, traits:purchased, points };
   const definition = growthTraitDefinitions.find(item => item.id === id)!;
-  return { purchased:true, traits:[...purchased, id], points:points - definition.cost };
+  return { purchased:true, traits:[...canonicalGrowthTraits(purchased), id], points:points - definition.cost };
 }
 
 export function activeCallingTraits(calling: GuardianCallingId | null, purchased: GrowthTraitId[]): GrowthTraitId[] {
   if (!calling) return [];
-  return growthTraitDefinitions.filter(item => item.calling === calling && purchased.includes(item.id)).map(item => item.id);
+  const validPurchased = new Set(canonicalGrowthTraits(purchased));
+  return growthTraitDefinitions.filter(item => item.calling === calling && validPurchased.has(item.id)).map(item => item.id);
 }

--- a/src/guardian-calling-corruption.test.ts
+++ b/src/guardian-calling-corruption.test.ts
@@ -18,8 +18,7 @@ describe('guardian calling corruption boundaries', () => {
       lastSwitchKey:null,
       history:['vanguard'],
     });
-    expect(result).toMatchObject({ changed:false, reason:'insufficient_gold', current:'vanguard' });
-    expect(Number.isFinite(result.gold)).toBe(false);
+    expect(result).toMatchObject({ changed:false, reason:'insufficient_gold', current:'vanguard', gold:0 });
   });
 
   it('canonicalizes duplicate history when a new Calling is selected', () => {

--- a/src/guardian-calling-corruption.test.ts
+++ b/src/guardian-calling-corruption.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { applyCallingSelection, callingSwitchKey } from './guardian-callings';
+
+describe('guardian calling corruption boundaries', () => {
+  it('canonicalizes non-finite year and month into a stable switch key', () => {
+    expect(callingSwitchKey(Number.NaN, Number.POSITIVE_INFINITY)).toBe('1-1');
+    expect(callingSwitchKey(Number.NEGATIVE_INFINITY, -99)).toBe('1-1');
+  });
+
+  it('blocks a paid switch when gold is non-finite instead of creating NaN currency', () => {
+    const result = applyCallingSelection({
+      current:'vanguard',
+      next:'arcanist',
+      guardianRank:'guardian',
+      gold:Number.NaN,
+      year:2,
+      month:7,
+      lastSwitchKey:null,
+      history:['vanguard'],
+    });
+    expect(result).toMatchObject({ changed:false, reason:'insufficient_gold', current:'vanguard' });
+    expect(Number.isFinite(result.gold)).toBe(false);
+  });
+
+  it('canonicalizes duplicate history when a new Calling is selected', () => {
+    const result = applyCallingSelection({
+      current:'vanguard',
+      next:'caretaker',
+      guardianRank:'guardian',
+      gold:500,
+      year:2,
+      month:8,
+      lastSwitchKey:null,
+      history:['vanguard','vanguard','arcanist'],
+    });
+    expect(result.history).toEqual(['vanguard','arcanist','caretaker']);
+  });
+});

--- a/src/guardian-calling-corruption.test.ts
+++ b/src/guardian-calling-corruption.test.ts
@@ -21,6 +21,20 @@ describe('guardian calling corruption boundaries', () => {
     expect(result).toMatchObject({ changed:false, reason:'insufficient_gold', current:'vanguard', gold:0 });
   });
 
+  it('does not let a stale switch key block the first free Calling selection', () => {
+    const result = applyCallingSelection({
+      current:null,
+      next:'arcanist',
+      guardianRank:'guardian',
+      gold:0,
+      year:2,
+      month:7,
+      lastSwitchKey:'2-7',
+      history:[],
+    });
+    expect(result).toMatchObject({ changed:true, reason:null, current:'arcanist', gold:0 });
+  });
+
   it('canonicalizes duplicate history without destroying first-seen chronology', () => {
     const result = applyCallingSelection({
       current:'vanguard',

--- a/src/guardian-calling-corruption.test.ts
+++ b/src/guardian-calling-corruption.test.ts
@@ -21,7 +21,7 @@ describe('guardian calling corruption boundaries', () => {
     expect(result).toMatchObject({ changed:false, reason:'insufficient_gold', current:'vanguard', gold:0 });
   });
 
-  it('canonicalizes duplicate history when a new Calling is selected', () => {
+  it('canonicalizes duplicate history without destroying first-seen chronology', () => {
     const result = applyCallingSelection({
       current:'vanguard',
       next:'caretaker',
@@ -30,8 +30,8 @@ describe('guardian calling corruption boundaries', () => {
       year:2,
       month:8,
       lastSwitchKey:null,
-      history:['vanguard','vanguard','arcanist'],
+      history:['pathfinder','vanguard','pathfinder','arcanist'],
     });
-    expect(result.history).toEqual(['vanguard','arcanist','caretaker']);
+    expect(result.history).toEqual(['pathfinder','vanguard','arcanist','caretaker']);
   });
 });

--- a/src/guardian-callings.ts
+++ b/src/guardian-callings.ts
@@ -67,8 +67,8 @@ export function applyCallingSelection(input: CallingSelectionInput): CallingSele
   }
   if (input.current === input.next) return { ...input, gold, history, changed:false, reason:'same_calling' };
   const key = callingSwitchKey(input.year, input.month);
-  if (input.lastSwitchKey === key) return { ...input, gold, history, changed:false, reason:'monthly_lock' };
   const switching = input.current !== null;
+  if (switching && input.lastSwitchKey === key) return { ...input, gold, history, changed:false, reason:'monthly_lock' };
   if (switching && gold < 300) return { ...input, gold, history, changed:false, reason:'insufficient_gold' };
   return {
     ...input,

--- a/src/guardian-callings.ts
+++ b/src/guardian-callings.ts
@@ -20,8 +20,22 @@ export const guardianCallingDefinitions: GuardianCallingDefinition[] = [
 export const guardianCallingIds = guardianCallingDefinitions.map(item => item.id);
 const guardianRankOrder: GuardianRankId[] = ['trainee','junior','guardian','veteran','starlight'];
 
+function positiveInt(value:number): number {
+  return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1;
+}
+
+function canonicalGold(value:number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function canonicalHistory(history:readonly GuardianCallingId[]): GuardianCallingId[] {
+  return guardianCallingIds.filter(id => history.includes(id));
+}
+
 export function callingSwitchKey(year: number, month: number): string {
-  return `${Math.max(1, Math.floor(year))}-${Math.max(1, Math.min(12, Math.floor(month)))}`;
+  const safeYear = positiveInt(year);
+  const safeMonth = Number.isFinite(month) ? Math.max(1, Math.min(12, Math.floor(month))) : 1;
+  return `${safeYear}-${safeMonth}`;
 }
 
 export type CallingSelectionInput = {
@@ -41,20 +55,22 @@ export type CallingSelectionResult = CallingSelectionInput & {
 };
 
 export function applyCallingSelection(input: CallingSelectionInput): CallingSelectionResult {
+  const gold = canonicalGold(input.gold);
+  const history = canonicalHistory(input.history);
   if (guardianRankOrder.indexOf(input.guardianRank) < guardianRankOrder.indexOf('guardian')) {
-    return { ...input, changed:false, reason:'rank_locked' };
+    return { ...input, gold, history, changed:false, reason:'rank_locked' };
   }
-  if (input.current === input.next) return { ...input, changed:false, reason:'same_calling' };
+  if (input.current === input.next) return { ...input, gold, history, changed:false, reason:'same_calling' };
   const key = callingSwitchKey(input.year, input.month);
-  if (input.lastSwitchKey === key) return { ...input, changed:false, reason:'monthly_lock' };
+  if (input.lastSwitchKey === key) return { ...input, gold, history, changed:false, reason:'monthly_lock' };
   const switching = input.current !== null;
-  if (switching && input.gold < 300) return { ...input, changed:false, reason:'insufficient_gold' };
+  if (switching && gold < 300) return { ...input, gold, history, changed:false, reason:'insufficient_gold' };
   return {
     ...input,
     current: input.next,
-    gold: switching ? input.gold - 300 : input.gold,
+    gold: switching ? gold - 300 : gold,
     lastSwitchKey: key,
-    history: input.history.includes(input.next) ? input.history : [...input.history, input.next],
+    history: history.includes(input.next) ? history : [...history, input.next],
     changed:true,
     reason:null,
   };

--- a/src/guardian-callings.ts
+++ b/src/guardian-callings.ts
@@ -29,7 +29,12 @@ function canonicalGold(value:number): number {
 }
 
 function canonicalHistory(history:readonly GuardianCallingId[]): GuardianCallingId[] {
-  return guardianCallingIds.filter(id => history.includes(id));
+  const result:GuardianCallingId[] = [];
+  for (const id of history) {
+    if (!guardianCallingIds.includes(id) || result.includes(id)) continue;
+    result.push(id);
+  }
+  return result;
 }
 
 export function callingSwitchKey(year: number, month: number): string {

--- a/src/guardian-rank-corruption.test.ts
+++ b/src/guardian-rank-corruption.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { guardianGrowthPoints, guardianRank } from './guardian-rank';
+
+describe('guardian rank damaged mastery defense', () => {
+  it('ignores non-finite mastery instead of bypassing rank thresholds', () => {
+    const points = guardianGrowthPoints({ memories:0, skills:0, discoveries:0, masteryLevels:[Number.POSITIVE_INFINITY, Number.NaN] });
+    expect(points).toBe(0);
+    expect(guardianRank(points)).toBe('trainee');
+  });
+
+  it('caps malformed mastery levels at the real level-five ceiling', () => {
+    const points = guardianGrowthPoints({ memories:0, skills:0, discoveries:0, masteryLevels:[999, 5] });
+    expect(points).toBe(8);
+    expect(guardianRank(points)).toBe('junior');
+  });
+
+  it('keeps guardian rank helpers finite for damaged aggregate progress', () => {
+    const points = guardianGrowthPoints({ memories:Number.NaN, skills:Number.POSITIVE_INFINITY, discoveries:-20, masteryLevels:[-10, 3.9] });
+    expect(points).toBe(2);
+    expect(Number.isFinite(points)).toBe(true);
+  });
+});

--- a/src/guardian-rank.ts
+++ b/src/guardian-rank.ts
@@ -17,20 +17,25 @@ export const guardianRankDefinitions: Array<{ id: GuardianRankId; label: string;
 
 export const rewardableGuardianRanks: GuardianRankId[] = ['junior', 'guardian', 'veteran', 'starlight'];
 
+const safeCount = (value: number): number => Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+const safeMasteryLevel = (value: number): number => Number.isFinite(value) ? Math.max(1, Math.min(5, Math.floor(value))) : 1;
+
 export function guardianGrowthPoints(progress: GuardianProgress): number {
-  const masteryPoints = progress.masteryLevels.reduce((sum, level) => sum + Math.max(0, level - 1), 0);
-  return progress.memories + progress.skills * 2 + progress.discoveries + masteryPoints;
+  const masteryPoints = progress.masteryLevels.reduce((sum, rawLevel) => sum + safeMasteryLevel(rawLevel) - 1, 0);
+  return safeCount(progress.memories) + safeCount(progress.skills) * 2 + safeCount(progress.discoveries) + masteryPoints;
 }
 
 export function guardianRank(points: number): GuardianRankId {
+  const safePoints = safeCount(points);
   let result: GuardianRankId = 'trainee';
   for (const definition of guardianRankDefinitions) {
-    if (points >= definition.threshold) result = definition.id;
+    if (safePoints >= definition.threshold) result = definition.id;
   }
   return result;
 }
 
 export function nextGuardianRank(points: number): { rank: GuardianRankId; threshold: number } | null {
-  const next = guardianRankDefinitions.find(definition => definition.threshold > points);
+  const safePoints = safeCount(points);
+  const next = guardianRankDefinitions.find(definition => definition.threshold > safePoints);
   return next ? { rank: next.id, threshold: next.threshold } : null;
 }

--- a/src/personality-choice-impact.test.ts
+++ b/src/personality-choice-impact.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { applyTrainingIdentityEffects } from './raising-depth-effects';
+
+const stats = {
+  strength:30,
+  intelligence:30,
+  magic:30,
+  morality:40,
+  affection:45,
+  stress:12,
+  fatigue:18,
+};
+
+const mastery = {
+  hunt:{ xp:0 },
+  magic:{ xp:0 },
+  rest:{ xp:0 },
+  herb:{ xp:0 },
+};
+
+describe('personality choice impact', () => {
+  it('leaves one preferred-activity growth trace for each actual schedule choice', () => {
+    const result = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:60, kindness:20, curiosity:20, calmness:20 },
+      mastery,
+      schedule:['hunt','hunt','hunt'],
+      trainingScore:500,
+      activeCalling:null,
+      purchasedTraits:[],
+    });
+
+    expect(result.mastery.hunt.xp).toBe(3);
+    expect(result.personality.courage).toBe(63);
+  });
+
+  it('sanitizes malformed identity values before applying preferred growth', () => {
+    const result = applyTrainingIdentityEffects({
+      stats:{ ...stats, strength:Number.NaN, fatigue:Number.POSITIVE_INFINITY },
+      personality:{ courage:Number.POSITIVE_INFINITY, kindness:20, curiosity:20, calmness:20 },
+      mastery:{ ...mastery, hunt:{ xp:Number.NaN } },
+      schedule:['hunt'],
+      trainingScore:Number.POSITIVE_INFINITY,
+      activeCalling:'vanguard',
+      purchasedTraits:['vanguard_power','vanguard_focus'],
+    });
+
+    expect(Object.values(result.stats).every(Number.isFinite)).toBe(true);
+    expect(Object.values(result.personality).every(Number.isFinite)).toBe(true);
+    expect(Object.values(result.mastery).every(entry => Number.isFinite(entry.xp))).toBe(true);
+  });
+});

--- a/src/personality-choice-impact.test.ts
+++ b/src/personality-choice-impact.test.ts
@@ -49,4 +49,23 @@ describe('personality choice impact', () => {
     expect(Object.values(result.personality).every(Number.isFinite)).toBe(true);
     expect(Object.values(result.mastery).every(entry => Number.isFinite(entry.xp))).toBe(true);
   });
+
+  it('restores a complete mastery shape when a direct caller supplies a damaged partial object', () => {
+    const result = applyTrainingIdentityEffects({
+      stats,
+      personality:{ courage:20, kindness:20, curiosity:60, calmness:20 },
+      mastery:{ magic:{ xp:2 } } as typeof mastery,
+      schedule:['magic'],
+      trainingScore:500,
+      activeCalling:null,
+      purchasedTraits:[],
+    });
+
+    expect(result.mastery).toEqual({
+      hunt:{ xp:0 },
+      magic:{ xp:3 },
+      rest:{ xp:0 },
+      herb:{ xp:0 },
+    });
+  });
 });

--- a/src/personality-outcomes.test.ts
+++ b/src/personality-outcomes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { personalityOutcome } from './runa-personality';
+
+describe('personality outcome differentiation', () => {
+  it('gives each dominant personality a distinct dialogue, event, reward, and career direction', () => {
+    const archetypes = ['brave', 'gentle', 'curious', 'serene'] as const;
+    const outcomes = archetypes.map(archetype => personalityOutcome(archetype));
+
+    expect(new Set(outcomes.map(item => item.dialogue)).size).toBe(archetypes.length);
+    expect(new Set(outcomes.map(item => item.event)).size).toBe(archetypes.length);
+    expect(new Set(outcomes.map(item => item.reward)).size).toBe(archetypes.length);
+    expect(new Set(outcomes.map(item => item.career)).size).toBe(archetypes.length);
+  });
+
+  it('keeps balanced personality neutral instead of silently collapsing to serene', () => {
+    expect(personalityOutcome('balanced')).toEqual({
+      dialogue: 'adaptive',
+      event: 'open_choice',
+      reward: 'flexible',
+      career: null,
+    });
+  });
+});

--- a/src/raising-calling-history.test.ts
+++ b/src/raising-calling-history.test.ts
@@ -23,4 +23,13 @@ describe('Raising Calling history hydration', () => {
     });
     expect(present.callingHistory).toEqual(['arcanist','vanguard']);
   });
+
+  it('clears a stale monthly switch lock when no Calling is active', () => {
+    const hydrated = hydrateRaisingDepthState({
+      activeCalling:null,
+      callingHistory:[],
+      callingLastSwitchKey:'2-7',
+    });
+    expect(hydrated.callingLastSwitchKey).toBeNull();
+  });
 });

--- a/src/raising-calling-history.test.ts
+++ b/src/raising-calling-history.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { hydrateRaisingDepthState } from './raising-depth-state';
+
+describe('Raising Calling history hydration', () => {
+  it('preserves first-seen Calling chronology instead of re-sorting by definition order', () => {
+    const hydrated = hydrateRaisingDepthState({
+      activeCalling:'caretaker',
+      callingHistory:['pathfinder','vanguard','pathfinder','caretaker'],
+    });
+    expect(hydrated.callingHistory).toEqual(['pathfinder','vanguard','caretaker']);
+  });
+
+  it('restores a valid active Calling into damaged history without duplication', () => {
+    const missing = hydrateRaisingDepthState({
+      activeCalling:'arcanist',
+      callingHistory:['vanguard','caretaker'],
+    });
+    expect(missing.callingHistory).toEqual(['vanguard','caretaker','arcanist']);
+
+    const present = hydrateRaisingDepthState({
+      activeCalling:'arcanist',
+      callingHistory:['arcanist','vanguard','arcanist'],
+    });
+    expect(present.callingHistory).toEqual(['arcanist','vanguard']);
+  });
+});

--- a/src/raising-depth-effects.test.ts
+++ b/src/raising-depth-effects.test.ts
@@ -8,7 +8,7 @@ describe('raising depth training and gift effects', () => {
     expect(next.stats.affection).toBe(42);
   });
 
-  it('adds one personality point only when the scheduled activity matches Runa preference', () => {
+  it('adds one personality trace for each scheduled activity matching Runa preference', () => {
     const brave = {
       ...initialState,
       schedule:['hunt','hunt','hunt','hunt'] as typeof initialState.schedule,
@@ -20,7 +20,7 @@ describe('raising depth training and gift effects', () => {
     };
     const favored = reducer(brave, { type:'FINISH_TRAINING', eventRoll:0.999 });
     const control = reducer(sereneControl, { type:'FINISH_TRAINING', eventRoll:0.999 });
-    expect(favored.personality.courage).toBe(control.personality.courage + 1);
+    expect(favored.personality.courage).toBe(control.personality.courage + 4);
   });
 
   it('applies active vanguard power trait on hunt training', () => {

--- a/src/raising-depth-effects.ts
+++ b/src/raising-depth-effects.ts
@@ -4,7 +4,11 @@ import { activeCallingTraits, type GrowthTraitId } from './growth-traits';
 import type { GuardianCallingId } from './guardian-callings';
 import { personalityArchetype, runaPreferences } from './runa-personality';
 
-const clamp = (value:number) => Math.max(0, Math.min(100, value));
+const clamp = (value:number) => {
+  const safe = Number.isFinite(value) ? value : 0;
+  return Math.max(0, Math.min(100, safe));
+};
+const safeXp = (value:number) => Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 
 const personalityKeyByActivity: Record<ActivityId, keyof Personality> = {
   hunt:'courage',
@@ -12,6 +16,37 @@ const personalityKeyByActivity: Record<ActivityId, keyof Personality> = {
   rest:'calmness',
   herb:'curiosity',
 };
+
+function canonicalStats(stats:Stats): Stats {
+  return {
+    strength:clamp(stats.strength),
+    intelligence:clamp(stats.intelligence),
+    magic:clamp(stats.magic),
+    morality:clamp(stats.morality),
+    affection:clamp(stats.affection),
+    stress:clamp(stats.stress),
+    fatigue:clamp(stats.fatigue),
+  };
+}
+
+function canonicalPersonality(personality:Personality): Personality {
+  return {
+    courage:clamp(personality.courage),
+    kindness:clamp(personality.kindness),
+    curiosity:clamp(personality.curiosity),
+    calmness:clamp(personality.calmness),
+  };
+}
+
+function canonicalMastery(mastery:MasteryState): MasteryState {
+  return Object.fromEntries(
+    Object.entries(mastery).map(([id, entry]) => [id, { xp:safeXp(entry?.xp) }]),
+  ) as MasteryState;
+}
+
+function incrementMasteryXp(mastery:MasteryState, activity:ActivityId): void {
+  mastery[activity] = { xp:safeXp(mastery[activity]?.xp) + 1 };
+}
 
 export type TrainingIdentityInput = {
   stats:Stats;
@@ -24,15 +59,17 @@ export type TrainingIdentityInput = {
 };
 
 export function applyTrainingIdentityEffects(input:TrainingIdentityInput) {
-  const stats = { ...input.stats };
-  const personality = { ...input.personality };
-  const mastery = Object.fromEntries(Object.entries(input.mastery).map(([id, entry]) => [id, { ...entry }])) as MasteryState;
+  const stats = canonicalStats(input.stats);
+  const personality = canonicalPersonality(input.personality);
+  const mastery = canonicalMastery(input.mastery);
   const preferences = runaPreferences(personalityArchetype(input.personality), input.activeCalling);
   const activeTraits = new Set(activeCallingTraits(input.activeCalling, input.purchasedTraits));
 
-  if (input.schedule.includes(preferences.favoriteActivity)) {
+  const preferredActivityCount = input.schedule.filter(activity => activity === preferences.favoriteActivity).length;
+  if (preferredActivityCount > 0) {
     const key = personalityKeyByActivity[preferences.favoriteActivity];
-    personality[key] = clamp(personality[key] + 1);
+    personality[key] = clamp(personality[key] + preferredActivityCount);
+    for (let count = 0; count < preferredActivityCount; count += 1) incrementMasteryXp(mastery, preferences.favoriteActivity);
   }
 
   if (activeTraits.has('vanguard_power') && input.schedule.includes('hunt')) stats.strength = clamp(stats.strength + 1);
@@ -40,9 +77,8 @@ export function applyTrainingIdentityEffects(input:TrainingIdentityInput) {
   if (activeTraits.has('arcanist_insight') && input.schedule.includes('magic')) stats.intelligence = clamp(stats.intelligence + 1);
   if (activeTraits.has('caretaker_rest') && input.schedule.includes('rest')) stats.fatigue = clamp(stats.fatigue - 2);
   if (activeTraits.has('pathfinder_herb') && input.schedule.includes('herb')) stats.intelligence = clamp(stats.intelligence + 1);
-  if (activeTraits.has('vanguard_focus') && input.schedule.includes('hunt') && input.trainingScore >= 650) {
-    mastery.hunt = { xp: mastery.hunt.xp + 1 };
-  }
+  const trainingScore = Number.isFinite(input.trainingScore) ? Math.max(0, input.trainingScore) : 0;
+  if (activeTraits.has('vanguard_focus') && input.schedule.includes('hunt') && trainingScore >= 650) incrementMasteryXp(mastery, 'hunt');
 
   return { stats, personality, mastery, preferences };
 }
@@ -56,7 +92,7 @@ export type GiftIdentityInput = {
 };
 
 export function applyGiftIdentityEffects(input:GiftIdentityInput) {
-  const stats = { ...input.stats };
+  const stats = canonicalStats(input.stats);
   const preferences = runaPreferences(personalityArchetype(input.personality), input.activeCalling);
   const activeTraits = new Set(activeCallingTraits(input.activeCalling, input.purchasedTraits));
   if (input.item === preferences.favoriteGift) stats.affection = clamp(stats.affection + 2);

--- a/src/raising-depth-effects.ts
+++ b/src/raising-depth-effects.ts
@@ -9,6 +9,7 @@ const clamp = (value:number) => {
   return Math.max(0, Math.min(100, safe));
 };
 const safeXp = (value:number) => Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+const activityIds:ActivityId[] = ['hunt','magic','rest','herb'];
 
 const personalityKeyByActivity: Record<ActivityId, keyof Personality> = {
   hunt:'courage',
@@ -40,7 +41,7 @@ function canonicalPersonality(personality:Personality): Personality {
 
 function canonicalMastery(mastery:MasteryState): MasteryState {
   return Object.fromEntries(
-    Object.entries(mastery).map(([id, entry]) => [id, { xp:safeXp(entry?.xp) }]),
+    activityIds.map(id => [id, { xp:safeXp(mastery[id]?.xp) }]),
   ) as MasteryState;
 }
 

--- a/src/raising-depth-reward-boundary.test.ts
+++ b/src/raising-depth-reward-boundary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { emptyCallingMastery } from './calling-mastery';
+import {
+  applyBossGrowthPointReward,
+  incrementCallingMonthMastery,
+  monthGrowthPointReward,
+  reconcileBondSceneRewards,
+} from './raising-depth-rewards';
+
+describe('Raising reward corruption boundaries', () => {
+  it('does not treat non-finite training score as an S-month bonus', () => {
+    expect(monthGrowthPointReward(Number.POSITIVE_INFINITY)).toBe(1);
+    expect(monthGrowthPointReward(Number.NaN)).toBe(1);
+  });
+
+  it('repairs malformed active Calling mastery before incrementing it', () => {
+    const mastery = { ...emptyCallingMastery(), vanguard:Number.NaN };
+    expect(incrementCallingMonthMastery(mastery, 'vanguard').vanguard).toBe(1);
+  });
+
+  it('sanitizes boss growth points and canonicalizes rewarded boss ids', () => {
+    const result = applyBossGrowthPointReward(
+      'forest_guardian',
+      true,
+      ['forest_guardian','forest_guardian'],
+      Number.POSITIVE_INFINITY,
+    );
+    expect(result.points).toBe(0);
+    expect(result.rewarded).toEqual(['forest_guardian']);
+  });
+
+  it('repairs non-finite bond currency without paying the same scene again', () => {
+    const progress = {
+      affection:55,
+      outings:0,
+      trainings:0,
+      gifts:0,
+      guardianRank:'trainee' as const,
+      bossClears:0,
+      annualRecords:0,
+      unlocked:['first_trust' as const],
+      rewarded:['first_trust' as const],
+      gold:Number.NaN,
+      gems:Number.POSITIVE_INFINITY,
+    };
+    const result = reconcileBondSceneRewards(progress, progress);
+    expect(result.changed).toBe(true);
+    expect(result.gold).toBe(0);
+    expect(result.gems).toBe(0);
+    expect(result.rewarded).toEqual(['first_trust']);
+  });
+});

--- a/src/raising-depth-rewards.test.ts
+++ b/src/raising-depth-rewards.test.ts
@@ -108,7 +108,7 @@ describe('raising depth rewards and bond progression', () => {
     expect(caughtUp.gold).toBe(600);
   });
 
-  it('restores a missing unlock from an existing reward claim without paying twice', () => {
+  it('restores a missing unlock from an existing reward claim without treating it as a new scene or paying twice', () => {
     const progress = {
       affection:0,
       outings:0,
@@ -126,6 +126,7 @@ describe('raising depth rewards and bond progression', () => {
     expect(repaired.changed).toBe(true);
     expect(repaired.unlocked).toEqual(['first_trust']);
     expect(repaired.rewarded).toEqual(['first_trust']);
+    expect(repaired.newlyUnlocked).toEqual([]);
     expect(repaired.gold).toBe(500);
     expect(repaired.gems).toBe(2);
   });

--- a/src/raising-depth-rewards.ts
+++ b/src/raising-depth-rewards.ts
@@ -50,7 +50,7 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
   const provenUnlocks = bondSceneIds.filter(id => claimedUnlocks.includes(id) || claimedRewards.includes(id));
   const afterEligible = eligible({ ...current, unlocked:provenUnlocks });
   const unlocked = bondSceneIds.filter(id => provenUnlocks.includes(id) || afterEligible.includes(id));
-  const newlyUnlocked = unlocked.filter(id => !claimedUnlocks.includes(id));
+  const newlyUnlocked = unlocked.filter(id => !claimedUnlocks.includes(id) && !claimedRewards.includes(id));
   const newlyRewarded = unlocked.filter(id => !claimedRewards.includes(id));
   const rewarded = bondSceneIds.filter(id => claimedRewards.includes(id) || newlyRewarded.includes(id));
   const safeGold = safeNonNegativeInt(current.gold);

--- a/src/raising-depth-rewards.ts
+++ b/src/raising-depth-rewards.ts
@@ -1,6 +1,6 @@
 import { bondSceneDefinitions, bondSceneIds, eligibleBondScenes, type BondSceneId } from './bond-scenes';
 import type { CallingMasteryState } from './calling-mastery';
-import type { GuardianCallingId } from './guardian-callings';
+import { guardianCallingIds, type GuardianCallingId } from './guardian-callings';
 import type { GuardianRankId } from './guardian-rank';
 import { isBossStage } from './expedition-bosses';
 import type { ExpeditionStageId } from './expedition-regions';
@@ -19,15 +19,23 @@ export type BondRewardProgress = {
   gems:number;
 };
 
+function safeNonNegativeInt(value:number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function safeAffection(value:number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 0;
+}
+
 function eligible(progress: BondRewardProgress): BondSceneId[] {
   return eligibleBondScenes({
-    affection:progress.affection,
-    outings:progress.outings,
-    trainings:progress.trainings,
-    gifts:progress.gifts,
+    affection:safeAffection(progress.affection),
+    outings:safeNonNegativeInt(progress.outings),
+    trainings:safeNonNegativeInt(progress.trainings),
+    gifts:safeNonNegativeInt(progress.gifts),
     guardianRank:progress.guardianRank,
-    bossClears:progress.bossClears,
-    annualRecords:progress.annualRecords,
+    bossClears:safeNonNegativeInt(progress.bossClears),
+    annualRecords:safeNonNegativeInt(progress.annualRecords),
     alreadyUnlocked:progress.unlocked,
   });
 }
@@ -45,7 +53,12 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
   const newlyUnlocked = unlocked.filter(id => !claimedUnlocks.includes(id));
   const newlyRewarded = unlocked.filter(id => !claimedRewards.includes(id));
   const rewarded = bondSceneIds.filter(id => claimedRewards.includes(id) || newlyRewarded.includes(id));
-  const canonicalized = !sameIds(current.unlocked, unlocked) || !sameIds(current.rewarded, rewarded);
+  const safeGold = safeNonNegativeInt(current.gold);
+  const safeGems = safeNonNegativeInt(current.gems);
+  const canonicalized = !sameIds(current.unlocked, unlocked)
+    || !sameIds(current.rewarded, rewarded)
+    || safeGold !== current.gold
+    || safeGems !== current.gems;
 
   if (!newlyUnlocked.length && !newlyRewarded.length && !canonicalized) return {
     changed:false,
@@ -56,8 +69,8 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
     newlyUnlocked:[] as BondSceneId[],
   };
 
-  let gold = current.gold;
-  let gems = current.gems;
+  let gold = safeGold;
+  let gems = safeGems;
   for (const id of newlyRewarded) {
     const reward = bondSceneDefinitions.find(item => item.id === id)?.reward;
     gold += reward?.gold ?? 0;
@@ -74,15 +87,18 @@ export function reconcileBondSceneRewards(_previous: BondRewardProgress, current
 }
 
 export function monthGrowthPointReward(trainingScore:number): number {
-  return 1 + (trainingScore >= 900 ? 1 : 0);
+  return 1 + (Number.isFinite(trainingScore) && trainingScore >= 900 ? 1 : 0);
 }
 
 export function incrementCallingMonthMastery(mastery: CallingMasteryState, calling: GuardianCallingId | null): CallingMasteryState {
-  if (!calling) return mastery;
-  return { ...mastery, [calling]:mastery[calling] + 1 };
+  const sanitized = Object.fromEntries(guardianCallingIds.map(id => [id, safeNonNegativeInt(mastery[id])])) as CallingMasteryState;
+  if (!calling) return sanitized;
+  return { ...sanitized, [calling]:sanitized[calling] + 1 };
 }
 
 export function applyBossGrowthPointReward(stageId: ExpeditionStageId, firstClear:boolean, rewarded:ExpeditionStageId[], points:number) {
-  if (!firstClear || !isBossStage(stageId) || rewarded.includes(stageId)) return { points, rewarded };
-  return { points:points + 1, rewarded:[...rewarded, stageId] };
+  const safePoints = safeNonNegativeInt(points);
+  const canonicalRewards = rewarded.filter((id, index) => isBossStage(id) && rewarded.indexOf(id) === index);
+  if (!firstClear || !isBossStage(stageId) || canonicalRewards.includes(stageId)) return { points:safePoints, rewarded:canonicalRewards };
+  return { points:safePoints + 1, rewarded:[...canonicalRewards, stageId] };
 }

--- a/src/raising-depth-state.ts
+++ b/src/raising-depth-state.ts
@@ -1,7 +1,7 @@
 import { bondSceneIds, type BondSceneId } from './bond-scenes';
 import { emptyCallingMastery, type CallingMasteryState } from './calling-mastery';
 import { guardianCallingIds, type GuardianCallingId } from './guardian-callings';
-import { growthTraitIds, type GrowthTraitId } from './growth-traits';
+import { canonicalGrowthTraits, growthTraitIds, type GrowthTraitId } from './growth-traits';
 import { expeditionStageDefinitions, type ExpeditionStageId } from './expedition-regions';
 
 export type RaisingDepthPersistentState = {
@@ -64,13 +64,14 @@ export function hydrateRaisingDepthState(raw: unknown): RaisingDepthPersistentSt
   const masterySource = isRecord(source.callingMastery) ? source.callingMastery : {};
   const unlockedBondScenes = uniqueAllowed(source.unlockedBondScenes, bondSceneIds);
   const rewardedBondScenes = uniqueAllowed(source.rewardedBondScenes, bondSceneIds).filter(id => unlockedBondScenes.includes(id));
+  const purchasedTraits = canonicalGrowthTraits(uniqueAllowed(source.purchasedTraits, growthTraitIds));
   return {
     activeCalling,
     callingHistory:uniqueAllowed(source.callingHistory, guardianCallingIds),
     callingMastery:Object.fromEntries(guardianCallingIds.map(id => [id, int(masterySource[id])])) as CallingMasteryState,
     callingLastSwitchKey:hydrateSwitchKey(source.callingLastSwitchKey),
     growthPoints:int(source.growthPoints),
-    purchasedTraits:uniqueAllowed(source.purchasedTraits, growthTraitIds),
+    purchasedTraits,
     unlockedBondScenes,
     rewardedBondScenes,
     growthPointBossRewards:uniqueAllowed(source.growthPointBossRewards, bossStageIds),

--- a/src/raising-depth-state.ts
+++ b/src/raising-depth-state.ts
@@ -41,6 +41,19 @@ function uniqueAllowed<T extends string>(raw: unknown, allowed: readonly T[]): T
   return allowed.filter(id => raw.includes(id));
 }
 
+function hydrateCallingHistory(raw:unknown, activeCalling:GuardianCallingId | null): GuardianCallingId[] {
+  const history:GuardianCallingId[] = [];
+  if (Array.isArray(raw)) {
+    for (const value of raw) {
+      if (typeof value !== 'string' || !guardianCallingIds.includes(value as GuardianCallingId)) continue;
+      const id = value as GuardianCallingId;
+      if (!history.includes(id)) history.push(id);
+    }
+  }
+  if (activeCalling && !history.includes(activeCalling)) history.push(activeCalling);
+  return history;
+}
+
 function hydrateSwitchKey(raw: unknown): string | null {
   if (typeof raw !== 'string') return null;
   const match = /^(\d+)-(\d+)$/.exec(raw);
@@ -68,7 +81,7 @@ export function hydrateRaisingDepthState(raw: unknown): RaisingDepthPersistentSt
   const purchasedTraits = canonicalGrowthTraits(uniqueAllowed(source.purchasedTraits, growthTraitIds));
   return {
     activeCalling,
-    callingHistory:uniqueAllowed(source.callingHistory, guardianCallingIds),
+    callingHistory:hydrateCallingHistory(source.callingHistory, activeCalling),
     callingMastery:Object.fromEntries(guardianCallingIds.map(id => [id, int(masterySource[id])])) as CallingMasteryState,
     callingLastSwitchKey:hydrateSwitchKey(source.callingLastSwitchKey),
     growthPoints:int(source.growthPoints),

--- a/src/raising-depth-state.ts
+++ b/src/raising-depth-state.ts
@@ -83,7 +83,7 @@ export function hydrateRaisingDepthState(raw: unknown): RaisingDepthPersistentSt
     activeCalling,
     callingHistory:hydrateCallingHistory(source.callingHistory, activeCalling),
     callingMastery:Object.fromEntries(guardianCallingIds.map(id => [id, int(masterySource[id])])) as CallingMasteryState,
-    callingLastSwitchKey:hydrateSwitchKey(source.callingLastSwitchKey),
+    callingLastSwitchKey:activeCalling ? hydrateSwitchKey(source.callingLastSwitchKey) : null,
     growthPoints:int(source.growthPoints),
     purchasedTraits,
     unlockedBondScenes,

--- a/src/raising-depth-state.ts
+++ b/src/raising-depth-state.ts
@@ -62,8 +62,9 @@ export function hydrateRaisingDepthState(raw: unknown): RaisingDepthPersistentSt
     ? source.activeCalling as GuardianCallingId
     : null;
   const masterySource = isRecord(source.callingMastery) ? source.callingMastery : {};
-  const unlockedBondScenes = uniqueAllowed(source.unlockedBondScenes, bondSceneIds);
-  const rewardedBondScenes = uniqueAllowed(source.rewardedBondScenes, bondSceneIds).filter(id => unlockedBondScenes.includes(id));
+  const claimedUnlocks = uniqueAllowed(source.unlockedBondScenes, bondSceneIds);
+  const rewardedBondScenes = uniqueAllowed(source.rewardedBondScenes, bondSceneIds);
+  const unlockedBondScenes = bondSceneIds.filter(id => claimedUnlocks.includes(id) || rewardedBondScenes.includes(id));
   const purchasedTraits = canonicalGrowthTraits(uniqueAllowed(source.purchasedTraits, growthTraitIds));
   return {
     activeCalling,

--- a/src/raising-depth-state.ts
+++ b/src/raising-depth-state.ts
@@ -18,6 +18,7 @@ export type RaisingDepthPersistentState = {
 };
 
 const bossStageIds = expeditionStageDefinitions.filter(item => item.boss).map(item => item.id);
+const legendRewardEffects = ['vanguard_legend','arcanist_legend','pathfinder_legend'] as const;
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
 const int = (value: unknown) => typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 
@@ -65,8 +66,19 @@ function hydrateSwitchKey(raw: unknown): string | null {
 
 function hydrateLegendRewardKeys(raw: unknown): string[] {
   if (!Array.isArray(raw)) return [];
-  const valid = raw.filter((value): value is string => typeof value === 'string' && /^\d+-\d+:[a-z0-9_:-]+$/.test(value));
-  return [...new Set(valid)];
+  const valid:string[] = [];
+  for (const value of raw) {
+    if (typeof value !== 'string') continue;
+    const match = /^(\d+)-(\d+):([a-z0-9_]+)$/.exec(value);
+    if (!match) continue;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const effect = match[3];
+    if (year < 1 || month < 1 || month > 12 || !legendRewardEffects.includes(effect as typeof legendRewardEffects[number])) continue;
+    const key = `${year}-${month}:${effect}`;
+    if (!valid.includes(key)) valid.push(key);
+  }
+  return valid;
 }
 
 export function hydrateRaisingDepthState(raw: unknown): RaisingDepthPersistentState {

--- a/src/raising-legend-key-hydration.test.ts
+++ b/src/raising-legend-key-hydration.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { hydrateRaisingDepthState } from './raising-depth-state';
+
+describe('Raising legend reward key hydration', () => {
+  it('keeps only canonical monthly legend reward claims', () => {
+    const hydrated = hydrateRaisingDepthState({
+      legendRewardKeys:[
+        '1-4:vanguard_legend',
+        '2-12:arcanist_legend',
+        '3-7:pathfinder_legend',
+        '0-4:vanguard_legend',
+        '1-13:vanguard_legend',
+        '1-4:unknown_effect',
+        '1-4:vanguard_legend',
+      ],
+    });
+    expect(hydrated.legendRewardKeys).toEqual([
+      '1-4:vanguard_legend',
+      '2-12:arcanist_legend',
+      '3-7:pathfinder_legend',
+    ]);
+  });
+});

--- a/src/raising-legend-key-hydration.test.ts
+++ b/src/raising-legend-key-hydration.test.ts
@@ -20,4 +20,15 @@ describe('Raising legend reward key hydration', () => {
       '3-7:pathfinder_legend',
     ]);
   });
+
+  it('canonicalizes zero-padded dates before deduping claims', () => {
+    const hydrated = hydrateRaisingDepthState({
+      legendRewardKeys:[
+        '2-06:vanguard_legend',
+        '2-6:vanguard_legend',
+        '0002-006:vanguard_legend',
+      ],
+    });
+    expect(hydrated.legendRewardKeys).toEqual(['2-6:vanguard_legend']);
+  });
 });

--- a/src/raising-path-diversity.test.ts
+++ b/src/raising-path-diversity.test.ts
@@ -45,4 +45,23 @@ describe('multi-run Raising path diversity', () => {
     expect(caretaker.callingMastery.caretaker).toBe(6);
     expect(pathfinder.callingMastery.pathfinder).toBe(6);
   });
+
+  it('does not leak Raising identity state into a fresh run after RESET', () => {
+    const completed = simulateRoute(routes[0]);
+    const withBond:GameState = {
+      ...completed,
+      growthPoints:9,
+      unlockedBondScenes:['first_trust','shared_secret'],
+      rewardedBondScenes:['first_trust','shared_secret'],
+    };
+    const fresh = reducer(withBond, { type:'RESET' });
+
+    expect(fresh.activeCalling).toBeNull();
+    expect(fresh.callingHistory).toEqual([]);
+    expect(fresh.callingMastery).toEqual({ vanguard:0, arcanist:0, caretaker:0, pathfinder:0 });
+    expect(fresh.purchasedTraits).toEqual([]);
+    expect(fresh.unlockedBondScenes).toEqual([]);
+    expect(fresh.rewardedBondScenes).toEqual([]);
+    expect(fresh.growthPoints).toBe(0);
+  });
 });

--- a/src/raising-path-diversity.test.ts
+++ b/src/raising-path-diversity.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { initialState, reducer, type ActivityId, type GameState, type GuardianCallingId, type GrowthTraitId } from './game-base';
+
+const routes: Array<{ calling:GuardianCallingId; schedule:ActivityId[]; traits:GrowthTraitId[] }> = [
+  { calling:'vanguard', schedule:['hunt','hunt','hunt','hunt'], traits:['vanguard_power','vanguard_focus'] },
+  { calling:'arcanist', schedule:['magic','magic','magic','magic'], traits:['arcanist_mana','arcanist_insight'] },
+  { calling:'caretaker', schedule:['rest','rest','rest','rest'], traits:['caretaker_rest','caretaker_bond'] },
+  { calling:'pathfinder', schedule:['herb','herb','herb','herb'], traits:['pathfinder_herb','pathfinder_eye'] },
+];
+
+function simulateRoute(route: (typeof routes)[number], months = 6): GameState {
+  let state:GameState = {
+    ...initialState,
+    activeCalling:route.calling,
+    callingHistory:[route.calling],
+    purchasedTraits:[...route.traits],
+  };
+  for (let month = 0; month < months; month += 1) {
+    state = reducer({ ...state, schedule:[...route.schedule], trainingScore:700 }, { type:'FINISH_TRAINING', eventRoll:0.99 });
+    state = reducer(state, { type:'NEXT_MONTH' });
+  }
+  return state;
+}
+
+describe('multi-run Raising path diversity', () => {
+  it('keeps four deliberate growth routes observably distinct after repeated months', () => {
+    const results = routes.map(route => simulateRoute(route));
+    const fingerprints = results.map(state => JSON.stringify({
+      stats:state.stats,
+      personality:state.personality,
+      mastery:state.mastery,
+      callingMastery:state.callingMastery,
+    }));
+    expect(new Set(fingerprints).size).toBe(routes.length);
+  });
+
+  it('preserves each route primary mastery instead of converging on one line', () => {
+    const [vanguard, arcanist, caretaker, pathfinder] = routes.map(route => simulateRoute(route));
+    expect(vanguard.mastery.hunt.xp).toBeGreaterThan(vanguard.mastery.magic.xp);
+    expect(arcanist.mastery.magic.xp).toBeGreaterThan(arcanist.mastery.hunt.xp);
+    expect(caretaker.mastery.rest.xp).toBeGreaterThan(caretaker.mastery.hunt.xp);
+    expect(pathfinder.mastery.herb.xp).toBeGreaterThan(pathfinder.mastery.hunt.xp);
+    expect(vanguard.callingMastery.vanguard).toBe(6);
+    expect(arcanist.callingMastery.arcanist).toBe(6);
+    expect(caretaker.callingMastery.caretaker).toBe(6);
+    expect(pathfinder.callingMastery.pathfinder).toBe(6);
+  });
+});

--- a/src/runa-personality.ts
+++ b/src/runa-personality.ts
@@ -4,6 +4,13 @@ import type { ActivityId, Personality } from './game-core';
 export type RunaPersonalityArchetype = 'brave' | 'gentle' | 'curious' | 'serene' | 'balanced';
 export type PreferenceCallingId = 'vanguard' | 'arcanist' | 'caretaker' | 'pathfinder';
 
+export type PersonalityOutcome = {
+  dialogue: 'direct' | 'empathetic' | 'inquisitive' | 'reflective' | 'adaptive';
+  event: 'challenge' | 'bond' | 'discovery' | 'recovery' | 'open_choice';
+  reward: 'mastery' | 'affection' | 'insight' | 'recovery' | 'flexible';
+  career: PreferenceCallingId | null;
+};
+
 const personalityKeys: Array<keyof Personality> = ['courage', 'kindness', 'curiosity', 'calmness'];
 const archetypeByKey: Record<keyof Personality, Exclude<RunaPersonalityArchetype, 'balanced'>> = {
   courage: 'brave',
@@ -12,12 +19,24 @@ const archetypeByKey: Record<keyof Personality, Exclude<RunaPersonalityArchetype
   calmness: 'serene',
 };
 
+const outcomeByArchetype: Record<RunaPersonalityArchetype, PersonalityOutcome> = {
+  brave: { dialogue: 'direct', event: 'challenge', reward: 'mastery', career: 'vanguard' },
+  gentle: { dialogue: 'empathetic', event: 'bond', reward: 'affection', career: 'caretaker' },
+  curious: { dialogue: 'inquisitive', event: 'discovery', reward: 'insight', career: 'arcanist' },
+  serene: { dialogue: 'reflective', event: 'recovery', reward: 'recovery', career: 'pathfinder' },
+  balanced: { dialogue: 'adaptive', event: 'open_choice', reward: 'flexible', career: null },
+};
+
 export function personalityArchetype(personality: Personality): RunaPersonalityArchetype {
   const ranked = personalityKeys
     .map(key => ({ key, value: Number.isFinite(personality[key]) ? personality[key] : 0 }))
     .sort((a, b) => b.value - a.value);
   if (ranked.length < 2 || ranked[0].value - ranked[1].value < 5) return 'balanced';
   return archetypeByKey[ranked[0].key];
+}
+
+export function personalityOutcome(archetype: RunaPersonalityArchetype): PersonalityOutcome {
+  return outcomeByArchetype[archetype];
 }
 
 const activityByCalling: Record<PreferenceCallingId, ActivityId> = {

--- a/src/story-chapters.test.ts
+++ b/src/story-chapters.test.ts
@@ -110,4 +110,28 @@ describe('story chapter rules', () => {
     expect(eligibleStoryChapters({ ...base, discoveries: 3 })).not.toContain('starlight_road');
     expect(eligibleStoryChapters({ ...base, discoveries: 4 })).toContain('starlight_road');
   });
+
+  it('does not unlock Raising story gates from non-finite progress', () => {
+    const fallbackBond = eligibleStoryChapters({
+      memories:['first_training'],
+      visitedOutings:['forest','village','lakeside'],
+      affection:Number.POSITIVE_INFINITY,
+      guardianRank:'trainee',
+      discoveries:0,
+      expeditionStoryEntries:[],
+    });
+    expect(fallbackBond).toEqual(['first_step','wide_world']);
+
+    const finalGate = eligibleStoryChapters({
+      memories:['first_training'],
+      visitedOutings:['forest','village','lakeside'],
+      affection:95,
+      guardianRank:'veteran',
+      discoveries:Number.POSITIVE_INFINITY,
+      expeditionStoryEntries:[],
+      unlockedBondScenes:['shared_secret'],
+      activeCalling:'pathfinder',
+    });
+    expect(finalGate).not.toContain('starlight_road');
+  });
 });

--- a/src/story-chapters.ts
+++ b/src/story-chapters.ts
@@ -60,13 +60,15 @@ export const storyChapterDefinitions: StoryChapterDefinition[] = [...coreStoryCh
 export const storyChapterIds = storyChapterDefinitions.map(chapter => chapter.id);
 const guardianRankOrder: GuardianRankId[] = ['trainee', 'junior', 'guardian', 'veteran', 'starlight'];
 const requiredOutings: OutingLocationId[] = ['forest', 'village', 'lakeside'];
+const safeCount = (value:number):number => Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+const safeAffection = (value:number):number => Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 0;
 
 function rankAtLeast(rank: GuardianRankId, target: GuardianRankId): boolean {
   return guardianRankOrder.indexOf(rank) >= guardianRankOrder.indexOf(target);
 }
 
 function trustedBondReady(progress: StoryProgress): boolean {
-  if (progress.unlockedBondScenes === undefined) return progress.affection >= 75;
+  if (progress.unlockedBondScenes === undefined) return safeAffection(progress.affection) >= 75;
   return progress.unlockedBondScenes.includes('shared_secret');
 }
 
@@ -76,6 +78,7 @@ function callingChosen(progress: StoryProgress): boolean {
 
 export function eligibleStoryChapters(progress: StoryProgress): StoryChapterId[] {
   const unlocked = new Set<StoryChapterId>();
+  const discoveries = safeCount(progress.discoveries);
 
   const firstStepReady = progress.memories.includes('first_training');
   if (firstStepReady) {
@@ -92,7 +95,7 @@ export function eligibleStoryChapters(progress: StoryProgress): StoryChapterId[]
         const oathReady = rankAtLeast(progress.guardianRank, 'guardian') && callingChosen(progress);
         if (oathReady) {
           unlocked.add('guardian_oath');
-          if (rankAtLeast(progress.guardianRank, 'veteran') && progress.discoveries >= 4) unlocked.add('starlight_road');
+          if (rankAtLeast(progress.guardianRank, 'veteran') && discoveries >= 4) unlocked.add('starlight_road');
         }
       }
     }

--- a/src/story-chapters.ts
+++ b/src/story-chapters.ts
@@ -38,6 +38,16 @@ const coreStoryChapterDefinitions: StoryChapterDefinition[] = [
 
 export const coreStoryChapterIds = coreStoryChapterDefinitions.map(chapter => chapter.id as CoreStoryChapterId);
 
+export function canonicalCoreStoryClaims(raw: readonly string[]): CoreStoryChapterId[] {
+  const claimed = new Set(raw.filter(id => coreStoryChapterIds.includes(id as CoreStoryChapterId)));
+  const canonical: CoreStoryChapterId[] = [];
+  for (const id of coreStoryChapterIds) {
+    if (!claimed.has(id)) break;
+    canonical.push(id);
+  }
+  return canonical;
+}
+
 const expeditionChapters: StoryChapterDefinition[] = expeditionStoryDefinitions.map(entry => ({
   id: entry.stageId,
   title: entry.title,

--- a/src/story-claim-order.test.ts
+++ b/src/story-claim-order.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalCoreStoryClaims } from './story-chapters';
+
+describe('core story claim order integrity', () => {
+  it('drops later chapter claims when an earlier prerequisite chapter is missing', () => {
+    expect(canonicalCoreStoryClaims(['wide_world','guardian_oath'])).toEqual([]);
+    expect(canonicalCoreStoryClaims(['first_step','wide_world','guardian_oath'])).toEqual(['first_step','wide_world']);
+  });
+
+  it('deduplicates and returns only the contiguous narrative prefix', () => {
+    expect(canonicalCoreStoryClaims(['trusted_bond','first_step','wide_world','first_step','guardian_oath'])).toEqual([
+      'first_step','wide_world','trusted_bond','guardian_oath',
+    ]);
+  });
+});


### PR DESCRIPTION
Verification-only frozen Raising compatibility gate.

Base: verify/raising-after-world-season-base @ 88742c349b4943d41fd02a9acb81c13e10f49a97 (current integration/v2)
Head: verify/raising-next-snapshot-c9ab @ c9abcb67af756184265bde28c0662dd0c47e4384

Purpose:
- identify/compose overlaps with newly integrated World Calling hardening
- preserve current World/Season/Global-QA behavior
- before any integration, add the three 06-owned shared consumption changes requested by Raising: personality presentation consumption, mastery-gated signature consumption, and canonical core-story claim hydration
- then validate Raising targeted/E2E, save/old-save/malformed, Global RC, full suite, TypeScript and production build

Verification only. Do not merge this PR into integration/v2 or main. No production deploy.