### PR TITLE
[03] V3 Spring campaign seasonal objectives

### DIFF
--- a/docs/superpowers/plans/2026-08-22-v3-spring-seasonal-objectives.md
+++ b/docs/superpowers/plans/2026-08-22-v3-spring-seasonal-objectives.md
@@ -1,0 +1,79 @@
+# V3 Spring Campaign Seasonal Objectives Implementation Plan
+
+**Goal:** Add campaign-aware Spring/Summer Seasonal Objectives as a thin adapter over existing Season, Weekly Directive, World, Tactical, Bond, Relic, Astral, and Rift outcomes without adding a new daily/weekly chore loop.
+
+**Architecture:** Keep this wave self-contained in new pure Season-owned modules. Existing actions emit a normalized campaign-season signal; the adapter deterministically selects at most one matching objective per action. Objective completion emits a canonical season-scoped claim key and a Legacy hook payload. Persistence remains caller-owned; no shared save/game fields are added in 03. If persistent wiring is required, file a 06 Integration Request.
+
+**Baseline:** `integration/v3@46faf9031a86ff09d92cc17ee043e9180414d510`
+**Branch:** `work/v3-spring-season`
+
+## Constraints
+
+- Spring and Summer definitions only. No Autumn/Winter mainline implementation.
+- No second daily/weekly chore stack.
+- One existing action may advance at most one Seasonal Objective.
+- Rewards are season-scoped reward-once and remain claimed across week rollover/reload/re-entry.
+- Malformed campaign IDs, objective IDs, claim keys, and unsupported seasons are ignored/rejected safely.
+- Legacy/True support is contract-only. No True Campaign eligibility or story implementation.
+- Do not modify shared save/game/App/Root files.
+- Preserve existing Sanctuary/Astral/Celestial/Rift behavior by consuming their outcomes as signals only.
+- RED before production code; verify targeted Season tests, then full test and build (`build` includes TypeScript).
+- Push only to `work/v3-spring-season`; Draft PR targets `integration/v3`; do not merge.
+
+---
+
+### Task 1: Define adapter contracts and Spring/Summer sets
+
+**Files:**
+- Create: `src/campaign-seasonal-objectives.test.ts`
+- Create: `src/campaign-seasonal-objectives.ts`
+
+- [ ] RED: campaign IDs and Spring/Summer objective definitions cover Caretaker, Pathfinder, Vanguard, Arcanist.
+- [ ] RED: Autumn/Winter have no objective sets in this wave.
+- [ ] RED: Caretaker consumes Bond/rescue/protect/recovery signals.
+- [ ] RED: Pathfinder consumes Discovery/uncleared-region/action-limited exploration signals.
+- [ ] RED: Vanguard consumes Tactical challenge/streak/strong-opponent signals.
+- [ ] RED: Arcanist consumes Relic/Astral/Rift/status-combat signals.
+- [ ] Implement minimal typed definitions and signal adapter.
+
+### Task 2: Enforce single-objective action semantics
+
+**Files:**
+- Modify: `src/campaign-seasonal-objectives.test.ts`
+- Modify: `src/campaign-seasonal-objectives.ts`
+
+- [ ] RED: an action carrying multiple matching facts resolves to exactly one objective using stable definition priority.
+- [ ] RED: duplicate dispatch of the same action cannot fan out into another objective.
+- [ ] Implement deterministic first-match/single-result resolution; no aggregate multi-objective progress output.
+
+### Task 3: Reward-once and sanitation contracts
+
+**Files:**
+- Modify: `src/campaign-seasonal-objectives.test.ts`
+- Modify: `src/campaign-seasonal-objectives.ts`
+
+- [ ] RED: canonical claim keys are `year-season:campaign:objective` and use positive canonical years.
+- [ ] RED: claimed ledger blocks duplicate reward after reload/re-entry and duplicate action dispatch.
+- [ ] RED: week rollover does not reset season-scoped claims.
+- [ ] RED: malformed/unknown campaign IDs, objective IDs, noncanonical season keys, and malformed claim keys are rejected by hydration/sanitation helpers.
+- [ ] Implement pure claim-key validation/sanitation and reward-once resolver using caller-provided claimed keys.
+
+### Task 4: Legacy/True hook contract only
+
+**Files:**
+- Modify: `src/campaign-seasonal-objectives.test.ts`
+- Modify: `src/campaign-seasonal-objectives.ts`
+
+- [ ] RED: accepted objective completion emits a compact Legacy hook containing campaign, season key, objective, source domain, and optional True clue tag.
+- [ ] RED: duplicate/already-claimed completion emits no second reward/hook.
+- [ ] Ensure contract contains no True Campaign eligibility, path selection, state mutation, or story implementation.
+
+### Task 5: Regression and integration boundary
+
+- [ ] Run targeted Seasonal Objective tests.
+- [ ] Run existing Season/Weekly/Sanctuary/Astral/Celestial/Rift targeted suites.
+- [ ] Run full `npm run test`.
+- [ ] Run `npm run build` (TypeScript + Vite production build).
+- [ ] If persistent claim storage cannot be achieved without shared save/game changes, post a `[06 Integration Request]` on #58 with the exact minimal wiring contract.
+- [ ] Push candidate commits and create Draft PR against `integration/v3`.
+- [ ] Do not merge.

