### PR TITLE
02 World next-2: reward markers & cross-state hardening

### DIFF
--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -7,6 +7,7 @@ import type { GrowthTraitId } from './growth-traits';
 
 const legendEffectIds = ['vanguard_legend', 'arcanist_legend', 'pathfinder_legend'] as const;
 type LegendEffectId = typeof legendEffectIds[number];
+const expeditionRegionIds: readonly ExpeditionRegionId[] = ['starlight_forest', 'ancient_city', 'wind_lakes'];
 
 export function legendRewardKey(year:number, month:number, effectId:string): string {
   const safeYear = Math.max(1, Math.floor(Number.isFinite(year) ? year : 1));
@@ -48,6 +49,14 @@ function hasValidAction(value:number): boolean {
   return Number.isFinite(value) && value > 0;
 }
 
+function hasValidDiscovery(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function hasValidRegion(value: unknown): value is ExpeditionRegionId {
+  return typeof value === 'string' && expeditionRegionIds.includes(value as ExpeditionRegionId);
+}
+
 export function specialistMasteryCalling(
   calling:GuardianCallingId | null,
   actions:ExpeditionActionCounts,
@@ -59,9 +68,8 @@ export function specialistMasteryCalling(
   if (calling === 'arcanist') return hasValidAction(actions.charge) ? calling : null;
   if (calling === 'caretaker') return hasValidAction(actions.dodge) ? calling : null;
   const acted = hasValidAction(actions.attack) || hasValidAction(actions.dodge) || hasValidAction(actions.charge);
-  const hasDiscovery = typeof summary.discovery === 'string' && summary.discovery.length > 0;
   const hasMaterialReward = Number.isFinite(summary.materialReward) && summary.materialReward > 0;
-  const explored = hasDiscovery || hasMaterialReward || isBossStage(summary.stageId);
+  const explored = hasValidDiscovery(summary.discovery) || hasMaterialReward || isBossStage(summary.stageId);
   return acted && explored ? calling : null;
 }
 
@@ -111,7 +119,7 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
       extraMaterial += 1;
       applied.push('trail_reading');
     }
-    if (signatures.has('star_compass') && input.regionCompleted) {
+    if (signatures.has('star_compass') && hasValidRegion(input.regionCompleted)) {
       extraMaterial += 1;
       applied.push('star_compass');
     }
@@ -131,7 +139,7 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
     }
   }
 
-  if (input.calling === 'arcanist' && traits.has('arcanist_legend') && (input.grade === 'A' || input.grade === 'S') && input.discovery) {
+  if (input.calling === 'arcanist' && traits.has('arcanist_legend') && (input.grade === 'A' || input.grade === 'S') && hasValidDiscovery(input.discovery)) {
     const key = legendRewardKey(input.year, input.month, 'arcanist_legend');
     if (!legendRewardKeys.includes(key)) {
       stressDelta = Math.max(0, stressDelta - 2);

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -34,8 +34,9 @@ export function specialistMasteryCalling(
   if (calling === 'arcanist') return hasValidAction(actions.charge) ? calling : null;
   if (calling === 'caretaker') return hasValidAction(actions.dodge) ? calling : null;
   const acted = hasValidAction(actions.attack) || hasValidAction(actions.dodge) || hasValidAction(actions.charge);
+  const hasDiscovery = typeof summary.discovery === 'string' && summary.discovery.length > 0;
   const hasMaterialReward = Number.isFinite(summary.materialReward) && summary.materialReward > 0;
-  const explored = summary.discovery !== null || hasMaterialReward || isBossStage(summary.stageId);
+  const explored = hasDiscovery || hasMaterialReward || isBossStage(summary.stageId);
   return acted && explored ? calling : null;
 }
 

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -8,6 +8,7 @@ import type { GrowthTraitId } from './growth-traits';
 const legendEffectIds = ['vanguard_legend', 'arcanist_legend', 'pathfinder_legend'] as const;
 type LegendEffectId = typeof legendEffectIds[number];
 const expeditionRegionIds: readonly ExpeditionRegionId[] = ['starlight_forest', 'ancient_city', 'wind_lakes'];
+const guardianCallingIds: readonly GuardianCallingId[] = ['vanguard', 'arcanist', 'caretaker', 'pathfinder'];
 
 export function legendRewardKey(year:number, month:number, effectId:string): string {
   const safeYear = Math.max(1, Math.floor(Number.isFinite(year) ? year : 1));
@@ -53,8 +54,8 @@ export function effectivePathfinderExplorationXp(
   return safeXp + (calling === 'pathfinder' && safeTraits(traits).includes('pathfinder_eye') ? 3 : 0);
 }
 
-function hasValidAction(value:number): boolean {
-  return Number.isFinite(value) && value > 0;
+function hasValidAction(value:unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 function hasValidDiscovery(value: unknown): value is string {
@@ -65,17 +66,28 @@ function hasValidRegion(value: unknown): value is ExpeditionRegionId {
   return typeof value === 'string' && expeditionRegionIds.includes(value as ExpeditionRegionId);
 }
 
+function hasValidCalling(value: unknown): value is GuardianCallingId {
+  return typeof value === 'string' && guardianCallingIds.includes(value as GuardianCallingId);
+}
+
+function safeActions(raw: unknown): Partial<ExpeditionActionCounts> {
+  return typeof raw === 'object' && raw !== null && !Array.isArray(raw)
+    ? raw as Partial<ExpeditionActionCounts>
+    : {};
+}
+
 export function specialistMasteryCalling(
   calling:GuardianCallingId | null,
   actions:ExpeditionActionCounts,
   summary:{ stageId:ExpeditionStageId; grade:ExpeditionGrade; discovery:string | null; materialReward:number },
 ): GuardianCallingId | null {
   const successful = summary.grade === 'B' || summary.grade === 'A' || summary.grade === 'S';
-  if (!calling || !successful) return null;
-  if (calling === 'vanguard') return hasValidAction(actions.attack) ? calling : null;
-  if (calling === 'arcanist') return hasValidAction(actions.charge) ? calling : null;
-  if (calling === 'caretaker') return hasValidAction(actions.dodge) ? calling : null;
-  const acted = hasValidAction(actions.attack) || hasValidAction(actions.dodge) || hasValidAction(actions.charge);
+  if (!hasValidCalling(calling) || !successful) return null;
+  const actionCounts = safeActions(actions);
+  if (calling === 'vanguard') return hasValidAction(actionCounts.attack) ? calling : null;
+  if (calling === 'arcanist') return hasValidAction(actionCounts.charge) ? calling : null;
+  if (calling === 'caretaker') return hasValidAction(actionCounts.dodge) ? calling : null;
+  const acted = hasValidAction(actionCounts.attack) || hasValidAction(actionCounts.dodge) || hasValidAction(actionCounts.charge);
   const hasMaterialReward = Number.isFinite(summary.materialReward) && summary.materialReward > 0;
   const explored = hasValidDiscovery(summary.discovery) || hasMaterialReward || isBossStage(summary.stageId);
   return acted && explored ? calling : null;

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -5,6 +5,9 @@ import type { ExpeditionGrade, ExpeditionRegionId, ExpeditionStageId } from './e
 import type { GuardianCallingId } from './guardian-callings';
 import type { GrowthTraitId } from './growth-traits';
 
+const legendEffectIds = ['vanguard_legend', 'arcanist_legend', 'pathfinder_legend'] as const;
+type LegendEffectId = typeof legendEffectIds[number];
+
 export function legendRewardKey(year:number, month:number, effectId:string): string {
   const safeYear = Math.max(1, Math.floor(Number.isFinite(year) ? year : 1));
   const safeMonth = Math.max(1, Math.min(12, Math.floor(Number.isFinite(month) ? month : 1)));
@@ -13,7 +16,23 @@ export function legendRewardKey(year:number, month:number, effectId:string): str
 
 function sanitizeLegendRewardKeys(raw: unknown): string[] {
   if (!Array.isArray(raw)) return [];
-  return [...new Set(raw.filter((value): value is string => typeof value === 'string' && value.length > 0))];
+  const validEffects = new Set<string>(legendEffectIds);
+  const keys:string[] = [];
+  const seen = new Set<string>();
+  for (const value of raw) {
+    if (typeof value !== 'string' || !value) continue;
+    const match = /^(\d+)-(\d+):([a-z_]+)$/.exec(value);
+    if (!match) continue;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const effectId = match[3] as LegendEffectId;
+    if (!Number.isSafeInteger(year) || year < 1 || !Number.isInteger(month) || month < 1 || month > 12 || !validEffects.has(effectId)) continue;
+    const canonical = legendRewardKey(year, month, effectId);
+    if (canonical !== value || seen.has(canonical)) continue;
+    seen.add(canonical);
+    keys.push(canonical);
+  }
+  return keys;
 }
 
 export function effectivePathfinderExplorationXp(

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -34,7 +34,8 @@ export function specialistMasteryCalling(
   if (calling === 'arcanist') return hasValidAction(actions.charge) ? calling : null;
   if (calling === 'caretaker') return hasValidAction(actions.dodge) ? calling : null;
   const acted = hasValidAction(actions.attack) || hasValidAction(actions.dodge) || hasValidAction(actions.charge);
-  const explored = summary.discovery !== null || summary.materialReward > 0 || isBossStage(summary.stageId);
+  const hasMaterialReward = Number.isFinite(summary.materialReward) && summary.materialReward > 0;
+  const explored = summary.discovery !== null || hasMaterialReward || isBossStage(summary.stageId);
   return acted && explored ? calling : null;
 }
 

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -81,6 +81,7 @@ export function specialistMasteryCalling(
   actions:ExpeditionActionCounts,
   summary:{ stageId:ExpeditionStageId; grade:ExpeditionGrade; discovery:string | null; materialReward:number },
 ): GuardianCallingId | null {
+  if (typeof summary !== 'object' || summary === null || Array.isArray(summary)) return null;
   const successful = summary.grade === 'B' || summary.grade === 'A' || summary.grade === 'S';
   if (!hasValidCalling(calling) || !successful) return null;
   const actionCounts = safeActions(actions);

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -102,10 +102,11 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
   const applied:string[] = [];
   const signatures = new Set(input.signatures);
   const traits = new Set(input.traits);
-  const successful = input.grade !== 'C';
+  const successful = input.grade === 'B' || input.grade === 'A' || input.grade === 'S';
+  const hasMaterialReward = Number.isFinite(input.materialReward) && input.materialReward > 0;
 
   if (successful && input.calling === 'pathfinder') {
-    if (signatures.has('trail_reading') && input.firstClear && input.materialReward > 0) {
+    if (signatures.has('trail_reading') && input.firstClear && hasMaterialReward) {
       extraMaterial += 1;
       applied.push('trail_reading');
     }

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -53,7 +53,8 @@ export function specialistMasteryCalling(
   actions:ExpeditionActionCounts,
   summary:{ stageId:ExpeditionStageId; grade:ExpeditionGrade; discovery:string | null; materialReward:number },
 ): GuardianCallingId | null {
-  if (!calling || summary.grade === 'C') return null;
+  const successful = summary.grade === 'B' || summary.grade === 'A' || summary.grade === 'S';
+  if (!calling || !successful) return null;
   if (calling === 'vanguard') return hasValidAction(actions.attack) ? calling : null;
   if (calling === 'arcanist') return hasValidAction(actions.charge) ? calling : null;
   if (calling === 'caretaker') return hasValidAction(actions.dodge) ? calling : null;

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -11,6 +11,11 @@ export function legendRewardKey(year:number, month:number, effectId:string): str
   return `${safeYear}-${safeMonth}:${effectId}`;
 }
 
+function sanitizeLegendRewardKeys(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.filter((value): value is string => typeof value === 'string' && value.length > 0))];
+}
+
 export function effectivePathfinderExplorationXp(
   xp:number,
   calling:GuardianCallingId | null,
@@ -74,7 +79,7 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
   let extraMaterial = 0;
   let fatigueDelta = safeNonNegativeDelta(input.fatigueDelta);
   let stressDelta = safeNonNegativeDelta(input.stressDelta);
-  let legendRewardKeys = [...input.legendRewardKeys];
+  const legendRewardKeys = sanitizeLegendRewardKeys(input.legendRewardKeys);
   const applied:string[] = [];
   const signatures = new Set(input.signatures);
   const traits = new Set(input.traits);
@@ -125,10 +130,11 @@ export function applyPathfinderOutingLegend(
   discovered:boolean,
   existingKeys:string[],
 ): { goldBonus:number; legendRewardKeys:string[]; applied:boolean } {
+  const legendRewardKeys = sanitizeLegendRewardKeys(existingKeys);
   if (calling !== 'pathfinder' || !traits.includes('pathfinder_legend') || !discovered) {
-    return { goldBonus:0, legendRewardKeys:existingKeys, applied:false };
+    return { goldBonus:0, legendRewardKeys, applied:false };
   }
   const key = legendRewardKey(year, month, 'pathfinder_legend');
-  if (existingKeys.includes(key)) return { goldBonus:0, legendRewardKeys:existingKeys, applied:false };
-  return { goldBonus:100, legendRewardKeys:[...existingKeys, key], applied:true };
+  if (legendRewardKeys.includes(key)) return { goldBonus:0, legendRewardKeys, applied:false };
+  return { goldBonus:100, legendRewardKeys:[...legendRewardKeys, key], applied:true };
 }

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -36,13 +36,21 @@ function sanitizeLegendRewardKeys(raw: unknown): string[] {
   return keys;
 }
 
+function safeTraits(raw: unknown): readonly GrowthTraitId[] {
+  return Array.isArray(raw) ? raw as readonly GrowthTraitId[] : [];
+}
+
+function safeSignatures(raw: unknown): readonly CallingSignatureId[] {
+  return Array.isArray(raw) ? raw as readonly CallingSignatureId[] : [];
+}
+
 export function effectivePathfinderExplorationXp(
   xp:number,
   calling:GuardianCallingId | null,
   traits:readonly GrowthTraitId[],
 ): number {
   const safeXp = Math.max(0, Math.floor(Number.isFinite(xp) ? xp : 0));
-  return safeXp + (calling === 'pathfinder' && traits.includes('pathfinder_eye') ? 3 : 0);
+  return safeXp + (calling === 'pathfinder' && safeTraits(traits).includes('pathfinder_eye') ? 3 : 0);
 }
 
 function hasValidAction(value:number): boolean {
@@ -109,8 +117,8 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
   let stressDelta = safeNonNegativeDelta(input.stressDelta);
   const legendRewardKeys = sanitizeLegendRewardKeys(input.legendRewardKeys);
   const applied:string[] = [];
-  const signatures = new Set(input.signatures);
-  const traits = new Set(input.traits);
+  const signatures = new Set(safeSignatures(input.signatures));
+  const traits = new Set(safeTraits(input.traits));
   const successful = input.grade === 'B' || input.grade === 'A' || input.grade === 'S';
   const hasMaterialReward = Number.isFinite(input.materialReward) && input.materialReward > 0;
   const firstClear = input.firstClear === true;
@@ -161,7 +169,7 @@ export function applyPathfinderOutingLegend(
   existingKeys:string[],
 ): { goldBonus:number; legendRewardKeys:string[]; applied:boolean } {
   const legendRewardKeys = sanitizeLegendRewardKeys(existingKeys);
-  if (calling !== 'pathfinder' || !traits.includes('pathfinder_legend') || discovered !== true) {
+  if (calling !== 'pathfinder' || !safeTraits(traits).includes('pathfinder_legend') || discovered !== true) {
     return { goldBonus:0, legendRewardKeys, applied:false };
   }
   const key = legendRewardKey(year, month, 'pathfinder_legend');

--- a/src/calling-depth-effects.ts
+++ b/src/calling-depth-effects.ts
@@ -113,9 +113,10 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
   const traits = new Set(input.traits);
   const successful = input.grade === 'B' || input.grade === 'A' || input.grade === 'S';
   const hasMaterialReward = Number.isFinite(input.materialReward) && input.materialReward > 0;
+  const firstClear = input.firstClear === true;
 
   if (successful && input.calling === 'pathfinder') {
-    if (signatures.has('trail_reading') && input.firstClear && hasMaterialReward) {
+    if (signatures.has('trail_reading') && firstClear && hasMaterialReward) {
       extraMaterial += 1;
       applied.push('trail_reading');
     }
@@ -130,7 +131,7 @@ export function applyExpeditionCallingRewards(input:ExpeditionCallingRewardInput
     applied.push('heart_anchor');
   }
 
-  if (successful && input.calling === 'vanguard' && traits.has('vanguard_legend') && input.firstClear) {
+  if (successful && input.calling === 'vanguard' && traits.has('vanguard_legend') && firstClear) {
     const key = legendRewardKey(input.year, input.month, 'vanguard_legend');
     if (!legendRewardKeys.includes(key)) {
       fatigueDelta = Math.max(0, fatigueDelta - 2);
@@ -160,7 +161,7 @@ export function applyPathfinderOutingLegend(
   existingKeys:string[],
 ): { goldBonus:number; legendRewardKeys:string[]; applied:boolean } {
   const legendRewardKeys = sanitizeLegendRewardKeys(existingKeys);
-  if (calling !== 'pathfinder' || !traits.includes('pathfinder_legend') || !discovered) {
+  if (calling !== 'pathfinder' || !traits.includes('pathfinder_legend') || discovered !== true) {
     return { goldBonus:0, legendRewardKeys, applied:false };
   }
   const key = legendRewardKey(year, month, 'pathfinder_legend');

--- a/src/calling-expedition-array-sanitization.test.ts
+++ b/src/calling-expedition-array-sanitization.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { applyExpeditionCallingRewards, applyPathfinderOutingLegend, effectivePathfinderExplorationXp } from './calling-depth-effects';
+
+describe('Calling expedition array sanitation', () => {
+  it('treats malformed traits and signatures as empty collections', () => {
+    expect(() => applyExpeditionCallingRewards({
+      year:2026,
+      month:8,
+      calling:'pathfinder',
+      traits:null,
+      signatures:null,
+      legendRewardKeys:null,
+      stageId:'forest_path',
+      grade:'A',
+      firstClear:true,
+      discovery:null,
+      regionCompleted:null,
+      materialReward:1,
+      fatigueDelta:0,
+      stressDelta:0,
+    } as any)).not.toThrow();
+
+    const result = applyExpeditionCallingRewards({
+      year:2026,
+      month:8,
+      calling:'pathfinder',
+      traits:null,
+      signatures:null,
+      legendRewardKeys:null,
+      stageId:'forest_path',
+      grade:'A',
+      firstClear:true,
+      discovery:null,
+      regionCompleted:null,
+      materialReward:1,
+      fatigueDelta:0,
+      stressDelta:0,
+    } as any);
+    expect(result.extraMaterial).toBe(0);
+    expect(result.applied).toEqual([]);
+    expect(result.legendRewardKeys).toEqual([]);
+  });
+
+  it('treats malformed Pathfinder trait lists as empty', () => {
+    expect(effectivePathfinderExplorationXp(3, 'pathfinder', null as any)).toBe(3);
+    expect(applyPathfinderOutingLegend(2026, 8, 'pathfinder', null as any, true, [])).toEqual({
+      goldBonus:0,
+      legendRewardKeys:[],
+      applied:false,
+    });
+  });
+});

--- a/src/calling-expedition-cross-state-sanitization.test.ts
+++ b/src/calling-expedition-cross-state-sanitization.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { applyExpeditionCallingRewards } from './calling-depth-effects';
+
+describe('Calling expedition cross-state sanitation', () => {
+  it('does not grant star compass from malformed region completion evidence', () => {
+    for (const regionCompleted of ['stale_region', 42, true] as any[]) {
+      const result = applyExpeditionCallingRewards({
+        year:2026, month:8, calling:'pathfinder', traits:[], signatures:['star_compass'], legendRewardKeys:[],
+        stageId:'forest_guardian', grade:'A', firstClear:false, discovery:null,
+        regionCompleted, materialReward:0, fatigueDelta:0, stressDelta:0,
+      } as any);
+      expect(result.extraMaterial).toBe(0);
+      expect(result.applied).not.toContain('star_compass');
+    }
+  });
+
+  it('does not grant Arcanist legend from malformed discovery evidence', () => {
+    for (const discovery of [42, true, {}, []] as any[]) {
+      const result = applyExpeditionCallingRewards({
+        year:2026, month:8, calling:'arcanist', traits:['arcanist_legend'], signatures:[], legendRewardKeys:[],
+        stageId:'city_square', grade:'A', firstClear:false, discovery,
+        regionCompleted:null, materialReward:1, fatigueDelta:0, stressDelta:6,
+      } as any);
+      expect(result.stressDelta).toBe(6);
+      expect(result.applied).not.toContain('arcanist_legend');
+      expect(result.legendRewardKeys).not.toContain('2026-8:arcanist_legend');
+    }
+  });
+});

--- a/src/calling-expedition-reward-input-sanitization.test.ts
+++ b/src/calling-expedition-reward-input-sanitization.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyExpeditionCallingRewards } from './calling-depth-effects';
+import { applyExpeditionCallingRewards, applyPathfinderOutingLegend } from './calling-depth-effects';
 
 const base = () => ({
   year:2026,
@@ -32,6 +32,41 @@ describe('Calling expedition reward input sanitation', () => {
       const result = applyExpeditionCallingRewards({ ...base(), grade } as any);
       expect(result.extraMaterial).toBe(0);
       expect(result.applied).not.toContain('trail_reading');
+    }
+  });
+
+  it('requires firstClear to be the literal boolean true for first-clear Calling rewards', () => {
+    for (const firstClear of ['yes', 1, {}, [], 'true'] as any[]) {
+      const pathfinder = applyExpeditionCallingRewards({ ...base(), firstClear } as any);
+      expect(pathfinder.extraMaterial).toBe(0);
+      expect(pathfinder.applied).not.toContain('trail_reading');
+
+      const vanguard = applyExpeditionCallingRewards({
+        ...base(),
+        calling:'vanguard',
+        traits:['vanguard_legend'],
+        signatures:[],
+        firstClear,
+        fatigueDelta:5,
+      } as any);
+      expect(vanguard.fatigueDelta).toBe(5);
+      expect(vanguard.applied).not.toContain('vanguard_legend');
+    }
+  });
+
+  it('requires Pathfinder outing discovery evidence to be the literal boolean true', () => {
+    for (const discovered of ['yes', 1, {}, [], 'true'] as any[]) {
+      const result = applyPathfinderOutingLegend(
+        2026,
+        8,
+        'pathfinder',
+        ['pathfinder_legend'],
+        discovered,
+        [],
+      );
+      expect(result.goldBonus).toBe(0);
+      expect(result.applied).toBe(false);
+      expect(result.legendRewardKeys).toEqual([]);
     }
   });
 });

--- a/src/calling-expedition-reward-input-sanitization.test.ts
+++ b/src/calling-expedition-reward-input-sanitization.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { applyExpeditionCallingRewards } from './calling-depth-effects';
+
+const base = () => ({
+  year:2026,
+  month:8,
+  calling:'pathfinder' as const,
+  traits:[] as any[],
+  signatures:['trail_reading'] as any[],
+  legendRewardKeys:[],
+  stageId:'forest_path' as const,
+  grade:'A' as const,
+  firstClear:true,
+  discovery:null,
+  regionCompleted:null,
+  materialReward:1,
+  fatigueDelta:0,
+  stressDelta:0,
+});
+
+describe('Calling expedition reward input sanitation', () => {
+  it('does not grant trail reading from malformed material rewards', () => {
+    for (const materialReward of [Number.POSITIVE_INFINITY, Number.NaN, -1]) {
+      const result = applyExpeditionCallingRewards({ ...base(), materialReward });
+      expect(result.extraMaterial).toBe(0);
+      expect(result.applied).not.toContain('trail_reading');
+    }
+  });
+
+  it('fails closed for malformed grades instead of applying successful-clear rewards', () => {
+    for (const grade of ['Z', '', null, undefined, 42] as any[]) {
+      const result = applyExpeditionCallingRewards({ ...base(), grade } as any);
+      expect(result.extraMaterial).toBe(0);
+      expect(result.applied).not.toContain('trail_reading');
+    }
+  });
+});

--- a/src/calling-legend-reward-key-sanitization.test.ts
+++ b/src/calling-legend-reward-key-sanitization.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { applyExpeditionCallingRewards, applyPathfinderOutingLegend } from './calling-depth-effects';
+
+describe('Calling legend reward key sanitation', () => {
+  it('deduplicates string keys and drops malformed entries on expedition rewards', () => {
+    const result = applyExpeditionCallingRewards({
+      year:2026,
+      month:8,
+      calling:null,
+      traits:[],
+      signatures:[],
+      legendRewardKeys:['2026-8:vanguard_legend','2026-8:vanguard_legend',null,42,'','legacy:unknown'] as any,
+      stageId:'forest_path',
+      grade:'C',
+      firstClear:false,
+      discovery:null,
+      regionCompleted:null,
+      materialReward:0,
+      fatigueDelta:0,
+      stressDelta:0,
+    });
+
+    expect(result.legendRewardKeys).toEqual(['2026-8:vanguard_legend','legacy:unknown']);
+  });
+
+  it('sanitizes existing keys even when Pathfinder legend does not apply', () => {
+    const result = applyPathfinderOutingLegend(
+      2026,
+      8,
+      null,
+      [],
+      false,
+      ['2026-8:pathfinder_legend','2026-8:pathfinder_legend',null,7,''] as any,
+    );
+
+    expect(result.applied).toBe(false);
+    expect(result.goldBonus).toBe(0);
+    expect(result.legendRewardKeys).toEqual(['2026-8:pathfinder_legend']);
+  });
+});

--- a/src/calling-legend-reward-key-sanitization.test.ts
+++ b/src/calling-legend-reward-key-sanitization.test.ts
@@ -2,14 +2,25 @@ import { describe, expect, it } from 'vitest';
 import { applyExpeditionCallingRewards, applyPathfinderOutingLegend } from './calling-depth-effects';
 
 describe('Calling legend reward key sanitation', () => {
-  it('deduplicates string keys and drops malformed entries on expedition rewards', () => {
+  it('keeps only canonical known legend reward keys on expedition rewards', () => {
     const result = applyExpeditionCallingRewards({
       year:2026,
       month:8,
       calling:null,
       traits:[],
       signatures:[],
-      legendRewardKeys:['2026-8:vanguard_legend','2026-8:vanguard_legend',null,42,'','legacy:unknown'] as any,
+      legendRewardKeys:[
+        '2026-8:vanguard_legend',
+        '2026-8:vanguard_legend',
+        '2026-8:unknown_legend',
+        'legacy:unknown',
+        '0-8:vanguard_legend',
+        '2026-13:vanguard_legend',
+        '2026-08:vanguard_legend',
+        null,
+        42,
+        '',
+      ] as any,
       stageId:'forest_path',
       grade:'C',
       firstClear:false,
@@ -20,7 +31,7 @@ describe('Calling legend reward key sanitation', () => {
       stressDelta:0,
     });
 
-    expect(result.legendRewardKeys).toEqual(['2026-8:vanguard_legend','legacy:unknown']);
+    expect(result.legendRewardKeys).toEqual(['2026-8:vanguard_legend']);
   });
 
   it('sanitizes existing keys even when Pathfinder legend does not apply', () => {
@@ -30,7 +41,15 @@ describe('Calling legend reward key sanitation', () => {
       null,
       [],
       false,
-      ['2026-8:pathfinder_legend','2026-8:pathfinder_legend',null,7,''] as any,
+      [
+        '2026-8:pathfinder_legend',
+        '2026-8:pathfinder_legend',
+        '2026-8:unknown_legend',
+        '2026-08:pathfinder_legend',
+        null,
+        7,
+        '',
+      ] as any,
     );
 
     expect(result.applied).toBe(false);

--- a/src/calling-mastery-sanitization.test.ts
+++ b/src/calling-mastery-sanitization.test.ts
@@ -54,4 +54,12 @@ describe('Calling mastery action sanitation', () => {
       expect(specialistMasteryCalling('pathfinder', actions, summary)).toBeNull();
     }
   });
+
+  it('does not throw when malformed summary values reach the exported mastery authority', () => {
+    const actions = { attack:1, dodge:1, charge:1 };
+    for (const summary of [null, undefined, 42, 'bad'] as any[]) {
+      expect(() => specialistMasteryCalling('pathfinder', actions, summary)).not.toThrow();
+      expect(specialistMasteryCalling('pathfinder', actions, summary)).toBeNull();
+    }
+  });
 });

--- a/src/calling-mastery-sanitization.test.ts
+++ b/src/calling-mastery-sanitization.test.ts
@@ -44,4 +44,20 @@ describe('Calling mastery action sanitation', () => {
       materialReward:-1,
     })).toBeNull();
   });
+
+  it('requires a non-empty string discovery for Pathfinder exploration evidence', () => {
+    const actions = { attack:1, dodge:0, charge:0 };
+    const base = { stageId:'forest_path' as const, grade:'A' as const, materialReward:0 };
+
+    for (const discovery of [undefined, 42, '', false] as any[]) {
+      expect(specialistMasteryCalling('pathfinder', actions, {
+        ...base,
+        discovery,
+      } as any)).toBeNull();
+    }
+    expect(specialistMasteryCalling('pathfinder', actions, {
+      ...base,
+      discovery:'forest_echo',
+    })).toBe('pathfinder');
+  });
 });

--- a/src/calling-mastery-sanitization.test.ts
+++ b/src/calling-mastery-sanitization.test.ts
@@ -26,4 +26,22 @@ describe('Calling mastery action sanitation', () => {
       charge:-1,
     }, { ...summary, discovery:'forest_echo' })).toBeNull();
   });
+
+  it('does not treat malformed material rewards as Pathfinder exploration evidence', () => {
+    const actions = { attack:1, dodge:0, charge:0 };
+    const base = { stageId:'forest_path' as const, grade:'A' as const, discovery:null };
+
+    expect(specialistMasteryCalling('pathfinder', actions, {
+      ...base,
+      materialReward:Number.POSITIVE_INFINITY,
+    })).toBeNull();
+    expect(specialistMasteryCalling('pathfinder', actions, {
+      ...base,
+      materialReward:Number.NaN,
+    })).toBeNull();
+    expect(specialistMasteryCalling('pathfinder', actions, {
+      ...base,
+      materialReward:-1,
+    })).toBeNull();
+  });
 });

--- a/src/calling-mastery-sanitization.test.ts
+++ b/src/calling-mastery-sanitization.test.ts
@@ -5,74 +5,52 @@ describe('Calling mastery action sanitation', () => {
   it('does not treat non-finite or negative raw action counts as valid specialist actions', () => {
     const summary = { stageId:'forest_path' as const, grade:'A' as const, discovery:null, materialReward:1 };
 
-    expect(specialistMasteryCalling('vanguard', {
-      attack:Number.POSITIVE_INFINITY,
-      dodge:0,
-      charge:0,
-    }, summary)).toBeNull();
-    expect(specialistMasteryCalling('arcanist', {
-      attack:0,
-      dodge:0,
-      charge:Number.NaN,
-    }, summary)).toBeNull();
-    expect(specialistMasteryCalling('caretaker', {
-      attack:0,
-      dodge:-1,
-      charge:0,
-    }, summary)).toBeNull();
-    expect(specialistMasteryCalling('pathfinder', {
-      attack:Number.POSITIVE_INFINITY,
-      dodge:Number.NaN,
-      charge:-1,
-    }, { ...summary, discovery:'forest_echo' })).toBeNull();
+    expect(specialistMasteryCalling('vanguard', { attack:Number.POSITIVE_INFINITY, dodge:0, charge:0 }, summary)).toBeNull();
+    expect(specialistMasteryCalling('arcanist', { attack:0, dodge:0, charge:Number.NaN }, summary)).toBeNull();
+    expect(specialistMasteryCalling('caretaker', { attack:0, dodge:-1, charge:0 }, summary)).toBeNull();
+    expect(specialistMasteryCalling('pathfinder', { attack:Number.POSITIVE_INFINITY, dodge:Number.NaN, charge:-1 }, { ...summary, discovery:'forest_echo' })).toBeNull();
   });
 
   it('does not treat malformed material rewards as Pathfinder exploration evidence', () => {
     const actions = { attack:1, dodge:0, charge:0 };
     const base = { stageId:'forest_path' as const, grade:'A' as const, discovery:null };
-
-    expect(specialistMasteryCalling('pathfinder', actions, {
-      ...base,
-      materialReward:Number.POSITIVE_INFINITY,
-    })).toBeNull();
-    expect(specialistMasteryCalling('pathfinder', actions, {
-      ...base,
-      materialReward:Number.NaN,
-    })).toBeNull();
-    expect(specialistMasteryCalling('pathfinder', actions, {
-      ...base,
-      materialReward:-1,
-    })).toBeNull();
+    for (const materialReward of [Number.POSITIVE_INFINITY, Number.NaN, -1]) {
+      expect(specialistMasteryCalling('pathfinder', actions, { ...base, materialReward })).toBeNull();
+    }
   });
 
   it('requires a non-empty string discovery for Pathfinder exploration evidence', () => {
     const actions = { attack:1, dodge:0, charge:0 };
     const base = { stageId:'forest_path' as const, grade:'A' as const, materialReward:0 };
-
     for (const discovery of [undefined, 42, '', false] as any[]) {
-      expect(specialistMasteryCalling('pathfinder', actions, {
-        ...base,
-        discovery,
-      } as any)).toBeNull();
+      expect(specialistMasteryCalling('pathfinder', actions, { ...base, discovery } as any)).toBeNull();
     }
-    expect(specialistMasteryCalling('pathfinder', actions, {
-      ...base,
-      discovery:'forest_echo',
-    })).toBe('pathfinder');
+    expect(specialistMasteryCalling('pathfinder', actions, { ...base, discovery:'forest_echo' })).toBe('pathfinder');
   });
 
   it('fails closed for malformed grades across all specialist callings', () => {
     const actions = { attack:1, dodge:1, charge:1 };
     for (const grade of ['Z', '', null, undefined, 42] as any[]) {
-      const summary = {
-        stageId:'forest_path' as const,
-        grade,
-        discovery:'forest_echo',
-        materialReward:1,
-      } as any;
+      const summary = { stageId:'forest_path' as const, grade, discovery:'forest_echo', materialReward:1 } as any;
       expect(specialistMasteryCalling('vanguard', actions, summary)).toBeNull();
       expect(specialistMasteryCalling('arcanist', actions, summary)).toBeNull();
       expect(specialistMasteryCalling('caretaker', actions, summary)).toBeNull();
+      expect(specialistMasteryCalling('pathfinder', actions, summary)).toBeNull();
+    }
+  });
+
+  it('fails closed for malformed calling ids instead of falling through to Pathfinder logic', () => {
+    const actions = { attack:1, dodge:1, charge:1 };
+    const summary = { stageId:'forest_path' as const, grade:'A' as const, discovery:'forest_echo', materialReward:1 };
+    for (const calling of ['unknown', '', 42, {}, []] as any[]) {
+      expect(specialistMasteryCalling(calling, actions, summary)).toBeNull();
+    }
+  });
+
+  it('does not throw when malformed action collections reach the exported mastery authority', () => {
+    const summary = { stageId:'forest_path' as const, grade:'A' as const, discovery:'forest_echo', materialReward:1 };
+    for (const actions of [null, undefined, 42, 'bad'] as any[]) {
+      expect(() => specialistMasteryCalling('pathfinder', actions, summary)).not.toThrow();
       expect(specialistMasteryCalling('pathfinder', actions, summary)).toBeNull();
     }
   });

--- a/src/calling-mastery-sanitization.test.ts
+++ b/src/calling-mastery-sanitization.test.ts
@@ -60,4 +60,20 @@ describe('Calling mastery action sanitation', () => {
       discovery:'forest_echo',
     })).toBe('pathfinder');
   });
+
+  it('fails closed for malformed grades across all specialist callings', () => {
+    const actions = { attack:1, dodge:1, charge:1 };
+    for (const grade of ['Z', '', null, undefined, 42] as any[]) {
+      const summary = {
+        stageId:'forest_path' as const,
+        grade,
+        discovery:'forest_echo',
+        materialReward:1,
+      } as any;
+      expect(specialistMasteryCalling('vanguard', actions, summary)).toBeNull();
+      expect(specialistMasteryCalling('arcanist', actions, summary)).toBeNull();
+      expect(specialistMasteryCalling('caretaker', actions, summary)).toBeNull();
+      expect(specialistMasteryCalling('pathfinder', actions, summary)).toBeNull();
+    }
+  });
 });

--- a/src/pathfinder-outing-legend-sanitization.test.ts
+++ b/src/pathfinder-outing-legend-sanitization.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { applyPathfinderOutingLegend } from './calling-depth-effects';
+
+describe('Pathfinder outing legend sanitation', () => {
+  it('requires an exact true discovery flag before awarding legend gold', () => {
+    for (const discovered of ['false', 1, {}, []] as any[]) {
+      const result = applyPathfinderOutingLegend(
+        2026,
+        8,
+        'pathfinder',
+        ['pathfinder_legend'],
+        discovered,
+        [],
+      );
+      expect(result.goldBonus).toBe(0);
+      expect(result.applied).toBe(false);
+      expect(result.legendRewardKeys).not.toContain('2026-8:pathfinder_legend');
+    }
+
+    const valid = applyPathfinderOutingLegend(
+      2026,
+      8,
+      'pathfinder',
+      ['pathfinder_legend'],
+      true,
+      [],
+    );
+    expect(valid.goldBonus).toBe(100);
+    expect(valid.applied).toBe(true);
+  });
+});

--- a/src/world-contract-grade-sanitization.test.ts
+++ b/src/world-contract-grade-sanitization.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { advanceWorldContracts, emptyWorldContractProgress } from './world-contracts';
+import { worldEvent } from './world-event';
+
+describe('World Contract grade sanitation', () => {
+  it('does not advance any contract for malformed grades', () => {
+    const event = worldEvent(2026, 8);
+    for (const grade of ['Z', '', null, undefined, 42, {}, []] as any[]) {
+      const result = advanceWorldContracts({
+        year:2026,
+        month:8,
+        event,
+        progress:emptyWorldContractProgress(),
+        rewardedKeys:[],
+        region:event.region,
+        grade,
+      } as any);
+
+      expect(result.progress).toEqual(emptyWorldContractProgress());
+      expect(result.reward).toEqual({ gold:0, gems:0 });
+      expect(result.newlyCompleted).toEqual([]);
+    }
+  });
+});

--- a/src/world-contract-reward-key-sanitization.test.ts
+++ b/src/world-contract-reward-key-sanitization.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { advanceWorldContracts, emptyWorldContractProgress } from './world-contracts';
+import { worldEvent } from './world-event';
+
+describe('world contract rewarded key sanitation', () => {
+  it('deduplicates valid reward keys and drops malformed entries even on a failed expedition', () => {
+    const event = worldEvent(2026, 8);
+    const result = advanceWorldContracts({
+      year: 2026,
+      month: 8,
+      event,
+      progress: emptyWorldContractProgress(),
+      rewardedKeys: [
+        '2026-8:expedition_clear',
+        '2026-8:expedition_clear',
+        null,
+        42,
+        '',
+      ] as any,
+      region: event.region,
+      grade: 'C',
+    });
+
+    expect(result.rewardedKeys).toEqual(['2026-8:expedition_clear']);
+    expect(result.reward).toEqual({ gold: 0, gems: 0 });
+  });
+
+  it('does not append a duplicate completion key when malformed duplicates already exist', () => {
+    const event = worldEvent(2026, 8);
+    const result = advanceWorldContracts({
+      year: 2026,
+      month: 8,
+      event,
+      progress: { expedition_clear: 2, high_grade: 0, featured_region: 0 },
+      rewardedKeys: ['2026-8:expedition_clear', '2026-8:expedition_clear'] as any,
+      region: event.region,
+      grade: 'B',
+    });
+
+    expect(result.rewardedKeys.filter(key => key === '2026-8:expedition_clear')).toHaveLength(1);
+    expect(result.reward.gold).toBe(0);
+    expect(result.newlyCompleted).not.toContain('expedition_clear');
+  });
+});

--- a/src/world-contracts.test.ts
+++ b/src/world-contracts.test.ts
@@ -83,6 +83,31 @@ describe('world contracts', () => {
     expect(result.newlyCompleted).toEqual([]);
   });
 
+  it('treats missing or malformed progress objects as empty progress instead of crashing', () => {
+    for (const progress of [null, undefined, 42, 'bad', []] as any[]) {
+      expect(() => advanceWorldContracts({
+        year:1,
+        month:1,
+        event:worldEvent(1, 1),
+        progress,
+        rewardedKeys:[],
+        region:'starlight_forest',
+        grade:'A',
+      } as any)).not.toThrow();
+
+      const result = advanceWorldContracts({
+        year:1,
+        month:1,
+        event:worldEvent(1, 1),
+        progress,
+        rewardedKeys:[],
+        region:'starlight_forest',
+        grade:'A',
+      } as any);
+      expect(result.progress).toEqual({ expedition_clear:1, high_grade:1, featured_region:1 });
+    }
+  });
+
   it('auto-pays newly completed contracts once and caps completed counters', () => {
     const result = advanceWorldContracts({
       year:1,

--- a/src/world-contracts.ts
+++ b/src/world-contracts.ts
@@ -38,6 +38,12 @@ function sanitizedRewardedKeys(raw: unknown): string[] {
   return keys;
 }
 
+function progressSource(raw: unknown): Partial<WorldContractProgress> {
+  return typeof raw === 'object' && raw !== null && !Array.isArray(raw)
+    ? raw as Partial<WorldContractProgress>
+    : {};
+}
+
 export function emptyWorldContractProgress(): WorldContractProgress {
   return { expedition_clear:0, high_grade:0, featured_region:0 };
 }
@@ -75,9 +81,10 @@ export function advanceWorldContracts(input:AdvanceInput): {
 } {
   const contracts = monthlyWorldContracts(input.year, input.month, input.event);
   const targetFor = (id:WorldContractId) => contracts.find(contract => contract.id === id)?.target ?? Number.MAX_SAFE_INTEGER;
+  const stored = progressSource(input.progress);
   const storedProgress = (id:WorldContractId) => {
-    const value = input.progress[id];
-    return Math.min(targetFor(id), Math.max(0, Math.floor(Number.isFinite(value) ? value : 0)));
+    const value = stored[id];
+    return Math.min(targetFor(id), Math.max(0, Math.floor(Number.isFinite(value) ? value as number : 0)));
   };
   const current:WorldContractProgress = {
     expedition_clear:storedProgress('expedition_clear'),

--- a/src/world-contracts.ts
+++ b/src/world-contracts.ts
@@ -92,8 +92,9 @@ export function advanceWorldContracts(input:AdvanceInput): {
     featured_region:storedProgress('featured_region'),
   };
   const rewardedKeys = sanitizedRewardedKeys(input.rewardedKeys);
+  const successful = input.grade === 'B' || input.grade === 'A' || input.grade === 'S';
 
-  if (input.grade === 'C') {
+  if (!successful) {
     return { progress:current, rewardedKeys, reward:{ gold:0, gems:0 }, newlyCompleted:[] };
   }
 

--- a/src/world-contracts.ts
+++ b/src/world-contracts.ts
@@ -15,6 +15,28 @@ export type WorldContractDefinition = {
 
 const safeYear = (year:number) => Math.max(1, Math.floor(Number.isFinite(year) ? year : 1));
 const safeMonth = (month:number) => Math.max(1, Math.min(12, Math.floor(Number.isFinite(month) ? month : 1)));
+const worldContractIds: readonly WorldContractId[] = ['expedition_clear', 'high_grade', 'featured_region'];
+
+function sanitizedRewardedKeys(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const valid = new Set<WorldContractId>(worldContractIds);
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  for (const value of raw) {
+    if (typeof value !== 'string' || !value) continue;
+    const match = /^(\d+)-(\d+):([a-z_]+)$/.exec(value);
+    if (!match) continue;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const id = match[3] as WorldContractId;
+    if (!Number.isSafeInteger(year) || year < 1 || !Number.isInteger(month) || month < 1 || month > 12 || !valid.has(id)) continue;
+    const canonical = worldContractRewardKey(year, month, id);
+    if (canonical !== value || seen.has(canonical)) continue;
+    seen.add(canonical);
+    keys.push(canonical);
+  }
+  return keys;
+}
 
 export function emptyWorldContractProgress(): WorldContractProgress {
   return { expedition_clear:0, high_grade:0, featured_region:0 };
@@ -62,9 +84,10 @@ export function advanceWorldContracts(input:AdvanceInput): {
     high_grade:storedProgress('high_grade'),
     featured_region:storedProgress('featured_region'),
   };
+  const rewardedKeys = sanitizedRewardedKeys(input.rewardedKeys);
 
   if (input.grade === 'C') {
-    return { progress:current, rewardedKeys:[...input.rewardedKeys], reward:{ gold:0, gems:0 }, newlyCompleted:[] };
+    return { progress:current, rewardedKeys, reward:{ gold:0, gems:0 }, newlyCompleted:[] };
   }
 
   const progress:WorldContractProgress = {
@@ -72,7 +95,6 @@ export function advanceWorldContracts(input:AdvanceInput): {
     high_grade:Math.min(targetFor('high_grade'),current.high_grade + (input.grade === 'A' || input.grade === 'S' ? 1 : 0)),
     featured_region:Math.min(targetFor('featured_region'),current.featured_region + (input.region === input.event.region ? 1 : 0)),
   };
-  const rewardedKeys = [...input.rewardedKeys];
   const newlyCompleted:WorldContractId[] = [];
   let gold = 0;
   let gems = 0;

--- a/src/world-event.test.ts
+++ b/src/world-event.test.ts
@@ -34,6 +34,13 @@ describe('monthly world events', () => {
     expect(worldEventExpeditionBonus(event, 'starlight_forest', 'C')).toEqual({ seasonPoints:0, materialBonus:0 });
   });
 
+  it('fails closed for malformed expedition grades', () => {
+    const event = worldEvent(1, 1);
+    for (const grade of ['Z', '', null, undefined, 42] as any[]) {
+      expect(worldEventExpeditionBonus(event, 'starlight_forest', grade)).toEqual({ seasonPoints:0, materialBonus:0 });
+    }
+  });
+
   it('sanitizes invalid calendar inputs to a deterministic event', () => {
     expect(worldEvent(0, 0)).toEqual(worldEvent(1, 1));
     expect(worldEvent(Number.NaN, Number.NaN)).toEqual(worldEvent(1, 1));

--- a/src/world-event.ts
+++ b/src/world-event.ts
@@ -36,6 +36,7 @@ export function worldEventExpeditionBonus(
   region:ExpeditionRegionId,
   grade:ExpeditionGrade,
 ): { seasonPoints:number; materialBonus:number } {
-  if (grade === 'C' || region !== event.region) return { seasonPoints:0, materialBonus:0 };
+  const successfulGrade = grade === 'B' || grade === 'A' || grade === 'S';
+  if (!successfulGrade || region !== event.region) return { seasonPoints:0, materialBonus:0 };
   return { seasonPoints:5, materialBonus:grade === 'S' ? 1 : 0 };
 }

--- a/src/world-reward-key-long-run.test.ts
+++ b/src/world-reward-key-long-run.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { applyExpeditionCallingRewards } from './calling-depth-effects';
+import { advanceWorldContracts, emptyWorldContractProgress } from './world-contracts';
+import { worldEvent } from './world-event';
+
+describe('World reward key long-run stability', () => {
+  it('keeps monthly World Contract reward markers bounded across repeated runs', () => {
+    const event = worldEvent(2026, 8);
+    let progress = emptyWorldContractProgress();
+    let rewardedKeys: any[] = ['2026-8:expedition_clear', '2026-8:expedition_clear', null, 42, ''];
+
+    for (let i = 0; i < 500; i += 1) {
+      const result = advanceWorldContracts({
+        year:2026,
+        month:8,
+        event,
+        progress,
+        rewardedKeys,
+        region:event.region,
+        grade:'S',
+      });
+      progress = result.progress;
+      rewardedKeys = result.rewardedKeys;
+    }
+
+    expect(rewardedKeys).toEqual([
+      '2026-8:expedition_clear',
+      '2026-8:high_grade',
+      '2026-8:featured_region',
+    ]);
+  });
+
+  it('keeps Calling monthly legend markers canonical and bounded across repeated rewards', () => {
+    let legendRewardKeys: any[] = [
+      '2026-8:vanguard_legend',
+      '2026-8:vanguard_legend',
+      '2026-8:unknown_legend',
+      null,
+      42,
+      '',
+    ];
+
+    for (let i = 0; i < 500; i += 1) {
+      const result = applyExpeditionCallingRewards({
+        year:2026,
+        month:8,
+        calling:'vanguard',
+        traits:['vanguard_legend'],
+        signatures:[],
+        legendRewardKeys,
+        stageId:'forest_path',
+        grade:'A',
+        firstClear:true,
+        discovery:null,
+        regionCompleted:null,
+        materialReward:1,
+        fatigueDelta:8,
+        stressDelta:0,
+      });
+      legendRewardKeys = result.legendRewardKeys;
+    }
+
+    expect(legendRewardKeys).toEqual(['2026-8:vanguard_legend']);
+  });
+});


### PR DESCRIPTION
## 상태
- Draft / WIP
- base: `integration/v2`
- head: `work/world-expedition-next-2`
- PR #14 통합 완료 후 새 next-wave branch에서 재개
- 02는 World correctness만 담당
- `GuardianExpeditionOverlay.tsx` UI/accessibility 변경 보존
- 공용 game/save 직접 수정 금지
- integration은 06만 수행
- main/prod 금지

## 현재 타깃
1. World Contract rewarded-key malformed/duplicate sanitation
2. World Event ↔ Calling 교차 상태
3. durable marker/list 장기 성장 및 idempotency
4. malformed save/NaN/Infinity 추가 경계
