### PR TITLE
fix: pin Tactical retry to completed expedition stage

### DIFF
--- a/src/TacticalExpeditionFlow.tsx
+++ b/src/TacticalExpeditionFlow.tsx
@@ -32,6 +32,10 @@ function seedFor(state:GameState,stageId:ExpeditionStageId) {
   return hash;
 }
 
+export function tacticalBattleStageForRetry(activeStageId:ExpeditionStageId|null,currentStageId:ExpeditionStageId) {
+  return activeStageId ?? currentStageId;
+}
+
 export function closeTacticalFlow(clearSession:()=>void,closeBattle:()=>void,onExitToHome:()=>void) {
   clearSession();
   closeBattle();
@@ -41,11 +45,14 @@ export function closeTacticalFlow(clearSession:()=>void,closeBattle:()=>void,onE
 export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,onSetPreferences,onComplete,onExpeditionFinish,onExitToHome}:TacticalExpeditionFlowProps) {
   const [open,setOpen] = useState(false);
   const [session,setSession] = useState<BattleSession|null>(null);
+  const [battleStageId,setBattleStageId] = useState<ExpeditionStageId|null>(null);
   const [party,setParty] = useState<[CompanionId,CompanionId]>(()=>tacticalPartyForGame(state));
   const [auto,setAuto] = useState(state.tacticalAutoBattle);
   const [speed,setSpeed] = useState<1|2>(state.tacticalBattleSpeed);
   const stageId = (nextExpeditionStage(state.expeditionRecords) ?? 'forest_path') as ExpeditionStageId;
   const stage = useMemo(()=>expeditionStageDefinitions.find(item=>item.id===stageId)!,[stageId]);
+  const activeStageId = tacticalBattleStageForRetry(battleStageId,stageId);
+  const activeStage = useMemo(()=>expeditionStageDefinitions.find(item=>item.id===activeStageId)!,[activeStageId]);
   const bondLevels = useMemo(()=>({
     bear:state.tacticalCompanionBonds.bear.level,
     owl:state.tacticalCompanionBonds.owl.level,
@@ -62,6 +69,7 @@ export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,
 
   const start = () => {
     onSetParty(party);
+    setBattleStageId(stageId);
     setSession(createTacticalBattleFromGame({...state,selectedTacticalCompanions:party},stageId,seedFor(state,stageId)));
     setOpen(true);
   };
@@ -79,10 +87,10 @@ export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,
 
   const complete = (result:BattleResult,finalSession:BattleSession) => {
     const metrics = tacticalCompletionMetrics(finalSession);
-    onComplete(tacticalEncounterForExpeditionStage(stageId),result,metrics.rounds,metrics.survivingAllies,metrics.damageTaken,party);
+    onComplete(tacticalEncounterForExpeditionStage(activeStageId),result,metrics.rounds,metrics.survivingAllies,metrics.damageTaken,party);
     const actionKinds:ExpeditionActionCounts = { attack:metrics.rounds,dodge:0,charge:0 };
-    const expeditionScore = tacticalExpeditionFinishScore(stage.target,result);
-    onExpeditionFinish(stageId,expeditionScore,result==='victory'?2:6,result==='victory'?1:5,actionKinds);
+    const expeditionScore = tacticalExpeditionFinishScore(activeStage.target,result);
+    onExpeditionFinish(activeStageId,expeditionScore,result==='victory'?2:6,result==='victory'?1:5,actionKinds);
   };
 
   if (open && session) {
@@ -96,8 +104,8 @@ export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,
         onToggleAuto={toggleAuto}
         onToggleSpeed={toggleSpeed}
         onComplete={complete}
-        onRetry={()=>setSession(createTacticalBattleFromGame({...state,selectedTacticalCompanions:party},stageId,seedFor(state,stageId)+1))}
-        onExit={()=>closeTacticalFlow(()=>setSession(null),()=>setOpen(false),onExitToHome)}
+        onRetry={()=>setSession(createTacticalBattleFromGame({...state,selectedTacticalCompanions:party},activeStageId,seedFor(state,activeStageId)+1))}
+        onExit={()=>closeTacticalFlow(()=>{setSession(null);setBattleStageId(null)},()=>setOpen(false),onExitToHome)}
       />
     </div>;
   }

--- a/src/tactical-game.integration.test.ts
+++ b/src/tactical-game.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { hydrateGameState, initialState, reducer } from './game';
-import { closeTacticalFlow } from './TacticalExpeditionFlow';
+import { closeTacticalFlow, tacticalBattleStageForRetry } from './TacticalExpeditionFlow';
 
 describe('tactical game persistence integration', () => {
   it('hydrates old saves with safe tactical defaults and sanitizes party/bonds', () => {
@@ -49,6 +49,11 @@ describe('tactical game persistence integration', () => {
     expect(lost.claimedTacticalFirstClears).toEqual([]);
     expect(lost.tacticalCompanionBonds.wolf.xp).toBeGreaterThan(0);
     expect(lost.tacticalCompanionBonds.cat.xp).toBeGreaterThan(0);
+  });
+
+  it('keeps retry bound to the completed battle stage after expedition progression advances', () => {
+    expect(tacticalBattleStageForRetry('forest_path','river_gate')).toBe('forest_path');
+    expect(tacticalBattleStageForRetry(null,'river_gate')).toBe('river_gate');
   });
 
   it('closes the tactical battle state and outer expedition before returning home', () => {


### PR DESCRIPTION
Verification-only Tactical integration patch against integration/v2@88742c349b4943d41fd02a9acb81c13e10f49a97.

Scope is Tactical-owned only:
- src/TacticalExpeditionFlow.tsx
- src/tactical-game.integration.test.ts

Fixes a post-victory retry leak where parent expedition progression can advance `stageId` before the result-screen RETRY is pressed, causing RETRY to launch the next stage instead of replaying the completed stage.

No App.tsx / Root.tsx / game.ts / save / vercel / shared CSS changes.

Do not merge from 04. Intended for CI verification and 06 integration review only.