--- a/src/campaign-seasonal-objectives.test.ts
+++ b/src/campaign-seasonal-objectives.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  campaignSeasonalObjectiveSets,
+  campaignSeasonalObjectives,
+  isValidCampaignSeasonalObjectiveClaimKey,
+  resolveCampaignSeasonalObjective,
+  sanitizeCampaignId,
+  sanitizeCampaignSeasonalObjectiveClaimKeys,
+  sanitizeCampaignSeasonalObjectiveId,
+} from './campaign-seasonal-objectives';
+
+describe('campaign seasonal objectives', () => {
+  it('defines only Spring and Summer objective sets for all four main campaigns', () => {
+    expect(Object.keys(campaignSeasonalObjectiveSets).sort()).toEqual(['spring','summer']);
+    for (const season of ['spring','summer'] as const) {
+      expect(Object.keys(campaignSeasonalObjectiveSets[season]).sort()).toEqual([
+        'arcanist',
+        'caretaker',
+        'pathfinder',
+        'vanguard',
+      ]);
+      for (const campaign of ['caretaker','pathfinder','vanguard','arcanist'] as const) {
+        expect(campaignSeasonalObjectiveSets[season][campaign].length).toBeGreaterThanOrEqual(2);
+      }
+    }
+    expect(campaignSeasonalObjectives('autumn' as never,'caretaker')).toEqual([]);
+    expect(campaignSeasonalObjectives('winter' as never,'arcanist')).toEqual([]);
+  });
+
+  it.each([
+    ['caretaker','spring',['bond'],'spring_caretaker_bond'],
+    ['caretaker','summer',['rescue'],'summer_caretaker_rescue'],
+    ['caretaker','summer',['protect'],'summer_caretaker_rescue'],
+    ['caretaker','spring',['recovery'],'spring_caretaker_guardianship'],
+    ['pathfinder','spring',['discovery'],'spring_pathfinder_discovery'],
+    ['pathfinder','spring',['uncleared_region'],'spring_pathfinder_frontier'],
+    ['pathfinder','summer',['limited_exploration'],'summer_pathfinder_limited_route'],
+    ['vanguard','spring',['tactical_challenge'],'spring_vanguard_challenge'],
+    ['vanguard','spring',['strong_opponent'],'spring_vanguard_challenge'],
+    ['vanguard','summer',['win_streak'],'summer_vanguard_chain'],
+    ['arcanist','spring',['relic'],'spring_arcanist_relic'],
+    ['arcanist','spring',['status_combat'],'spring_arcanist_resonance'],
+    ['arcanist','summer',['astral'],'summer_arcanist_rift'],
+    ['arcanist','summer',['rift'],'summer_arcanist_rift'],
+  ] as const)('maps %s %s existing action signals to one objective', (campaign,season,signals,objectiveId) => {
+    const result = resolveCampaignSeasonalObjective({
+      year:1,
+      week:1,
+      season,
+      campaign,
+      signals:[...signals],
+      claimedKeys:[],
+    });
+    expect(result.accepted).toBe(true);
+    if (!result.accepted) return;
+    expect(result.objective.id).toBe(objectiveId);
+    expect(result.claimKey).toBe(`1-${season}:${campaign}:${objectiveId}`);
+  });
+
+  it('lets one action resolve at most one objective even when it carries several matching facts', () => {
+    const first = resolveCampaignSeasonalObjective({
+      year:1,
+      week:1,
+      season:'summer',
+      campaign:'caretaker',
+      signals:['rescue','protect','recovery','bond'],
+      claimedKeys:[],
+    });
+    expect(first.accepted).toBe(true);
+    if (!first.accepted) return;
+    expect(first.objective.id).toBe('summer_caretaker_rescue');
+
+    const duplicate = resolveCampaignSeasonalObjective({
+      year:1,
+      week:1,
+      season:'summer',
+      campaign:'caretaker',
+      signals:['rescue','protect','recovery','bond'],
+      claimedKeys:[first.claimKey],
+    });
+    expect(duplicate).toEqual(expect.objectContaining({ accepted:false, reason:'already_claimed' }));
+  });
+
+  it('keeps rewards claimed across reload and weekly rollover because claims are season scoped', () => {
+    const first = resolveCampaignSeasonalObjective({
+      year:2,
+      week:1,
+      season:'spring',
+      campaign:'pathfinder',
+      signals:['discovery'],
+      claimedKeys:[],
+    });
+    expect(first.accepted).toBe(true);
+    if (!first.accepted) return;
+
+    const hydratedClaims = sanitizeCampaignSeasonalObjectiveClaimKeys([
+      first.claimKey,
+      first.claimKey,
+      'bad',
+    ]);
+    const afterReload = resolveCampaignSeasonalObjective({
+      year:2,
+      week:1,
+      season:'spring',
+      campaign:'pathfinder',
+      signals:['discovery'],
+      claimedKeys:hydratedClaims,
+    });
+    const nextWeek = resolveCampaignSeasonalObjective({
+      year:2,
+      week:2,
+      season:'spring',
+      campaign:'pathfinder',
+      signals:['discovery'],
+      claimedKeys:hydratedClaims,
+    });
+
+    expect(hydratedClaims).toEqual([first.claimKey]);
+    expect(afterReload).toEqual(expect.objectContaining({ accepted:false, reason:'already_claimed' }));
+    expect(nextWeek).toEqual(expect.objectContaining({ accepted:false, reason:'already_claimed' }));
+  });
+
+  it('sanitizes malformed Campaign, Objective, and claim IDs without aliasing noncanonical values', () => {
+    expect(sanitizeCampaignId('caretaker')).toBe('caretaker');
+    expect(sanitizeCampaignId('Caretaker')).toBeNull();
+    expect(sanitizeCampaignId('true_path')).toBeNull();
+    expect(sanitizeCampaignId('retired_campaign')).toBeNull();
+
+    expect(sanitizeCampaignSeasonalObjectiveId('spring_caretaker_bond')).toBe('spring_caretaker_bond');
+    expect(sanitizeCampaignSeasonalObjectiveId('retired_objective')).toBeNull();
+
+    expect(isValidCampaignSeasonalObjectiveClaimKey('1-spring:caretaker:spring_caretaker_bond')).toBe(true);
+    expect(isValidCampaignSeasonalObjectiveClaimKey('01-spring:caretaker:spring_caretaker_bond')).toBe(false);
+    expect(isValidCampaignSeasonalObjectiveClaimKey('1-autumn:caretaker:spring_caretaker_bond')).toBe(false);
+    expect(isValidCampaignSeasonalObjectiveClaimKey('1-spring:true_path:spring_caretaker_bond')).toBe(false);
+    expect(isValidCampaignSeasonalObjectiveClaimKey('1-spring:caretaker:retired_objective')).toBe(false);
+  });
+
+  it('emits a Legacy-compatible campaign result hook without implementing True Campaign clues', () => {
+    const result = resolveCampaignSeasonalObjective({
+      year:1,
+      week:3,
+      season:'summer',
+      campaign:'arcanist',
+      signals:['rift','status_combat'],
+      claimedKeys:[],
+    });
+    expect(result.accepted).toBe(true);
+    if (!result.accepted) return;
+
+    expect(result.legacyHook).toEqual({
+      kind:'campaign_seasonal_objective',
+      campaignResult:{
+        campaignId:'arcanist',
+        seasonKey:'1-summer',
+        objectiveId:'summer_arcanist_rift',
+        sourceDomain:'rift',
+      },
+      trueClue:undefined,
+    });
+  });
+
+  it('does not mutate or require Sanctuary/Astral/Celestial/Rift state to interpret Arcanist signals', () => {
+    const astral = resolveCampaignSeasonalObjective({
+      year:1,
+      week:2,
+      season:'summer',
+      campaign:'arcanist',
+      signals:['astral'],
+      claimedKeys:[],
+    });
+    expect(astral.accepted).toBe(true);
+    if (!astral.accepted) return;
+    expect(astral.objective.id).toBe('summer_arcanist_rift');
+    expect(Object.keys(astral)).not.toContain('sanctuaryState');
+    expect(Object.keys(astral)).not.toContain('astralState');
+    expect(Object.keys(astral)).not.toContain('celestialState');
+    expect(Object.keys(astral)).not.toContain('riftState');
+  });
+});

