### PR TITLE
verify: future-version save downgrade guard

### DIFF
--- a/src/save-resilience.test.ts
+++ b/src/save-resilience.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { initialState } from './game';
-import { parseSavedGame, serializeSavedGame } from './save-schema';
+import { CURRENT_SAVE_SCHEMA_VERSION, parseSavedGame, serializeSavedGame } from './save-schema';
 import {
   loadResilientSave,
+  repairPrimarySave,
   saveStorageKeys,
   writeResilientSave,
   type SaveStorage,
@@ -13,6 +14,14 @@ class MemoryStorage implements SaveStorage {
   getItem(key:string) { return this.data.get(key) ?? null; }
   setItem(key:string, value:string) { this.data.set(key, value); }
   removeItem(key:string) { this.data.delete(key); }
+}
+
+function futureSave(gold:number) {
+  return JSON.stringify({
+    schemaVersion:CURRENT_SAVE_SCHEMA_VERSION + 1,
+    integrity:'future-integrity-format-is-opaque-to-this-version',
+    state:{ ...initialState, gold, unknownFutureField:{ keep:true } },
+  });
 }
 
 describe('save resilience', () => {
@@ -66,5 +75,37 @@ describe('save resilience', () => {
     writeResilientSave(storage, { ...initialState, gold:120 });
     expect(parseSavedGame(storage.getItem(saveStorageKeys.backups[0])).gold).toBe(90);
     expect(loadResilientSave(storage).state.gold).toBe(120);
+  });
+
+  it('keeps a future-version primary byte-for-byte intact instead of downgrading it on autosave', () => {
+    const storage = new MemoryStorage();
+    const future = futureSave(999);
+    storage.setItem(saveStorageKeys.primary, future);
+
+    const loaded = loadResilientSave(storage);
+    expect(loaded.source).toBe('primary');
+    expect(loaded.state.gold).toBe(999);
+
+    writeResilientSave(storage, { ...loaded.state, gold:1000 });
+
+    expect(storage.getItem(saveStorageKeys.primary)).toBe(future);
+    expect(storage.getItem(saveStorageKeys.backups[0])).toBeNull();
+  });
+
+  it('does not repair a future-version backup into a lossy current-schema primary', () => {
+    const storage = new MemoryStorage();
+    const future = futureSave(888);
+    storage.setItem(saveStorageKeys.primary, '{broken');
+    storage.setItem(saveStorageKeys.backups[0], future);
+
+    const loaded = loadResilientSave(storage);
+    expect(loaded.source).toBe('backup-1');
+    expect(loaded.recovered).toBe(true);
+    expect(loaded.state.gold).toBe(888);
+
+    repairPrimarySave(storage, loaded);
+
+    expect(storage.getItem(saveStorageKeys.primary)).toBe('{broken');
+    expect(storage.getItem(saveStorageKeys.backups[0])).toBe(future);
   });
 });

--- a/src/save-resilience.ts
+++ b/src/save-resilience.ts
@@ -22,12 +22,20 @@ export type ResilientSaveLoad = {
 
 type Candidate = { state:GameState; serialized:string };
 const acceptableStatuses = new Set(['valid','legacy','migrated-v1','future-version']);
+const allSaveKeys = [saveStorageKeys.primary, ...saveStorageKeys.backups] as const;
 
 function decodeCandidate(serialized:string|null): Candidate | null {
   if (!serialized) return null;
   const inspection = inspectSavedGame(serialized);
   if (!acceptableStatuses.has(inspection.status)) return null;
   return { state:inspection.state, serialized };
+}
+
+function hasFutureVersionSave(storage:SaveStorage): boolean {
+  return allSaveKeys.some(key => {
+    const serialized = storage.getItem(key);
+    return serialized ? inspectSavedGame(serialized).status === 'future-version' : false;
+  });
 }
 
 export function loadResilientSave(storage:SaveStorage): ResilientSaveLoad {
@@ -50,6 +58,8 @@ function validSerialized(storage:SaveStorage, key:string): string | null {
 }
 
 export function writeResilientSave(storage:SaveStorage, state:GameState): void {
+  if (hasFutureVersionSave(storage)) return;
+
   const primary = validSerialized(storage, saveStorageKeys.primary);
   const backup1 = validSerialized(storage, saveStorageKeys.backups[0]);
   const backup2 = validSerialized(storage, saveStorageKeys.backups[1]);
@@ -61,6 +71,6 @@ export function writeResilientSave(storage:SaveStorage, state:GameState): void {
 }
 
 export function repairPrimarySave(storage:SaveStorage, loaded:ResilientSaveLoad): void {
-  if (!loaded.recovered) return;
+  if (!loaded.recovered || hasFutureVersionSave(storage)) return;
   storage.setItem(saveStorageKeys.primary, serializeSavedGame(loaded.state));
 }


### PR DESCRIPTION
Verification-only TDD branch from authoritative `integration/v2@88742c349b4943d41fd02a9acb81c13e10f49a97`.

RED target:
- a future-schema primary must remain byte-for-byte intact when the older app autosaves;
- a future-schema backup must not be repaired into a lossy current-schema primary.

First commit is tests only and is expected to fail. After confirmed RED, 06 will apply the minimal save-resilience guard and rerun targeted save tests, Global RC, full suite, TypeScript and production build. No main/prod.