### PR TITLE
02 V3 Spring: campaign world objectives & facts

### DIFF
--- a/docs/superpowers/plans/2026-08-22-v3-spring-world-plan.md
+++ b/docs/superpowers/plans/2026-08-22-v3-spring-world-plan.md
@@ -1,0 +1,25 @@
+# V3 Spring World Implementation Plan
+
+**Baseline:** `integration/v3@46faf9031a86ff09d92cc17ee043e9180414d510`
+
+## Guardrails
+
+- Reuse the existing 3 Expedition regions and 9 stages; do not create campaign-specific maps.
+- Reuse `GuardianCallingId` for Caretaker / Pathfinder / Vanguard / Arcanist campaign identity.
+- Keep Spring World as a pure adapter/model layer. Do not edit App, Root, shared game/save, or 05 UI.
+- Preserve existing Expedition correctness and accessibility/UI behavior.
+- Prepare Great Expedition prerequisites only; do not implement Autumn Great Expedition gameplay.
+
+## Tasks
+
+1. Add a typed `WorldFactId` registry with canonical IDs only.
+2. Add sanitation for stale, malformed, unknown, and duplicate fact IDs.
+3. Model current-run facts and inherited echoes as separate collections and never merge echoes into current-run outcomes.
+4. Add Spring/Summer campaign World objective definitions over existing Expedition regions/stages.
+5. Add a fail-forward canonical outcome contract (`victory`, `defeat`, `costly`, `exceptional`) with once-only resolution and Story/Ending-consumable records.
+6. Add a Great Expedition prerequisite snapshot that carries campaign, current facts, inherited echoes, and resolved Spring/Summer outcomes without starting Autumn gameplay.
+7. Verify targeted World tests, full suite, `tsc -b`, and production build. Push only to `work/v3-spring-world` and open a Draft PR against `integration/v3`.
+
+## TDD order
+
+For each behavior: RED regression test → confirm failing CI → minimal production adapter/model → confirm GREEN → continue.

--- a/src/campaign-world-facts.test.ts
+++ b/src/campaign-world-facts.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizeCampaignWorldFacts,
+  sanitizeWorldFactIds,
+  worldFactDefinitions,
+} from './campaign-world';
+
+describe('V3 campaign world facts', () => {
+  it('exposes only the canonical Spring WorldFact registry', () => {
+    expect(worldFactDefinitions.map(item => item.id)).toEqual([
+      'festival_saved',
+      'festival_heavy_losses',
+      'ancient_route_opened',
+      'ancient_route_sealed',
+      'regional_alliance',
+      'rift_unstable',
+    ]);
+  });
+
+  it('drops stale, malformed and duplicate fact ids while preserving first canonical order', () => {
+    expect(sanitizeWorldFactIds([
+      'festival_saved',
+      'festival_saved',
+      'unknown_fact',
+      null,
+      42,
+      'ancient_route_opened',
+      'festival_saved',
+    ])).toEqual(['festival_saved', 'ancient_route_opened']);
+  });
+
+  it('keeps current-run facts and inherited echoes strictly separated', () => {
+    expect(sanitizeCampaignWorldFacts({
+      currentRunFacts: ['festival_saved', 'festival_saved', 'stale'],
+      inheritedEchoFacts: ['ancient_route_opened', 'festival_saved', 'unknown'],
+    })).toEqual({
+      currentRunFacts: ['festival_saved'],
+      inheritedEchoFacts: ['ancient_route_opened', 'festival_saved'],
+    });
+  });
+
+  it('fails malformed containers to empty collections instead of mixing history into the run', () => {
+    for (const raw of [null, undefined, 42, 'bad', []]) {
+      expect(sanitizeCampaignWorldFacts(raw)).toEqual({
+        currentRunFacts: [],
+        inheritedEchoFacts: [],
+      });
+    }
+  });
+});

--- a/src/campaign-world-facts.test.ts
+++ b/src/campaign-world-facts.test.ts
@@ -1,23 +1,22 @@
 import { describe, expect, it } from 'vitest';