--- a/src/campaign-seasonal-objectives.ts
+++ b/src/campaign-seasonal-objectives.ts
@@ -1,4 +1,5 @@
 import { mainCampaignIds, type MainCampaignId } from './campaign-model';
+import type { TrueClueId } from './legacy-state';
 import type { SeasonId } from './seasonal-cycle';
 
 export type CampaignSeasonalObjectiveSeason = 'spring'|'summer';
@@ -61,10 +62,7 @@ export type CampaignSeasonalLegacyHook = {
     objectiveId:CampaignSeasonalObjectiveId;
     sourceDomain:CampaignSeasonalSignalKind;
   };
-  trueClue:undefined|{
-    clueId:string;
-    domain:'season';
-  };
+  trueClue:TrueClueId|undefined;
 };
 
 const signalKinds = [

--- a/src/campaign-seasonal-objectives.ts
+++ b/src/campaign-seasonal-objectives.ts
@@ -1,0 +1,227 @@
+import { mainCampaignIds, type MainCampaignId } from './campaign-model';
+import type { SeasonId } from './seasonal-cycle';
+
+export type CampaignSeasonalObjectiveSeason = 'spring'|'summer';
+export type CampaignSeasonalSignalKind =
+  | 'bond'
+  | 'rescue'
+  | 'protect'
+  | 'recovery'
+  | 'discovery'
+  | 'uncleared_region'
+  | 'limited_exploration'
+  | 'tactical_challenge'
+  | 'win_streak'
+  | 'strong_opponent'
+  | 'relic'
+  | 'astral'
+  | 'rift'
+  | 'status_combat';
+
+export const campaignSeasonalObjectiveIds = [
+  'spring_caretaker_bond',
+  'spring_caretaker_guardianship',
+  'spring_pathfinder_discovery',
+  'spring_pathfinder_frontier',
+  'spring_vanguard_challenge',
+  'spring_vanguard_streak',
+  'spring_arcanist_relic',
+  'spring_arcanist_resonance',
+  'summer_caretaker_rescue',
+  'summer_caretaker_recovery',
+  'summer_pathfinder_uncharted',
+  'summer_pathfinder_limited_route',
+  'summer_vanguard_elite',
+  'summer_vanguard_chain',
+  'summer_arcanist_rift',
+  'summer_arcanist_rule_shift',
+] as const;
+
+export type CampaignSeasonalObjectiveId = typeof campaignSeasonalObjectiveIds[number];
+
+export type CampaignSeasonalObjectiveReward = {
+  kind:'campaign_memory';
+  memoryId:`${CampaignSeasonalObjectiveId}_memory`;
+};
+
+export type CampaignSeasonalObjectiveDefinition = {
+  id:CampaignSeasonalObjectiveId;
+  season:CampaignSeasonalObjectiveSeason;
+  campaign:MainCampaignId;
+  label:string;
+  signals:readonly CampaignSeasonalSignalKind[];
+  reward:CampaignSeasonalObjectiveReward;
+};
+
+export type CampaignSeasonalLegacyHook = {
+  kind:'campaign_seasonal_objective';
+  campaignResult:{
+    campaignId:MainCampaignId;
+    seasonKey:`${number}-${CampaignSeasonalObjectiveSeason}`;
+    objectiveId:CampaignSeasonalObjectiveId;
+    sourceDomain:CampaignSeasonalSignalKind;
+  };
+  trueClue:undefined|{
+    clueId:string;
+    domain:'season';
+  };
+};
+
+const signalKinds = [
+  'bond','rescue','protect','recovery',
+  'discovery','uncleared_region','limited_exploration',
+  'tactical_challenge','win_streak','strong_opponent',
+  'relic','astral','rift','status_combat',
+] as const satisfies readonly CampaignSeasonalSignalKind[];
+
+const mainCampaignIdSet = new Set<string>(mainCampaignIds);
+const objectiveIdSet = new Set<string>(campaignSeasonalObjectiveIds);
+const signalKindSet = new Set<string>(signalKinds);
+
+function objective(
+  id:CampaignSeasonalObjectiveId,
+  season:CampaignSeasonalObjectiveSeason,
+  campaign:MainCampaignId,
+  label:string,
+  signals:readonly CampaignSeasonalSignalKind[],
+):CampaignSeasonalObjectiveDefinition {
+  return { id, season, campaign, label, signals, reward:{ kind:'campaign_memory', memoryId:`${id}_memory` } };
+}
+
+export const campaignSeasonalObjectiveSets:Record<CampaignSeasonalObjectiveSeason,Record<MainCampaignId,readonly CampaignSeasonalObjectiveDefinition[]>> = {
+  spring:{
+    caretaker:[
+      objective('spring_caretaker_bond','spring','caretaker','마음을 지키는 약속',['bond']),
+      objective('spring_caretaker_guardianship','spring','caretaker','돌봄의 첫 선택',['rescue','protect','recovery']),
+    ],
+    pathfinder:[
+      objective('spring_pathfinder_discovery','spring','pathfinder','지도 밖의 발견',['discovery']),
+      objective('spring_pathfinder_frontier','spring','pathfinder','미답의 경계',['uncleared_region','limited_exploration']),
+    ],
+    vanguard:[
+      objective('spring_vanguard_challenge','spring','vanguard','강자에게 맞서기',['tactical_challenge','strong_opponent']),
+      objective('spring_vanguard_streak','spring','vanguard','흐름을 이어가기',['win_streak']),
+    ],
+    arcanist:[
+      objective('spring_arcanist_relic','spring','arcanist','유물의 첫 공명',['relic']),
+      objective('spring_arcanist_resonance','spring','arcanist','별빛 규칙 읽기',['astral','status_combat','rift']),
+    ],
+  },
+  summer:{
+    caretaker:[
+      objective('summer_caretaker_rescue','summer','caretaker','위기 속 보호',['rescue','protect']),
+      objective('summer_caretaker_recovery','summer','caretaker','다시 일어설 자리',['recovery','bond']),
+    ],
+    pathfinder:[
+      objective('summer_pathfinder_uncharted','summer','pathfinder','금지된 좌표',['discovery','uncleared_region']),
+      objective('summer_pathfinder_limited_route','summer','pathfinder','제한된 행동으로 길 찾기',['limited_exploration']),
+    ],
+    vanguard:[
+      objective('summer_vanguard_elite','summer','vanguard','강적 격파',['strong_opponent']),
+      objective('summer_vanguard_chain','summer','vanguard','연전의 압박',['win_streak','tactical_challenge']),
+    ],
+    arcanist:[
+      objective('summer_arcanist_rift','summer','arcanist','균열의 공명',['rift','astral']),
+      objective('summer_arcanist_rule_shift','summer','arcanist','바뀐 규칙을 이용하기',['status_combat','relic']),
+    ],
+  },
+};
+
+export function sanitizeCampaignId(value:unknown):MainCampaignId|null {
+  return typeof value === 'string' && mainCampaignIdSet.has(value) ? value as MainCampaignId : null;
+}
+
+export function sanitizeCampaignSeasonalObjectiveId(value:unknown):CampaignSeasonalObjectiveId|null {
+  return typeof value === 'string' && objectiveIdSet.has(value) ? value as CampaignSeasonalObjectiveId : null;
+}
+
+function sanitizeObjectiveSeason(value:unknown):CampaignSeasonalObjectiveSeason|null {
+  return value === 'spring' || value === 'summer' ? value : null;
+}
+
+function sanitizeSignals(raw:unknown):CampaignSeasonalSignalKind[] {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.filter((value):value is CampaignSeasonalSignalKind => typeof value === 'string' && signalKindSet.has(value)))];
+}
+
+function canonicalYear(value:unknown):number|null {
+  return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value) && value >= 1 ? value : null;
+}
+
+function validWeek(value:unknown):boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 4;
+}
+
+export function campaignSeasonalObjectives(season:SeasonId,campaign:MainCampaignId):readonly CampaignSeasonalObjectiveDefinition[] {
+  const objectiveSeason = sanitizeObjectiveSeason(season);
+  return objectiveSeason ? campaignSeasonalObjectiveSets[objectiveSeason][campaign] : [];
+}
+
+function definitionFor(
+  season:CampaignSeasonalObjectiveSeason,
+  campaign:MainCampaignId,
+  objectiveId:CampaignSeasonalObjectiveId,
+):CampaignSeasonalObjectiveDefinition|null {
+  return campaignSeasonalObjectiveSets[season][campaign].find(objective => objective.id === objectiveId) ?? null;
+}
+
+export function isValidCampaignSeasonalObjectiveClaimKey(value:string):boolean {
+  const match = /^([1-9]\d*)-(spring|summer):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
+  if (!match) return false;
+  const season = match[2] as CampaignSeasonalObjectiveSeason;
+  const campaign = sanitizeCampaignId(match[3]);
+  const objectiveId = sanitizeCampaignSeasonalObjectiveId(match[4]);
+  return Boolean(campaign && objectiveId && definitionFor(season,campaign,objectiveId));
+}
+
+export function sanitizeCampaignSeasonalObjectiveClaimKeys(raw:unknown):string[] {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.filter((value):value is string => typeof value === 'string' && isValidCampaignSeasonalObjectiveClaimKey(value)))];
+}
+
+export function resolveCampaignSeasonalObjective(input:{
+  year:unknown;
+  week:unknown;
+  season:unknown;
+  campaign:unknown;
+  signals:unknown;
+  claimedKeys:unknown;
+}) {
+  const year = canonicalYear(input.year);
+  const season = sanitizeObjectiveSeason(input.season);
+  const campaign = sanitizeCampaignId(input.campaign);
+  if (!year || !season || !campaign || !validWeek(input.week)) {
+    return { accepted:false as const, reason:'invalid_context' as const };
+  }
+
+  const signals = sanitizeSignals(input.signals);
+  const objective = campaignSeasonalObjectiveSets[season][campaign]
+    .find(candidate => candidate.signals.some(signal => signals.includes(signal)));
+  if (!objective) return { accepted:false as const, reason:'no_match' as const };
+
+  const claimKey = `${year}-${season}:${campaign}:${objective.id}` as const;
+  const claimedKeys = sanitizeCampaignSeasonalObjectiveClaimKeys(input.claimedKeys);
+  if (claimedKeys.includes(claimKey)) {
+    return { accepted:false as const, reason:'already_claimed' as const, objective, claimKey };
+  }
+
+  const sourceDomain = signals.find(signal => objective.signals.includes(signal))!;
+  const legacyHook:CampaignSeasonalLegacyHook = {
+    kind:'campaign_seasonal_objective',
+    campaignResult:{
+      campaignId:campaign,
+      seasonKey:`${year}-${season}`,
+      objectiveId:objective.id,
+      sourceDomain,
+    },
+    trueClue:undefined,
+  };
+
+  return {
+    accepted:true as const,
+    objective,
+    claimKey,
+    reward:objective.reward,
+    legacyHook,
+  };
+}


### PR DESCRIPTION
Parent: #58

Draft candidate for V3 Spring Campaign-aware Seasonal Objectives.

Baseline: `integration/v3@46faf9031a86ff09d92cc17ee043e9180414d510`
Head: `work/v3-spring-season@850913ba4f9f250444ba15fde0b34487b640d863`

Implemented:
- Spring/Summer objective sets for Caretaker / Pathfinder / Vanguard / Arcanist
- pure existing-action signal adapter; no new daily/weekly chore system
- deterministic one-action → at-most-one-objective semantics
- season-scoped canonical claim keys and reward-once resolver
- reload / week rollover / duplicate action / hydration duplicate defenses
- malformed Campaign / Objective / claim ID sanitation
- Legacy hook contract using existing `TrueClueId` registry; no True Campaign mainline
- Sanctuary / Astral / Celestial / Rift preserved as read-only signal sources

Verification on PR merge ref:
- RED first: existing 1209 tests passed; only new suite failed because adapter module did not yet exist
- final: `339/339` test files GREEN, `1229/1229` tests GREEN
- `npm run build` GREEN (`tsc -b && vite build`)

Changed files only:
- `src/campaign-seasonal-objectives.ts`
- `src/campaign-seasonal-objectives.test.ts`
- `docs/superpowers/plans/2026-08-22-v3-spring-seasonal-objectives.md`

No shared save/game/App/Root changes.

[06 Integration Request] for the minimal persistent `claimedSeasonalObjectives` wiring was posted on #58. Do not reuse weekly/campaign-milestone ledgers because their semantics/reset scopes differ.

Keep Draft. Do not merge; 06 integrates sequentially.