+import { worldFactIds } from './world-history';
 import {
   sanitizeCampaignWorldFacts,
   sanitizeWorldFactIds,
-  worldFactDefinitions,
 } from './campaign-world';
 
 describe('V3 campaign world facts', () => {
-  it('exposes only the canonical Spring WorldFact registry', () => {
-    expect(worldFactDefinitions.map(item => item.id)).toEqual([
-      'festival_saved',
-      'festival_heavy_losses',
-      'ancient_route_opened',
-      'ancient_route_sealed',
-      'regional_alliance',
-      'rift_unstable',
-    ]);
+  it('reuses the authoritative V3 WorldFact registry including the Spring contract ids', () => {
+    expect(worldFactIds).toContain('festival_saved');
+    expect(worldFactIds).toContain('festival_heavy_losses');
+    expect(worldFactIds).toContain('ancient_route_opened');
+    expect(worldFactIds).toContain('ancient_route_sealed');
+    expect(worldFactIds).toContain('regional_alliance');
+    expect(worldFactIds).toContain('rift_unstable');
+    expect(new Set(worldFactIds).size).toBe(worldFactIds.length);
   });
 
-  it('drops stale, malformed and duplicate fact ids while preserving first canonical order', () => {
+  it('drops stale, malformed and duplicate fact ids using canonical registry order', () => {
     expect(sanitizeWorldFactIds([
       'festival_saved',
       'festival_saved',
@@ -31,19 +30,19 @@ describe('V3 campaign world facts', () => {
 
   it('keeps current-run facts and inherited echoes strictly separated', () => {
     expect(sanitizeCampaignWorldFacts({
-      currentRunFacts: ['festival_saved', 'festival_saved', 'stale'],
-      inheritedEchoFacts: ['ancient_route_opened', 'festival_saved', 'unknown'],
+      currentFacts: ['festival_saved', 'festival_saved', 'stale'],
+      inheritedFacts: ['ancient_route_opened', 'festival_saved', 'unknown'],
     })).toEqual({
-      currentRunFacts: ['festival_saved'],
-      inheritedEchoFacts: ['ancient_route_opened', 'festival_saved'],
+      currentFacts: ['festival_saved'],
+      inheritedFacts: ['festival_saved', 'ancient_route_opened'],
     });
   });
 
   it('fails malformed containers to empty collections instead of mixing history into the run', () => {
     for (const raw of [null, undefined, 42, 'bad', []]) {
       expect(sanitizeCampaignWorldFacts(raw)).toEqual({
-        currentRunFacts: [],
-        inheritedEchoFacts: [],
+        currentFacts: [],
+        inheritedFacts: [],
       });
     }
   });

--- a/src/campaign-world-great-expedition-prerequisite.test.ts
+++ b/src/campaign-world-great-expedition-prerequisite.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { buildGreatExpeditionWorldPrerequisite } from './campaign-world';
+
+describe('V3 Great Expedition world prerequisite', () => {
+  it('prepares only sanitized Spring/Summer evidence for a main campaign', () => {
+    const result = buildGreatExpeditionWorldPrerequisite({
+      activeCampaign: 'pathfinder',
+      worldHistory: {
+        currentFacts: ['festival_saved', 'ancient_route_opened', 'festival_saved', 'stale'],
+        inheritedFacts: ['rift_unstable', 'festival_heavy_losses', 'unknown'],
+      },
+      majorOutcomes: { guardian_festival: 'victory' },
+      failForwardOutcomes: [],
+    });
+
+    expect(result).toEqual({
+      campaign: 'pathfinder',
+      ready: true,
+      guardianFestivalOutcome: 'victory',
+      festivalFailForward: false,
+      currentFacts: ['festival_saved', 'ancient_route_opened'],
+      inheritedFacts: ['festival_heavy_losses', 'rift_unstable'],
+    });
+  });
+
+  it('preserves a costly or defeated Summer result as fail-forward prerequisite evidence', () => {
+    const result = buildGreatExpeditionWorldPrerequisite({
+      activeCampaign: 'caretaker',
+      worldHistory: { currentFacts: ['festival_heavy_losses'], inheritedFacts: [] },
+      majorOutcomes: { guardian_festival: 'defeat' },
+      failForwardOutcomes: ['guardian_festival', 'guardian_festival'],
+    });
+
+    expect(result.ready).toBe(true);
+    expect(result.guardianFestivalOutcome).toBe('defeat');
+    expect(result.festivalFailForward).toBe(true);
+  });
+
+  it('is not ready until both a valid main campaign and Guardian Festival result exist', () => {
+    for (const input of [
+      { activeCampaign: 'pathfinder', majorOutcomes: {} },
+      { activeCampaign: 'true_path', majorOutcomes: { guardian_festival: 'victory' } },
+      { activeCampaign: 'unknown', majorOutcomes: { guardian_festival: 'victory' } },
+      { activeCampaign: null, majorOutcomes: { guardian_festival: 'victory' } },
+    ] as any[]) {
+      const result = buildGreatExpeditionWorldPrerequisite({
+        ...input,
+        worldHistory: null,
+        failForwardOutcomes: null,
+      });
+      expect(result.ready).toBe(false);
+    }
+  });
+
+  it('does not implement Great Expedition gameplay or resolve its outcome', () => {
+    const result = buildGreatExpeditionWorldPrerequisite({
+      activeCampaign: 'arcanist',
+      worldHistory: { currentFacts: ['rift_unstable'], inheritedFacts: [] },
+      majorOutcomes: {
+        guardian_festival: 'costly_victory',
+        great_expedition: 'exceptional_victory',
+      },
+      failForwardOutcomes: ['guardian_festival'],
+    });
+
+    expect(Object.keys(result).sort()).toEqual([
+      'campaign',
+      'currentFacts',
+      'festivalFailForward',
+      'guardianFestivalOutcome',
+      'inheritedFacts',
+      'ready',
+    ]);
+    expect(JSON.stringify(result)).not.toContain('great_expedition');
+    expect(JSON.stringify(result)).not.toContain('stageId');
+    expect(JSON.stringify(result)).not.toContain('reward');
+  });
+});

--- a/src/campaign-world-objectives.test.ts
+++ b/src/campaign-world-objectives.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { mainCampaignIds } from './campaign-model';
-import { expeditionRegions } from './expedition-regions';
+import { expeditionRegionDefinitions } from './expedition-regions';
 import { campaignWorldObjectives } from './campaign-world';
 
 describe('V3 campaign world objective overlays', () => {
@@ -14,11 +14,11 @@ describe('V3 campaign world objective overlays', () => {
 
   it('reuses only existing Expedition regions and stages instead of adding campaign maps', () => {
     const stageToRegion = new Map(
-      expeditionRegions.flatMap(region => region.stages.map(stage => [stage.id, region.id] as const)),
+      expeditionRegionDefinitions.flatMap(region => region.stages.map(stageId => [stageId, region.id] as const)),
     );
 
     for (const objective of campaignWorldObjectives) {
-      expect(expeditionRegions.some(region => region.id === objective.regionId)).toBe(true);
+      expect(expeditionRegionDefinitions.some(region => region.id === objective.regionId)).toBe(true);
       expect(objective.stageIds.length).toBeGreaterThan(0);
       for (const stageId of objective.stageIds) {
         expect(stageToRegion.get(stageId)).toBe(objective.regionId);

--- a/src/campaign-world-objectives.test.ts
+++ b/src/campaign-world-objectives.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { mainCampaignIds } from './campaign-model';
+import { expeditionRegions } from './expedition-regions';
+import { campaignWorldObjectives } from './campaign-world';
+
+describe('V3 campaign world objective overlays', () => {
+  it('defines one Spring and one Summer objective for each main campaign', () => {
+    for (const season of ['spring', 'summer'] as const) {
+      const seasonObjectives = campaignWorldObjectives.filter(item => item.season === season);
+      expect(seasonObjectives).toHaveLength(4);
+      expect(seasonObjectives.map(item => item.campaign).sort()).toEqual([...mainCampaignIds].sort());
+    }
+  });
+
+  it('reuses only existing Expedition regions and stages instead of adding campaign maps', () => {
+    const stageToRegion = new Map(
+      expeditionRegions.flatMap(region => region.stages.map(stage => [stage.id, region.id] as const)),
+    );
+
+    for (const objective of campaignWorldObjectives) {
+      expect(expeditionRegions.some(region => region.id === objective.regionId)).toBe(true);
+      expect(objective.stageIds.length).toBeGreaterThan(0);
+      for (const stageId of objective.stageIds) {
+        expect(stageToRegion.get(stageId)).toBe(objective.regionId);
+      }
+    }
+  });
+
+  it('keeps campaign objective semantics distinct on the shared world', () => {
+    const expectedKinds = {
+      caretaker: 'protect_residents',
+      pathfinder: 'discover_route',
+      vanguard: 'remove_threat',
+      arcanist: 'investigate_relic_rift',
+    } as const;
+
+    for (const objective of campaignWorldObjectives) {
+      expect(objective.kind).toBe(expectedKinds[objective.campaign]);
+    }
+  });
+
+  it('uses stable canonical objective ids for Spring evidence and Summer Guardian Festival setup', () => {
+    expect(campaignWorldObjectives.map(item => item.id)).toEqual([
+      'spring_caretaker_resident_guard',
+      'spring_pathfinder_hidden_route',
+      'spring_vanguard_threat_clear',
+      'spring_arcanist_relic_survey',
+      'summer_caretaker_festival_rescue',
+      'summer_pathfinder_festival_routes',
+      'summer_vanguard_festival_threat',
+      'summer_arcanist_festival_relic',
+    ]);
+  });
+});

--- a/src/campaign-world-outcomes.test.ts
+++ b/src/campaign-world-outcomes.test.ts
@@ -74,6 +74,30 @@ describe('V3 Guardian Festival world outcome', () => {
     expect(replay.failForwardOutcomes).toEqual(['guardian_festival']);
   });
 
+  it('repairs cross-field fail-forward evidence from the authoritative stored outcome', () => {
+    const costly = resolveGuardianFestivalWorldOutcome({
+      outcome: 'victory',
+      worldHistory: { currentFacts: [], inheritedFacts: [] },
+      majorOutcomes: { guardian_festival: 'costly_victory' },
+      failForwardOutcomes: [],
+    });
+    expect(costly.applied).toBe(false);
+    expect(costly.outcome).toBe('costly_victory');
+    expect(costly.worldHistory.currentFacts).toEqual(['festival_heavy_losses']);
+    expect(costly.failForwardOutcomes).toEqual(['guardian_festival']);
+
+    const clean = resolveGuardianFestivalWorldOutcome({
+      outcome: 'defeat',
+      worldHistory: { currentFacts: ['festival_heavy_losses'], inheritedFacts: [] },
+      majorOutcomes: { guardian_festival: 'victory' },
+      failForwardOutcomes: ['guardian_festival'],
+    });
+    expect(clean.applied).toBe(false);
+    expect(clean.outcome).toBe('victory');
+    expect(clean.worldHistory.currentFacts).toEqual(['festival_heavy_losses', 'festival_saved']);
+    expect(clean.failForwardOutcomes).toEqual([]);
+  });
+
   it('sanitizes malformed state and fails closed for unknown outcomes', () => {
     const result = resolveGuardianFestivalWorldOutcome({
       outcome: 'unknown_result',

--- a/src/campaign-world-outcomes.test.ts
+++ b/src/campaign-world-outcomes.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { majorOutcomeResults } from './campaign-model';
+import { resolveGuardianFestivalWorldOutcome } from './campaign-world';
+
+describe('V3 Guardian Festival world outcome', () => {
+  it('accepts only the canonical V3 outcome results and maps them to current-run world facts', () => {
+    const expectedFacts = {
+      exceptional_victory: 'festival_saved',
+      victory: 'festival_saved',
+      costly_victory: 'festival_heavy_losses',
+      defeat: 'festival_heavy_losses',
+    } as const;
+
+    for (const outcome of majorOutcomeResults) {
+      const result = resolveGuardianFestivalWorldOutcome({
+        outcome,
+        worldHistory: { currentFacts: [], inheritedFacts: ['ancient_route_opened'] },
+        majorOutcomes: {},
+        failForwardOutcomes: [],
+      });
+      expect(result.applied).toBe(true);
+      expect(result.eventId).toBe('guardian_festival');
+      expect(result.outcome).toBe(outcome);
+      expect(result.fact).toBe(expectedFacts[outcome]);
+      expect(result.worldHistory.currentFacts).toEqual([expectedFacts[outcome]]);
+      expect(result.worldHistory.inheritedFacts).toEqual(['ancient_route_opened']);
+      expect(result.majorOutcomes).toEqual({ guardian_festival: outcome });
+    }
+  });
+
+  it('marks costly victory and defeat as fail-forward without blocking canonical resolution', () => {
+    for (const outcome of ['costly_victory', 'defeat'] as const) {
+      const result = resolveGuardianFestivalWorldOutcome({
+        outcome,
+        worldHistory: { currentFacts: [], inheritedFacts: [] },
+        majorOutcomes: {},
+        failForwardOutcomes: [],
+      });
+      expect(result.applied).toBe(true);
+      expect(result.failForwardOutcomes).toEqual(['guardian_festival']);
+    }
+
+    for (const outcome of ['exceptional_victory', 'victory'] as const) {
+      const result = resolveGuardianFestivalWorldOutcome({
+        outcome,
+        worldHistory: { currentFacts: [], inheritedFacts: [] },
+        majorOutcomes: {},
+        failForwardOutcomes: [],
+      });
+      expect(result.failForwardOutcomes).toEqual([]);
+    }
+  });
+
+  it('is once-only and never overwrites the first canonical Guardian Festival result', () => {
+    const first = resolveGuardianFestivalWorldOutcome({
+      outcome: 'defeat',
+      worldHistory: { currentFacts: [], inheritedFacts: ['festival_saved'] },
+      majorOutcomes: {},
+      failForwardOutcomes: [],
+    });
+    const replay = resolveGuardianFestivalWorldOutcome({
+      outcome: 'exceptional_victory',
+      worldHistory: first.worldHistory,
+      majorOutcomes: first.majorOutcomes,
+      failForwardOutcomes: first.failForwardOutcomes,
+    });
+
+    expect(replay.applied).toBe(false);
+    expect(replay.outcome).toBe('defeat');
+    expect(replay.fact).toBe('festival_heavy_losses');
+    expect(replay.majorOutcomes).toEqual({ guardian_festival: 'defeat' });
+    expect(replay.worldHistory.currentFacts).toEqual(['festival_heavy_losses']);
+    expect(replay.worldHistory.inheritedFacts).toEqual(['festival_saved']);
+    expect(replay.failForwardOutcomes).toEqual(['guardian_festival']);
+  });
+
+  it('sanitizes malformed state and fails closed for unknown outcomes', () => {
+    const result = resolveGuardianFestivalWorldOutcome({
+      outcome: 'unknown_result',
+      worldHistory: {
+        currentFacts: ['festival_saved', 'festival_saved', 'stale'],
+        inheritedFacts: ['ancient_route_opened', 'unknown'],
+      },
+      majorOutcomes: { guardian_festival: 'broken', unknown_event: 'victory' },
+      failForwardOutcomes: ['guardian_festival', 'guardian_festival', 'unknown_event'],
+    } as any);
+
+    expect(result.applied).toBe(false);
+    expect(result.outcome).toBeNull();
+    expect(result.fact).toBeNull();
+    expect(result.worldHistory).toEqual({
+      currentFacts: ['festival_saved'],
+      inheritedFacts: ['ancient_route_opened'],
+    });
+    expect(result.majorOutcomes).toEqual({});
+    expect(result.failForwardOutcomes).toEqual(['guardian_festival']);
+  });
+});

--- a/src/campaign-world-outcomes.test.ts
+++ b/src/campaign-world-outcomes.test.ts
@@ -74,10 +74,10 @@ describe('V3 Guardian Festival world outcome', () => {
     expect(replay.failForwardOutcomes).toEqual(['guardian_festival']);
   });
 
-  it('repairs cross-field fail-forward evidence from the authoritative stored outcome', () => {
+  it('repairs cross-field Festival evidence from the authoritative stored outcome', () => {
     const costly = resolveGuardianFestivalWorldOutcome({
       outcome: 'victory',
-      worldHistory: { currentFacts: [], inheritedFacts: [] },
+      worldHistory: { currentFacts: ['festival_saved'], inheritedFacts: [] },
       majorOutcomes: { guardian_festival: 'costly_victory' },
       failForwardOutcomes: [],
     });
@@ -94,7 +94,7 @@ describe('V3 Guardian Festival world outcome', () => {
     });
     expect(clean.applied).toBe(false);
     expect(clean.outcome).toBe('victory');
-    expect(clean.worldHistory.currentFacts).toEqual(['festival_heavy_losses', 'festival_saved']);
+    expect(clean.worldHistory.currentFacts).toEqual(['festival_saved']);
     expect(clean.failForwardOutcomes).toEqual([]);
   });
 

--- a/src/campaign-world.ts
+++ b/src/campaign-world.ts
@@ -1,4 +1,5 @@
 import {
+  mainCampaignIds,
   majorEventIds,
   majorOutcomeResults,
   type MainCampaignId,
@@ -119,6 +120,10 @@ function isMajorOutcomeResult(value: unknown): value is MajorOutcomeResult {
   return typeof value === 'string' && majorOutcomeResults.includes(value as MajorOutcomeResult);
 }
 
+function isMainCampaignId(value: unknown): value is MainCampaignId {
+  return typeof value === 'string' && mainCampaignIds.includes(value as MainCampaignId);
+}
+
 function sanitizeMajorOutcomes(raw: unknown): Partial<Record<MajorEventId, MajorOutcomeResult>> {
   if (!isV3Record(raw)) return {};
   const result: Partial<Record<MajorEventId, MajorOutcomeResult>> = {};
@@ -211,5 +216,40 @@ export function resolveGuardianFestivalWorldOutcome(
     worldHistory,
     majorOutcomes,
     failForwardOutcomes,
+  };
+}
+
+export type GreatExpeditionWorldPrerequisiteInput = {
+  activeCampaign: unknown;
+  worldHistory: unknown;
+  majorOutcomes: unknown;
+  failForwardOutcomes: unknown;
+};
+
+export type GreatExpeditionWorldPrerequisite = {
+  campaign: MainCampaignId | null;
+  ready: boolean;
+  guardianFestivalOutcome: MajorOutcomeResult | null;
+  festivalFailForward: boolean;
+  currentFacts: WorldFactId[];
+  inheritedFacts: WorldFactId[];
+};
+
+export function buildGreatExpeditionWorldPrerequisite(
+  input: GreatExpeditionWorldPrerequisiteInput,
+): GreatExpeditionWorldPrerequisite {
+  const campaign = isMainCampaignId(input.activeCampaign) ? input.activeCampaign : null;
+  const worldHistory = sanitizeCampaignWorldFacts(input.worldHistory);
+  const majorOutcomes = sanitizeMajorOutcomes(input.majorOutcomes);
+  const failForwardOutcomes = uniqueRegistered(input.failForwardOutcomes, majorEventIds);
+  const guardianFestivalOutcome = majorOutcomes.guardian_festival ?? null;
+
+  return {
+    campaign,
+    ready: campaign !== null && guardianFestivalOutcome !== null,
+    guardianFestivalOutcome,
+    festivalFailForward: failForwardOutcomes.includes('guardian_festival'),
+    currentFacts: worldHistory.currentFacts,
+    inheritedFacts: worldHistory.inheritedFacts,
   };
 }

--- a/src/campaign-world.ts
+++ b/src/campaign-world.ts
@@ -140,6 +140,20 @@ function guardianFestivalFact(outcome: MajorOutcomeResult): WorldFactId {
     : 'festival_heavy_losses';
 }
 
+function isFailForwardOutcome(outcome: MajorOutcomeResult): boolean {
+  return outcome === 'costly_victory' || outcome === 'defeat';
+}
+
+function reconcileGuardianFestivalFailForward(
+  failForwardOutcomes: MajorEventId[],
+  outcome: MajorOutcomeResult,
+): MajorEventId[] {
+  if (isFailForwardOutcome(outcome)) {
+    return uniqueRegistered([...failForwardOutcomes, 'guardian_festival'], majorEventIds);
+  }
+  return failForwardOutcomes.filter(eventId => eventId !== 'guardian_festival');
+}
+
 export type GuardianFestivalWorldOutcomeInput = {
   outcome: unknown;
   worldHistory: unknown;
@@ -171,6 +185,7 @@ export function resolveGuardianFestivalWorldOutcome(
       ...worldHistory,
       currentFacts: sanitizeWorldFactIds([...worldHistory.currentFacts, fact]),
     };
+    failForwardOutcomes = reconcileGuardianFestivalFailForward(failForwardOutcomes, existing);
     return {
       applied: false,
       eventId: 'guardian_festival',
@@ -201,12 +216,7 @@ export function resolveGuardianFestivalWorldOutcome(
     currentFacts: sanitizeWorldFactIds([...worldHistory.currentFacts, fact]),
   };
   majorOutcomes.guardian_festival = outcome;
-  if (outcome === 'costly_victory' || outcome === 'defeat') {
-    failForwardOutcomes = uniqueRegistered(
-      [...failForwardOutcomes, 'guardian_festival'],
-      majorEventIds,
-    );
-  }
+  failForwardOutcomes = reconcileGuardianFestivalFailForward(failForwardOutcomes, outcome);
 
   return {
     applied: true,

--- a/src/campaign-world.ts
+++ b/src/campaign-world.ts
@@ -140,6 +140,20 @@ function guardianFestivalFact(outcome: MajorOutcomeResult): WorldFactId {
     : 'festival_heavy_losses';
 }
 
+function reconcileGuardianFestivalWorldHistory(
+  worldHistory: WorldHistoryState,
+  outcome: MajorOutcomeResult,
+): WorldHistoryState {
+  const fact = guardianFestivalFact(outcome);
+  const currentFacts = worldHistory.currentFacts.filter(
+    id => id !== 'festival_saved' && id !== 'festival_heavy_losses',
+  );
+  return {
+    ...worldHistory,
+    currentFacts: sanitizeWorldFactIds([...currentFacts, fact]),
+  };
+}
+
 function isFailForwardOutcome(outcome: MajorOutcomeResult): boolean {
   return outcome === 'costly_victory' || outcome === 'defeat';
 }
@@ -181,10 +195,7 @@ export function resolveGuardianFestivalWorldOutcome(
 
   if (existing) {
     const fact = guardianFestivalFact(existing);
-    worldHistory = {
-      ...worldHistory,
-      currentFacts: sanitizeWorldFactIds([...worldHistory.currentFacts, fact]),
-    };
+    worldHistory = reconcileGuardianFestivalWorldHistory(worldHistory, existing);
     failForwardOutcomes = reconcileGuardianFestivalFailForward(failForwardOutcomes, existing);
     return {
       applied: false,
@@ -211,10 +222,7 @@ export function resolveGuardianFestivalWorldOutcome(
 
   const outcome = input.outcome;
   const fact = guardianFestivalFact(outcome);
-  worldHistory = {
-    ...worldHistory,
-    currentFacts: sanitizeWorldFactIds([...worldHistory.currentFacts, fact]),
-  };
+  worldHistory = reconcileGuardianFestivalWorldHistory(worldHistory, outcome);
   majorOutcomes.guardian_festival = outcome;
   failForwardOutcomes = reconcileGuardianFestivalFailForward(failForwardOutcomes, outcome);
 

--- a/src/campaign-world.ts
+++ b/src/campaign-world.ts
@@ -1,6 +1,12 @@
-import type { MainCampaignId } from './campaign-model';
+import {
+  majorEventIds,
+  majorOutcomeResults,
+  type MainCampaignId,
+  type MajorEventId,
+  type MajorOutcomeResult,
+} from './campaign-model';
 import type { ExpeditionRegionId, ExpeditionStageId } from './expedition-regions';
-import { uniqueRegistered } from './v3-state-sanitize';
+import { isV3Record, uniqueRegistered } from './v3-state-sanitize';
 import {
   hydrateWorldHistoryState,
   worldFactIds,
@@ -107,4 +113,103 @@ export function sanitizeWorldFactIds(raw: unknown): WorldFactId[] {
 
 export function sanitizeCampaignWorldFacts(raw: unknown): WorldHistoryState {
   return hydrateWorldHistoryState(raw);
+}
+
+function isMajorOutcomeResult(value: unknown): value is MajorOutcomeResult {
+  return typeof value === 'string' && majorOutcomeResults.includes(value as MajorOutcomeResult);
+}
+
+function sanitizeMajorOutcomes(raw: unknown): Partial<Record<MajorEventId, MajorOutcomeResult>> {
+  if (!isV3Record(raw)) return {};
+  const result: Partial<Record<MajorEventId, MajorOutcomeResult>> = {};
+  for (const eventId of majorEventIds) {
+    const value = raw[eventId];
+    if (isMajorOutcomeResult(value)) result[eventId] = value;
+  }
+  return result;
+}
+
+function guardianFestivalFact(outcome: MajorOutcomeResult): WorldFactId {
+  return outcome === 'exceptional_victory' || outcome === 'victory'
+    ? 'festival_saved'
+    : 'festival_heavy_losses';
+}
+
+export type GuardianFestivalWorldOutcomeInput = {
+  outcome: unknown;
+  worldHistory: unknown;
+  majorOutcomes: unknown;
+  failForwardOutcomes: unknown;
+};
+
+export type GuardianFestivalWorldOutcomeResult = {
+  applied: boolean;
+  eventId: 'guardian_festival';
+  outcome: MajorOutcomeResult | null;
+  fact: WorldFactId | null;
+  worldHistory: WorldHistoryState;
+  majorOutcomes: Partial<Record<MajorEventId, MajorOutcomeResult>>;
+  failForwardOutcomes: MajorEventId[];
+};
+
+export function resolveGuardianFestivalWorldOutcome(
+  input: GuardianFestivalWorldOutcomeInput,
+): GuardianFestivalWorldOutcomeResult {
+  let worldHistory = sanitizeCampaignWorldFacts(input.worldHistory);
+  const majorOutcomes = sanitizeMajorOutcomes(input.majorOutcomes);
+  let failForwardOutcomes = uniqueRegistered(input.failForwardOutcomes, majorEventIds);
+  const existing = majorOutcomes.guardian_festival;
+
+  if (existing) {
+    const fact = guardianFestivalFact(existing);
+    worldHistory = {
+      ...worldHistory,
+      currentFacts: sanitizeWorldFactIds([...worldHistory.currentFacts, fact]),
+    };
+    return {
+      applied: false,
+      eventId: 'guardian_festival',
+      outcome: existing,
+      fact,
+      worldHistory,
+      majorOutcomes,
+      failForwardOutcomes,
+    };
+  }
+
+  if (!isMajorOutcomeResult(input.outcome)) {
+    return {
+      applied: false,
+      eventId: 'guardian_festival',
+      outcome: null,
+      fact: null,
+      worldHistory,
+      majorOutcomes,
+      failForwardOutcomes,
+    };
+  }
+
+  const outcome = input.outcome;
+  const fact = guardianFestivalFact(outcome);
+  worldHistory = {
+    ...worldHistory,
+    currentFacts: sanitizeWorldFactIds([...worldHistory.currentFacts, fact]),
+  };
+  majorOutcomes.guardian_festival = outcome;
+  if (outcome === 'costly_victory' || outcome === 'defeat') {
+    failForwardOutcomes = uniqueRegistered(
+      [...failForwardOutcomes, 'guardian_festival'],
+      majorEventIds,
+    );
+  }
+
+  return {
+    applied: true,
+    eventId: 'guardian_festival',
+    outcome,
+    fact,
+    worldHistory,
+    majorOutcomes,
+    failForwardOutcomes,
+  };
 }

--- a/src/campaign-world.ts
+++ b/src/campaign-world.ts
@@ -1,0 +1,15 @@
+import { uniqueRegistered } from './v3-state-sanitize';
+import {
+  hydrateWorldHistoryState,
+  worldFactIds,
+  type WorldFactId,
+  type WorldHistoryState,
+} from './world-history';
+
+export function sanitizeWorldFactIds(raw: unknown): WorldFactId[] {
+  return uniqueRegistered(raw, worldFactIds);
+}
+
+export function sanitizeCampaignWorldFacts(raw: unknown): WorldHistoryState {
+  return hydrateWorldHistoryState(raw);
+}

--- a/src/campaign-world.ts
+++ b/src/campaign-world.ts
@@ -1,3 +1,5 @@
+import type { MainCampaignId } from './campaign-model';
+import type { ExpeditionRegionId, ExpeditionStageId } from './expedition-regions';
 import { uniqueRegistered } from './v3-state-sanitize';
 import {
   hydrateWorldHistoryState,
@@ -5,6 +7,99 @@ import {
   type WorldFactId,
   type WorldHistoryState,
 } from './world-history';
+
+export type CampaignWorldSeason = 'spring' | 'summer';
+export type CampaignWorldObjectiveKind =
+  | 'protect_residents'
+  | 'discover_route'
+  | 'remove_threat'
+  | 'investigate_relic_rift';
+
+export type CampaignWorldObjectiveId =
+  | 'spring_caretaker_resident_guard'
+  | 'spring_pathfinder_hidden_route'
+  | 'spring_vanguard_threat_clear'
+  | 'spring_arcanist_relic_survey'
+  | 'summer_caretaker_festival_rescue'
+  | 'summer_pathfinder_festival_routes'
+  | 'summer_vanguard_festival_threat'
+  | 'summer_arcanist_festival_relic';
+
+export type CampaignWorldObjectiveDefinition = {
+  id: CampaignWorldObjectiveId;
+  season: CampaignWorldSeason;
+  campaign: MainCampaignId;
+  kind: CampaignWorldObjectiveKind;
+  regionId: ExpeditionRegionId;
+  stageIds: readonly ExpeditionStageId[];
+};
+
+export const campaignWorldObjectives: readonly CampaignWorldObjectiveDefinition[] = [
+  {
+    id: 'spring_caretaker_resident_guard',
+    season: 'spring',
+    campaign: 'caretaker',
+    kind: 'protect_residents',
+    regionId: 'starlight_forest',
+    stageIds: ['forest_path', 'forest_glade'],
+  },
+  {
+    id: 'spring_pathfinder_hidden_route',
+    season: 'spring',
+    campaign: 'pathfinder',
+    kind: 'discover_route',
+    regionId: 'ancient_city',
+    stageIds: ['city_square', 'city_gallery'],
+  },
+  {
+    id: 'spring_vanguard_threat_clear',
+    season: 'spring',
+    campaign: 'vanguard',
+    kind: 'remove_threat',
+    regionId: 'wind_lakes',
+    stageIds: ['lake_channel', 'lake_cliff'],
+  },
+  {
+    id: 'spring_arcanist_relic_survey',
+    season: 'spring',
+    campaign: 'arcanist',
+    kind: 'investigate_relic_rift',
+    regionId: 'ancient_city',
+    stageIds: ['city_gallery', 'city_core'],
+  },
+  {
+    id: 'summer_caretaker_festival_rescue',
+    season: 'summer',
+    campaign: 'caretaker',
+    kind: 'protect_residents',
+    regionId: 'starlight_forest',
+    stageIds: ['forest_glade', 'forest_guardian'],
+  },
+  {
+    id: 'summer_pathfinder_festival_routes',
+    season: 'summer',
+    campaign: 'pathfinder',
+    kind: 'discover_route',
+    regionId: 'ancient_city',
+    stageIds: ['city_square', 'city_gallery'],
+  },
+  {
+    id: 'summer_vanguard_festival_threat',
+    season: 'summer',
+    campaign: 'vanguard',
+    kind: 'remove_threat',
+    regionId: 'ancient_city',
+    stageIds: ['city_square', 'city_core'],
+  },
+  {
+    id: 'summer_arcanist_festival_relic',
+    season: 'summer',
+    campaign: 'arcanist',
+    kind: 'investigate_relic_rift',
+    regionId: 'wind_lakes',
+    stageIds: ['lake_cliff', 'lake_tempest'],
+  },
+] as const;
 
 export function sanitizeWorldFactIds(raw: unknown): WorldFactId[] {
   return uniqueRegistered(raw, worldFactIds);


### PR DESCRIPTION
## 상태
- Draft / WIP
- issue: #57
- parent control tower: #54
- base: `integration/v3@46faf9031a86ff09d92cc17ee043e9180414d510`
- head: `work/v3-spring-world@f458abfb1ab6733024b00178e11a28d227801e35`
- merge-ref verified: `35ced721e1bf892851c5c9f9db3f813fdcf93c22`
- integration/main/prod merge 없음

## 구현
### WorldFact
- Foundation `world-history.ts` canonical `WorldFactId` registry 재사용
- typed canonical IDs only
- stale / unknown / malformed / duplicate ID sanitation
- `currentFacts` / `inheritedFacts` strict separation
- NG+ inherited echo를 current-run 결과로 승격하지 않음

### Campaign World objectives
- 기존 3 regions / 9 Expedition stages 재사용
- 새 campaign map/region/stage 없음
- Spring/Summer × 4 main campaigns = 8 objective overlay definitions

### Fail-forward Guardian Festival
- Foundation `MajorOutcomeResult` 재사용
- first canonical outcome once-only
- `exceptional_victory` / `victory` → current fact exactly `festival_saved`, no fail-forward marker
- `costly_victory` / `defeat` → current fact exactly `festival_heavy_losses`, fail-forward marker present
- stored `majorOutcomes.guardian_festival` is authoritative on replay/hydration
- contradictory stale Festival current fact is removed
- missing/stale fail-forward marker is repaired in either direction
- malformed world history/outcome/fail-forward state sanitation preserved

### Autumn Great Expedition prerequisite
- prerequisite snapshot only
- main campaign + Guardian Festival outcome + current facts + inherited echoes + fail-forward evidence
- premature `great_expedition` outcome ignored
- no Great Expedition stage/combat/reward/result implementation

## Final invariant TDD
- CI #1473: RED — stored costly/defeat outcome with missing fail-forward marker was not repaired
- CI #1476: intermediate RED — marker repair exposed contradictory Festival facts coexisting
- refined invariant: authoritative stored outcome must produce exactly one matching Festival current fact and iff fail-forward marker
- CI #1478 / run `32543366344`: GREEN
- `campaign-world-outcomes.test.ts`: **5/5 PASS**
- full suite: **342/342 test files, 1226/1226 tests**
- `tsc -b`: PASS
- Vite production build: PASS
- 189 modules transformed

## Earlier Spring TDD evidence
- CI #1444 — WorldFact adapter missing RED
- CI #1448 — Campaign World objective adapter missing RED
- CI #1450 — Guardian Festival outcome resolver missing RED
- CI #1453 — Great Expedition prerequisite builder missing RED

## Guardrails
- App / Root untouched
- shared game/save untouched
- 05 UI/accessibility untouched
- existing Expedition/World correctness preserved by full suite
- direct merge 없음
- main/prod 없음
- `[06 Integration Request]`: 없음

## Notes
- CI `npm install` still reports the repository's existing `1 high severity vulnerability`; this Spring World change does not modify dependencies.