### PR TITLE
feat(v3): add Spring Tactical scenario contracts

### DIFF
--- a/src/tactical-bond-intervention.test.ts
+++ b/src/tactical-bond-intervention.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  campaignEncounterToTacticalScenario,
+  invokeTacticalBondIntervention,
+  type CampaignEncounterDefinition,
+  type TacticalBondInterventionCharacterId,
+  type TacticalBondInterventionHook,
+} from './tactical-scenario';
+
+function scenario(){
+  const encounter:CampaignEncounterDefinition={
+    id:'spring-bond-hook',
+    campaign:'arcanist',
+    stageId:'forest-1',
+    objective:{type:'standard'},
+    modifiers:[],
+    failForward:true,
+  };
+  return campaignEncounterToTacticalScenario(encounter);
+}
+
+describe('V3 Tactical Bond Intervention I/O hook',()=>{
+  it('supports Mira, Kael, Rex and Selene as plain Tactical intervention inputs',()=>{
+    const supported:TacticalBondInterventionCharacterId[]=['mira','kael','rex','selene'];
+    for(const characterId of supported){
+      const hook:TacticalBondInterventionHook=request=>({accepted:true,interventionId:`${request.characterId}-spring`});
+      expect(invokeTacticalBondIntervention(scenario(),characterId,'before-battle',hook)).toEqual({
+        accepted:true,
+        interventionId:`${characterId}-spring`,
+      });
+    }
+  });
+
+  it('passes only scenario identity and intervention context, never CharacterBondState',()=>{
+    const sourceScenario=scenario();
+    const before=structuredClone(sourceScenario);
+    const hook=vi.fn<TacticalBondInterventionHook>(request=>{
+      expect(Object.keys(request).sort()).toEqual(['campaign','characterId','scenarioId','timing']);
+      expect(request).toEqual({
+        scenarioId:'spring-bond-hook',
+        campaign:'arcanist',
+        characterId:'selene',
+        timing:'objective-check',
+      });
+      expect(request).not.toHaveProperty('bondState');
+      expect(request).not.toHaveProperty('characterBondState');
+      return {accepted:false,interventionId:'selene-declined'};
+    });
+
+    expect(invokeTacticalBondIntervention(sourceScenario,'selene','objective-check',hook)).toEqual({
+      accepted:false,
+      interventionId:'selene-declined',
+    });
+    expect(hook).toHaveBeenCalledOnce();
+    expect(sourceScenario).toEqual(before);
+  });
+
+  it('rejects unsupported runtime character ids before calling the hook',()=>{
+    const hook=vi.fn<TacticalBondInterventionHook>(()=>({accepted:true,interventionId:'should-not-run'}));
+    expect(()=>invokeTacticalBondIntervention(scenario(),'noa' as TacticalBondInterventionCharacterId,'terminal',hook)).toThrow('Bond Intervention character');
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('copies hook output so Tactical does not retain external mutable response state',()=>{
+    const response={accepted:true,interventionId:'mira-guard'};
+    const hook:TacticalBondInterventionHook=()=>response;
+    const output=invokeTacticalBondIntervention(scenario(),'mira','terminal',hook)!;
+    expect(output).toEqual(response);
+    expect(output).not.toBe(response);
+    response.interventionId='mutated-outside';
+    expect(output.interventionId).toBe('mira-guard');
+  });
+
+  it('rejects malformed hook output instead of forwarding it into combat integration',()=>{
+    const malformed=(()=>({accepted:true,interventionId:'   '})) as TacticalBondInterventionHook;
+    expect(()=>invokeTacticalBondIntervention(scenario(),'rex','before-battle',malformed)).toThrow('Bond Intervention response');
+  });
+});

--- a/src/tactical-scenario-engine.test.ts
+++ b/src/tactical-scenario-engine.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createTacticalExpeditionBattle } from './tactical-expedition';
+import {
+  campaignEncounterToTacticalScenario,
+  createTacticalScenarioBattle,
+  type CampaignEncounterDefinition,
+} from './tactical-scenario';
+
+const progression={power:42,magic:32,agility:13,maxHp:150};
+const party=['wolf','owl'] as const;
+
+function encounter():CampaignEncounterDefinition {
+  return {
+    id:'spring-pathfinder-engine',
+    campaign:'pathfinder',
+    stageId:'forest-1',
+    objective:{type:'escape',afterRounds:2},
+    modifiers:[
+      {campaign:'pathfinder',kind:'scout',revealCount:2},
+      {campaign:'pathfinder',kind:'turn-limit',maxRounds:6},
+    ],
+    failForward:true,
+  };
+}
+
+describe('V3 Tactical scenario engine adapter',()=>{
+  it('delegates battle creation to the existing Tactical expedition engine',()=>{
+    const scenario=campaignEncounterToTacticalScenario(encounter());
+    const viaScenario=createTacticalScenarioBattle(scenario,party,progression,73);
+    const direct=createTacticalExpeditionBattle('forest-1',party,progression,73);
+
+    expect(viaScenario).toEqual(direct);
+    expect(viaScenario).not.toBe(direct);
+    expect(viaScenario.units).not.toBe(direct.units);
+  });
+
+  it('remains deterministic for the same scenario, party, progression and seed',()=>{
+    const scenario=campaignEncounterToTacticalScenario(encounter());
+    expect(createTacticalScenarioBattle(scenario,party,progression,91)).toEqual(
+      createTacticalScenarioBattle(scenario,party,progression,91),
+    );
+  });
+});

--- a/src/tactical-scenario-result.test.ts
+++ b/src/tactical-scenario-result.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { createBattleSession, type BattleSession, type TacticalUnit } from './tactical-battle';
+import {
+  campaignEncounterToTacticalScenario,
+  resolveTacticalScenarioResult,
+  type CampaignEncounterDefinition,
+} from './tactical-scenario';
+
+const unit=(id:string,side:'ally'|'enemy',hp=100,maxHp=100):TacticalUnit=>({
+  id,side,position:'front',maxHp,hp,agility:10,ap:3,maxAp:3,mp:0,maxMp:10,shield:0,
+});
+
+function baseSession():BattleSession {
+  return createBattleSession(
+    [unit('runa','ally'),unit('companion-wolf','ally'),unit('companion-owl','ally')],
+    [unit('target','enemy'),unit('enemy-2','enemy'),unit('enemy-3','enemy')],
+    17,
+  );
+}
+
+function scenario(failForward:boolean):ReturnType<typeof campaignEncounterToTacticalScenario> {
+  const encounter:CampaignEncounterDefinition={
+    id:'spring-caretaker-result',
+    campaign:'caretaker',
+    stageId:'forest-1',
+    objective:{type:'protect',unitId:'runa'},
+    modifiers:[],
+    failForward,
+  };
+  return campaignEncounterToTacticalScenario(encounter);
+}
+
+describe('V3 Tactical fail-forward result contract',()=>{
+  it('returns no result while the scenario is still active',()=>{
+    expect(resolveTacticalScenarioResult(scenario(true),baseSession(),'attempt-1')).toBeNull();
+  });
+
+  it('returns combat facts only when a fail-forward scenario reaches terminal failure',()=>{
+    const session=baseSession();
+    session.units=session.units.map(entry=>entry.id==='runa'?{...entry,hp:0}:entry);
+    const result=resolveTacticalScenarioResult(scenario(true),session,'attempt-1');
+
+    expect(result).toEqual({
+      scenarioId:'spring-caretaker-result',
+      campaign:'caretaker',
+      attemptKey:'attempt-1',
+      terminalKey:'spring-caretaker-result:attempt-1',
+      objectiveResult:'failure',
+      battleResult:null,
+      failForward:true,
+      rounds:0,
+      survivingAllies:2,
+      damageTaken:100,
+    });
+    expect(result).not.toHaveProperty('story');
+    expect(result).not.toHaveProperty('campaignState');
+    expect(result).not.toHaveProperty('bondState');
+    expect(result).not.toHaveProperty('characterBondState');
+  });
+
+  it('reports a normal engine victory without mutating the source scenario or session',()=>{
+    const sourceScenario=scenario(false);
+    const session=baseSession();
+    const won={...session,round:4,units:session.units.map(entry=>entry.side==='enemy'?{...entry,hp:0}:entry)};
+    const scenarioBefore=structuredClone(sourceScenario);
+    const sessionBefore=structuredClone(won);
+
+    const result=resolveTacticalScenarioResult(sourceScenario,won,'attempt-2');
+
+    expect(result?.objectiveResult).toBe('success');
+    expect(result?.battleResult).toBe('victory');
+    expect(result?.rounds).toBe(3);
+    expect(result?.survivingAllies).toBe(3);
+    expect(sourceScenario).toEqual(scenarioBefore);
+    expect(won).toEqual(sessionBefore);
+  });
+
+  it('is deterministic for the same terminal input and attempt key',()=>{
+    const session=baseSession();
+    session.units=session.units.map(entry=>entry.id==='runa'?{...entry,hp:0}:entry);
+    expect(resolveTacticalScenarioResult(scenario(true),session,'attempt-9')).toEqual(
+      resolveTacticalScenarioResult(scenario(true),session,'attempt-9'),
+    );
+  });
+
+  it('rejects a blank attempt key so terminal handoff identity cannot collide',()=>{
+    const session=baseSession();
+    session.units=session.units.map(entry=>entry.id==='runa'?{...entry,hp:0}:entry);
+    expect(()=>resolveTacticalScenarioResult(scenario(true),session,'   ')).toThrow('attempt key');
+  });
+
+  it('sanitizes corrupted runtime metrics instead of emitting NaN or Infinity',()=>{
+    const session=baseSession();
+    session.round=Number.POSITIVE_INFINITY;
+    session.units=session.units.map(entry=>entry.id==='runa'
+      ? {...entry,hp:0,maxHp:Number.POSITIVE_INFINITY}
+      : entry.id==='companion-wolf'
+        ? {...entry,hp:Number.NaN,maxHp:Number.NaN}
+        : entry);
+    const result=resolveTacticalScenarioResult(scenario(true),session,'attempt-corrupt');
+    expect(result).not.toBeNull();
+    for(const value of [result!.rounds,result!.survivingAllies,result!.damageTaken]) expect(Number.isFinite(value)).toBe(true);
+  });
+});

--- a/src/tactical-scenario-sanitization.test.ts
+++ b/src/tactical-scenario-sanitization.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { campaignEncounterToTacticalScenario, type CampaignEncounterDefinition } from './tactical-scenario';
+
+const valid=():CampaignEncounterDefinition=>({
+  id:'spring-valid',
+  campaign:'caretaker',
+  stageId:'forest-1',
+  objective:{type:'protect',unitId:'runa'},
+  modifiers:[],
+  failForward:true,
+});
+
+describe('V3 Tactical scenario adapter runtime boundaries',()=>{
+  it('owns a copy of the objective so campaign input mutation cannot alter a compiled scenario',()=>{
+    const encounter=valid();
+    const scenario=campaignEncounterToTacticalScenario(encounter);
+    expect(scenario.objective).toEqual(encounter.objective);
+    expect(scenario.objective).not.toBe(encounter.objective);
+    (encounter.objective as {type:'protect';unitId:string}).unitId='mutated-outside';
+    expect(scenario.objective).toEqual({type:'protect',unitId:'runa'});
+  });
+
+  it('rejects blank scenario identity or stage routing before battle compilation',()=>{
+    for(const encounter of [
+      {...valid(),id:'   '},
+      {...valid(),stageId:''},
+    ]) {
+      expect(()=>campaignEncounterToTacticalScenario(encounter)).toThrow('invalid Tactical scenario definition');
+    }
+  });
+
+  it('rejects unsupported runtime campaign and non-boolean fail-forward configuration',()=>{
+    const badCampaign={...valid(),campaign:'summer'} as unknown as CampaignEncounterDefinition;
+    const badFailForward={...valid(),failForward:'yes'} as unknown as CampaignEncounterDefinition;
+    expect(()=>campaignEncounterToTacticalScenario(badCampaign)).toThrow('invalid Tactical scenario definition');
+    expect(()=>campaignEncounterToTacticalScenario(badFailForward)).toThrow('invalid Tactical scenario definition');
+  });
+
+  it('rejects malformed protect and target-elimination identifiers',()=>{
+    for(const objective of [
+      {type:'protect',unitId:' '},
+      {type:'target-elimination',targetId:''},
+    ]) {
+      const corrupted={...valid(),objective} as unknown as CampaignEncounterDefinition;
+      expect(()=>campaignEncounterToTacticalScenario(corrupted)).toThrow('invalid Tactical scenario objective');
+    }
+  });
+
+  it('rejects non-finite, fractional or out-of-range survive and escape boundaries',()=>{
+    const objectives=[
+      {type:'survive',rounds:Number.NaN},
+      {type:'survive',rounds:Number.POSITIVE_INFINITY},
+      {type:'survive',rounds:0},
+      {type:'survive',rounds:1.5},
+      {type:'escape',afterRounds:Number.NaN},
+      {type:'escape',afterRounds:Number.POSITIVE_INFINITY},
+      {type:'escape',afterRounds:-1},
+      {type:'escape',afterRounds:1.5},
+    ];
+    for(const objective of objectives) {
+      const corrupted={...valid(),objective} as unknown as CampaignEncounterDefinition;
+      expect(()=>campaignEncounterToTacticalScenario(corrupted)).toThrow('invalid Tactical scenario objective');
+    }
+  });
+
+  it('rejects unknown runtime objective kinds instead of treating them as target elimination',()=>{
+    const corrupted={...valid(),objective:{type:'boss-phase',targetId:'target'}} as unknown as CampaignEncounterDefinition;
+    expect(()=>campaignEncounterToTacticalScenario(corrupted)).toThrow('invalid Tactical scenario objective');
+  });
+});

--- a/src/tactical-scenario.test.ts
+++ b/src/tactical-scenario.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { tacticalBattleNodeForStage } from './tactical-expedition';
+import { campaignEncounterToTacticalScenario, type CampaignEncounterDefinition } from './tactical-scenario';
+
+describe('V3 Tactical scenario adapter', () => {
+  it('compiles a campaign encounter onto the existing Tactical battle node contract', () => {
+    const encounter:CampaignEncounterDefinition = {
+      id:'spring-caretaker-standard',
+      campaign:'caretaker',
+      stageId:'forest-1',
+      objective:{type:'standard'},
+      modifiers:[],
+      failForward:false,
+    };
+
+    const scenario = campaignEncounterToTacticalScenario(encounter);
+
+    expect(scenario).toEqual({
+      id:'spring-caretaker-standard',
+      campaign:'caretaker',
+      stageId:'forest-1',
+      battleNode:tacticalBattleNodeForStage('forest-1'),
+      objective:{type:'standard'},
+      modifiers:[],
+      failForward:false,
+    });
+  });
+});

--- a/src/tactical-scenario.test.ts
+++ b/src/tactical-scenario.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, it } from 'vitest';
+import { createBattleSession, type BattleSession, type TacticalUnit } from './tactical-battle';
 import { tacticalBattleNodeForStage } from './tactical-expedition';
-import { campaignEncounterToTacticalScenario, type CampaignEncounterDefinition } from './tactical-scenario';
+import {
+  campaignEncounterToTacticalScenario,
+  evaluateTacticalScenarioObjective,
+  type CampaignEncounterDefinition,
+  type TacticalScenarioObjective,
+} from './tactical-scenario';
+
+const unit=(id:string,side:'ally'|'enemy',hp=100):TacticalUnit=>({
+  id,side,position:'front',maxHp:100,hp,agility:10,ap:3,maxAp:3,mp:0,maxMp:10,shield:0,
+});
+
+function session():BattleSession {
+  return createBattleSession(
+    [unit('runa','ally'),unit('escort','ally'),unit('ally-3','ally')],
+    [unit('target','enemy'),unit('enemy-2','enemy'),unit('enemy-3','enemy')],
+    41,
+  );
+}
+
+function scenarioFor(objective:TacticalScenarioObjective) {
+  return campaignEncounterToTacticalScenario({
+    id:`scenario-${objective.type}`,
+    campaign:'caretaker',
+    stageId:'forest-1',
+    objective,
+    modifiers:[],
+    failForward:false,
+  });
+}
 
 describe('V3 Tactical scenario adapter', () => {
   it('compiles a campaign encounter onto the existing Tactical battle node contract', () => {
@@ -24,5 +53,48 @@ describe('V3 Tactical scenario adapter', () => {
       modifiers:[],
       failForward:false,
     });
+  });
+
+  it('evaluates standard victory without replacing the existing battle result', () => {
+    const active=session();
+    expect(evaluateTacticalScenarioObjective(scenarioFor({type:'standard'}),active)).toBeNull();
+    const won={...active,units:active.units.map(entry=>entry.side==='enemy'?{...entry,hp:0}:entry)};
+    expect(evaluateTacticalScenarioObjective(scenarioFor({type:'standard'}),won)).toBe('success');
+  });
+
+  it('fails protect immediately when the protected ally is down and succeeds only after victory with it alive', () => {
+    const active=session();
+    const protect=scenarioFor({type:'protect',unitId:'escort'});
+    const failed={...active,units:active.units.map(entry=>entry.id==='escort'?{...entry,hp:0}:entry)};
+    expect(evaluateTacticalScenarioObjective(protect,failed)).toBe('failure');
+    const won={...active,units:active.units.map(entry=>entry.side==='enemy'?{...entry,hp:0}:entry)};
+    expect(evaluateTacticalScenarioObjective(protect,won)).toBe('success');
+  });
+
+  it('uses completed rounds for survive so round one is not counted as already survived', () => {
+    const survive=scenarioFor({type:'survive',rounds:3});
+    expect(evaluateTacticalScenarioObjective(survive,{...session(),round:3})).toBeNull();
+    expect(evaluateTacticalScenarioObjective(survive,{...session(),round:4})).toBe('success');
+    const lost=session();
+    lost.units=lost.units.map(entry=>entry.side==='ally'?{...entry,hp:0}:entry);
+    expect(evaluateTacticalScenarioObjective(survive,{...lost,round:3})).toBe('failure');
+  });
+
+  it('opens escape only after the required completed rounds and fails if the party is wiped first', () => {
+    const escape=scenarioFor({type:'escape',afterRounds:2});
+    expect(evaluateTacticalScenarioObjective(escape,{...session(),round:2})).toBeNull();
+    expect(evaluateTacticalScenarioObjective(escape,{...session(),round:3})).toBe('success');
+    const lost=session();
+    lost.units=lost.units.map(entry=>entry.side==='ally'?{...entry,hp:0}:entry);
+    expect(evaluateTacticalScenarioObjective(escape,{...lost,round:2})).toBe('failure');
+  });
+
+  it('ends target-elimination when the named target dies even if other enemies remain', () => {
+    const targetScenario=scenarioFor({type:'target-elimination',targetId:'target'});
+    const active=session();
+    expect(evaluateTacticalScenarioObjective(targetScenario,active)).toBeNull();
+    const eliminated={...active,units:active.units.map(entry=>entry.id==='target'?{...entry,hp:0}:entry)};
+    expect(evaluateTacticalScenarioObjective(targetScenario,eliminated)).toBe('success');
+    expect(eliminated.units.some(entry=>entry.side==='enemy'&&entry.hp>0)).toBe(true);
   });
 });

--- a/src/tactical-scenario.test.ts
+++ b/src/tactical-scenario.test.ts
@@ -5,6 +5,7 @@ import {
   campaignEncounterToTacticalScenario,
   evaluateTacticalScenarioObjective,
   type CampaignEncounterDefinition,
+  type TacticalScenarioModifier,
   type TacticalScenarioObjective,
 } from './tactical-scenario';
 
@@ -30,6 +31,28 @@ function scenarioFor(objective:TacticalScenarioObjective) {
     failForward:false,
   });
 }
+
+const modifierSamples:Record<'caretaker'|'pathfinder'|'vanguard'|'arcanist',TacticalScenarioModifier[]> = {
+  caretaker:[
+    {campaign:'caretaker',kind:'protect',unitId:'escort'},
+    {campaign:'caretaker',kind:'survive',rounds:3},
+    {campaign:'caretaker',kind:'rescue',unitId:'civilian'},
+  ],
+  pathfinder:[
+    {campaign:'pathfinder',kind:'scout',revealCount:2},
+    {campaign:'pathfinder',kind:'turn-limit',maxRounds:6},
+    {campaign:'pathfinder',kind:'escape',afterRounds:2},
+  ],
+  vanguard:[
+    {campaign:'vanguard',kind:'elite',levelBonus:2},
+    {campaign:'vanguard',kind:'chained-battle',chainId:'spring-chain',index:1,total:3},
+  ],
+  arcanist:[
+    {campaign:'arcanist',kind:'status-amplify',statusId:'break',multiplier:1.5},
+    {campaign:'arcanist',kind:'relic-resonance',relicId:'spring-relic'},
+    {campaign:'arcanist',kind:'rule-shift',ruleId:'unstable-mana'},
+  ],
+};
 
 describe('V3 Tactical scenario adapter', () => {
   it('compiles a campaign encounter onto the existing Tactical battle node contract', () => {
@@ -96,5 +119,33 @@ describe('V3 Tactical scenario adapter', () => {
     const eliminated={...active,units:active.units.map(entry=>entry.id==='target'?{...entry,hp:0}:entry)};
     expect(evaluateTacticalScenarioObjective(targetScenario,eliminated)).toBe('success');
     expect(eliminated.units.some(entry=>entry.side==='enemy'&&entry.hp>0)).toBe(true);
+  });
+
+  it('carries the Spring modifier vocabulary for all four campaigns without sharing the source array', () => {
+    for(const campaign of ['caretaker','pathfinder','vanguard','arcanist'] as const) {
+      const modifiers=modifierSamples[campaign];
+      const scenario=campaignEncounterToTacticalScenario({
+        id:`spring-${campaign}-contract`,campaign,stageId:'forest-1',objective:{type:'standard'},modifiers,failForward:false,
+      });
+      expect(scenario.modifiers).toEqual(modifiers);
+      expect(scenario.modifiers).not.toBe(modifiers);
+      expect(scenario.modifiers.every(modifier=>modifier.campaign===campaign)).toBe(true);
+    }
+  });
+
+  it('rejects a modifier from a different campaign at the adapter boundary', () => {
+    const corrupted={
+      id:'spring-caretaker-mismatch',campaign:'caretaker',stageId:'forest-1',objective:{type:'standard'},
+      modifiers:[{campaign:'pathfinder',kind:'turn-limit',maxRounds:4}],failForward:false,
+    } as unknown as CampaignEncounterDefinition;
+    expect(()=>campaignEncounterToTacticalScenario(corrupted)).toThrow('campaign modifier mismatch');
+  });
+
+  it('rejects non-finite numeric modifier configuration before it reaches the Tactical engine', () => {
+    const corrupted={
+      id:'spring-pathfinder-invalid',campaign:'pathfinder',stageId:'forest-1',objective:{type:'standard'},
+      modifiers:[{campaign:'pathfinder',kind:'turn-limit',maxRounds:Number.POSITIVE_INFINITY}],failForward:false,
+    } as unknown as CampaignEncounterDefinition;
+    expect(()=>campaignEncounterToTacticalScenario(corrupted)).toThrow('invalid Tactical scenario modifier');
   });
 });

--- a/src/tactical-scenario.ts
+++ b/src/tactical-scenario.ts
@@ -1,6 +1,7 @@
 import type { MainCampaignId } from './campaign-model';
 import { isBattleFinished, type BattleSession, type TacticalStatusId } from './tactical-battle';
-import { tacticalBattleNodeForStage, type TacticalBattleNode } from './tactical-expedition';
+import type { CompanionId, LeaderCombatProgression } from './tactical-companions';
+import { createTacticalExpeditionBattle, tacticalBattleNodeForStage, type TacticalBattleNode } from './tactical-expedition';
 
 export type TacticalScenarioObjective =
   | { type:'standard' }
@@ -87,6 +88,15 @@ export function campaignEncounterToTacticalScenario(encounter:CampaignEncounterD
     modifiers:encounter.modifiers.map(modifier=>({...modifier})),
     failForward:encounter.failForward,
   };
+}
+
+export function createTacticalScenarioBattle(
+  scenario:TacticalScenario,
+  selected:readonly CompanionId[],
+  progression:LeaderCombatProgression,
+  seed:number,
+):BattleSession {
+  return createTacticalExpeditionBattle(scenario.stageId,selected,progression,seed);
 }
 
 function living(session:BattleSession,id:string) {

--- a/src/tactical-scenario.ts
+++ b/src/tactical-scenario.ts
@@ -209,14 +209,17 @@ export function handoffTacticalTerminalResult(
 ):TacticalTerminalHandoff {
   const normalizedState=normalizeHandoffState(state);
   if(result===null) return {state:normalizedState,result:null};
-  const terminalKey=typeof result.terminalKey==='string'?result.terminalKey.trim():'';
-  if(!terminalKey) throw new Error('Tactical terminal key is required');
+  const suppliedTerminalKey=typeof result.terminalKey==='string'?result.terminalKey.trim():'';
+  const scenarioId=typeof result.scenarioId==='string'?result.scenarioId.trim():'';
+  const attemptKey=typeof result.attemptKey==='string'?result.attemptKey.trim():'';
+  if(!suppliedTerminalKey||!scenarioId||!attemptKey) throw new Error('Tactical terminal key is required');
+  const terminalKey=`${scenarioId}:${attemptKey}`;
   if(normalizedState.handedOffKeys.includes(terminalKey)) {
     return {state:normalizedState,result:null};
   }
   return {
     state:{handedOffKeys:[...normalizedState.handedOffKeys,terminalKey]},
-    result:{...result,terminalKey},
+    result:{...result,scenarioId,attemptKey,terminalKey},
   };
 }
 

--- a/src/tactical-scenario.ts
+++ b/src/tactical-scenario.ts
@@ -1,4 +1,4 @@
-import type { MainCampaignId } from './campaign-model';
+import type { CharacterId, MainCampaignId } from './campaign-model';
 import { isBattleFinished, type BattleResult, type BattleSession, type TacticalStatusId } from './tactical-battle';
 import type { CompanionId, LeaderCombatProgression } from './tactical-companions';
 import { createTacticalExpeditionBattle, tacticalBattleNodeForStage, type TacticalBattleNode } from './tactical-expedition';
@@ -57,7 +57,25 @@ export type TacticalScenarioResult = {
   damageTaken:number;
 };
 
+export type TacticalBondInterventionCharacterId = Extract<CharacterId,'mira'|'kael'|'rex'|'selene'>;
+export type TacticalBondInterventionTiming = 'before-battle'|'objective-check'|'terminal';
+export type TacticalBondInterventionRequest = Readonly<{
+  scenarioId:string;
+  campaign:MainCampaignId;
+  characterId:TacticalBondInterventionCharacterId;
+  timing:TacticalBondInterventionTiming;
+}>;
+export type TacticalBondInterventionResponse = Readonly<{
+  accepted:boolean;
+  interventionId:string;
+}>;
+export type TacticalBondInterventionHook = (
+  request:TacticalBondInterventionRequest,
+)=>TacticalBondInterventionResponse|null;
+
 const statusIds:readonly TacticalStatusId[]=['guard','focus','break','regen'];
+const interventionCharacterIds:readonly TacticalBondInterventionCharacterId[]=['mira','kael','rex','selene'];
+const interventionTimings:readonly TacticalBondInterventionTiming[]=['before-battle','objective-check','terminal'];
 const nonEmpty=(value:string)=>typeof value==='string'&&value.trim().length>0;
 const positiveInteger=(value:number)=>Number.isFinite(value)&&Number.isInteger(value)&&value>=1;
 const nonNegativeInteger=(value:number)=>Number.isFinite(value)&&Number.isInteger(value)&&value>=0;
@@ -111,6 +129,32 @@ export function createTacticalScenarioBattle(
   seed:number,
 ):BattleSession {
   return createTacticalExpeditionBattle(scenario.stageId,selected,progression,seed);
+}
+
+export function invokeTacticalBondIntervention(
+  scenario:TacticalScenario,
+  characterId:TacticalBondInterventionCharacterId,
+  timing:TacticalBondInterventionTiming,
+  hook:TacticalBondInterventionHook,
+):TacticalBondInterventionResponse|null {
+  if(!interventionCharacterIds.includes(characterId)) {
+    throw new Error('Unsupported Tactical Bond Intervention character');
+  }
+  if(!interventionTimings.includes(timing)) {
+    throw new Error('Invalid Tactical Bond Intervention timing');
+  }
+  const request:TacticalBondInterventionRequest={
+    scenarioId:scenario.id,
+    campaign:scenario.campaign,
+    characterId,
+    timing,
+  };
+  const response=hook(request);
+  if(response===null) return null;
+  if(!response||typeof response.accepted!=='boolean'||!nonEmpty(response.interventionId)) {
+    throw new Error('Invalid Tactical Bond Intervention response');
+  }
+  return {accepted:response.accepted,interventionId:response.interventionId.trim()};
 }
 
 function living(session:BattleSession,id:string) {

--- a/src/tactical-scenario.ts
+++ b/src/tactical-scenario.ts
@@ -73,6 +73,15 @@ export type TacticalBondInterventionHook = (
   request:TacticalBondInterventionRequest,
 )=>TacticalBondInterventionResponse|null;
 
+export type TacticalTerminalHandoffState = Readonly<{
+  handedOffKeys:readonly string[];
+}>;
+
+export type TacticalTerminalHandoff = Readonly<{
+  state:TacticalTerminalHandoffState;
+  result:TacticalScenarioResult|null;
+}>;
+
 const statusIds:readonly TacticalStatusId[]=['guard','focus','break','regen'];
 const interventionCharacterIds:readonly TacticalBondInterventionCharacterId[]=['mira','kael','rex','selene'];
 const interventionTimings:readonly TacticalBondInterventionTiming[]=['before-battle','objective-check','terminal'];
@@ -155,6 +164,41 @@ export function invokeTacticalBondIntervention(
     throw new Error('Invalid Tactical Bond Intervention response');
   }
   return {accepted:response.accepted,interventionId:response.interventionId.trim()};
+}
+
+export function createTacticalTerminalHandoffState():TacticalTerminalHandoffState {
+  return {handedOffKeys:[]};
+}
+
+function normalizeHandoffState(state:TacticalTerminalHandoffState):TacticalTerminalHandoffState {
+  const source=Array.isArray(state?.handedOffKeys)?state.handedOffKeys:[];
+  const keys:string[]=[];
+  for(const value of source) {
+    if(typeof value!=='string') continue;
+    const key=value.trim();
+    if(key&&!keys.includes(key)) keys.push(key);
+  }
+  const canonical=Array.isArray(state?.handedOffKeys)
+    && state.handedOffKeys.length===keys.length
+    && state.handedOffKeys.every((value,index)=>value===keys[index]);
+  return canonical?state:{handedOffKeys:keys};
+}
+
+export function handoffTacticalTerminalResult(
+  state:TacticalTerminalHandoffState,
+  result:TacticalScenarioResult|null,
+):TacticalTerminalHandoff {
+  const normalizedState=normalizeHandoffState(state);
+  if(result===null) return {state:normalizedState,result:null};
+  const terminalKey=typeof result.terminalKey==='string'?result.terminalKey.trim():'';
+  if(!terminalKey) throw new Error('Tactical terminal key is required');
+  if(normalizedState.handedOffKeys.includes(terminalKey)) {
+    return {state:normalizedState,result:null};
+  }
+  return {
+    state:{handedOffKeys:[...normalizedState.handedOffKeys,terminalKey]},
+    result:{...result,terminalKey},
+  };
 }
 
 function living(session:BattleSession,id:string) {

--- a/src/tactical-scenario.ts
+++ b/src/tactical-scenario.ts
@@ -82,6 +82,7 @@ export type TacticalTerminalHandoff = Readonly<{
   result:TacticalScenarioResult|null;
 }>;
 
+const campaignIds:readonly MainCampaignId[]=['caretaker','pathfinder','vanguard','arcanist'];
 const statusIds:readonly TacticalStatusId[]=['guard','focus','break','regen'];
 const interventionCharacterIds:readonly TacticalBondInterventionCharacterId[]=['mira','kael','rex','selene'];
 const interventionTimings:readonly TacticalBondInterventionTiming[]=['before-battle','objective-check','terminal'];
@@ -89,6 +90,16 @@ const nonEmpty=(value:string)=>typeof value==='string'&&value.trim().length>0;
 const positiveInteger=(value:number)=>Number.isFinite(value)&&Number.isInteger(value)&&value>=1;
 const nonNegativeInteger=(value:number)=>Number.isFinite(value)&&Number.isInteger(value)&&value>=0;
 const safeInteger=(value:number)=>Number.isFinite(value)?Math.max(0,Math.min(Number.MAX_SAFE_INTEGER,Math.floor(value))):0;
+
+function validObjective(objective:TacticalScenarioObjective):boolean {
+  if(!objective||typeof objective!=='object') return false;
+  if(objective.type==='standard') return true;
+  if(objective.type==='protect') return nonEmpty(objective.unitId);
+  if(objective.type==='survive') return positiveInteger(objective.rounds);
+  if(objective.type==='escape') return nonNegativeInteger(objective.afterRounds);
+  if(objective.type==='target-elimination') return nonEmpty(objective.targetId);
+  return false;
+}
 
 function validModifier(modifier:TacticalScenarioModifier):boolean {
   if(!modifier||typeof modifier!=='object') return false;
@@ -114,18 +125,26 @@ function validModifier(modifier:TacticalScenarioModifier):boolean {
 }
 
 export function campaignEncounterToTacticalScenario(encounter:CampaignEncounterDefinition):TacticalScenario {
+  if(!encounter||typeof encounter!=='object'||!nonEmpty(encounter.id)||!nonEmpty(encounter.stageId)||!campaignIds.includes(encounter.campaign)||typeof encounter.failForward!=='boolean') {
+    throw new Error('invalid Tactical scenario definition');
+  }
+  if(!validObjective(encounter.objective)) {
+    throw new Error('invalid Tactical scenario objective');
+  }
   if(!Array.isArray(encounter.modifiers)||encounter.modifiers.some(modifier=>!validModifier(modifier))) {
     throw new Error('invalid Tactical scenario modifier');
   }
   if(encounter.modifiers.some(modifier=>modifier.campaign!==encounter.campaign)) {
     throw new Error('campaign modifier mismatch');
   }
+  const id=encounter.id.trim();
+  const stageId=encounter.stageId.trim();
   return {
-    id:encounter.id,
+    id,
     campaign:encounter.campaign,
-    stageId:encounter.stageId,
-    battleNode:tacticalBattleNodeForStage(encounter.stageId),
-    objective:encounter.objective,
+    stageId,
+    battleNode:tacticalBattleNodeForStage(stageId),
+    objective:{...encounter.objective},
     modifiers:encounter.modifiers.map(modifier=>({...modifier})),
     failForward:encounter.failForward,
   };

--- a/src/tactical-scenario.ts
+++ b/src/tactical-scenario.ts
@@ -1,0 +1,35 @@
+import type { MainCampaignId } from './campaign-model';
+import { tacticalBattleNodeForStage, type TacticalBattleNode } from './tactical-expedition';
+
+export type TacticalScenarioObjective = { type:'standard' };
+
+export type CampaignEncounterDefinition = {
+  id:string;
+  campaign:MainCampaignId;
+  stageId:string;
+  objective:TacticalScenarioObjective;
+  modifiers:readonly [];
+  failForward:boolean;
+};
+
+export type TacticalScenario = {
+  id:string;
+  campaign:MainCampaignId;
+  stageId:string;
+  battleNode:TacticalBattleNode;
+  objective:TacticalScenarioObjective;
+  modifiers:readonly [];
+  failForward:boolean;
+};
+
+export function campaignEncounterToTacticalScenario(encounter:CampaignEncounterDefinition):TacticalScenario {
+  return {
+    id:encounter.id,
+    campaign:encounter.campaign,
+    stageId:encounter.stageId,
+    battleNode:tacticalBattleNodeForStage(encounter.stageId),
+    objective:encounter.objective,
+    modifiers:encounter.modifiers,
+    failForward:encounter.failForward,
+  };
+}

--- a/src/tactical-scenario.ts
+++ b/src/tactical-scenario.ts
@@ -1,5 +1,5 @@
 import type { MainCampaignId } from './campaign-model';
-import { isBattleFinished, type BattleSession } from './tactical-battle';
+import { isBattleFinished, type BattleSession, type TacticalStatusId } from './tactical-battle';
 import { tacticalBattleNodeForStage, type TacticalBattleNode } from './tactical-expedition';
 
 export type TacticalScenarioObjective =
@@ -11,12 +11,25 @@ export type TacticalScenarioObjective =
 
 export type TacticalScenarioObjectiveResult = 'success'|'failure'|null;
 
+export type TacticalScenarioModifier =
+  | { campaign:'caretaker'; kind:'protect'; unitId:string }
+  | { campaign:'caretaker'; kind:'survive'; rounds:number }
+  | { campaign:'caretaker'; kind:'rescue'; unitId:string }
+  | { campaign:'pathfinder'; kind:'scout'; revealCount:number }
+  | { campaign:'pathfinder'; kind:'turn-limit'; maxRounds:number }
+  | { campaign:'pathfinder'; kind:'escape'; afterRounds:number }
+  | { campaign:'vanguard'; kind:'elite'; levelBonus:number }
+  | { campaign:'vanguard'; kind:'chained-battle'; chainId:string; index:number; total:number }
+  | { campaign:'arcanist'; kind:'status-amplify'; statusId:TacticalStatusId; multiplier:number }
+  | { campaign:'arcanist'; kind:'relic-resonance'; relicId:string }
+  | { campaign:'arcanist'; kind:'rule-shift'; ruleId:string };
+
 export type CampaignEncounterDefinition = {
   id:string;
   campaign:MainCampaignId;
   stageId:string;
   objective:TacticalScenarioObjective;
-  modifiers:readonly [];
+  modifiers:readonly TacticalScenarioModifier[];
   failForward:boolean;
 };
 
@@ -26,18 +39,52 @@ export type TacticalScenario = {
   stageId:string;
   battleNode:TacticalBattleNode;
   objective:TacticalScenarioObjective;
-  modifiers:readonly [];
+  modifiers:readonly TacticalScenarioModifier[];
   failForward:boolean;
 };
 
+const statusIds:readonly TacticalStatusId[]=['guard','focus','break','regen'];
+const nonEmpty=(value:string)=>typeof value==='string'&&value.trim().length>0;
+const positiveInteger=(value:number)=>Number.isFinite(value)&&Number.isInteger(value)&&value>=1;
+const nonNegativeInteger=(value:number)=>Number.isFinite(value)&&Number.isInteger(value)&&value>=0;
+
+function validModifier(modifier:TacticalScenarioModifier):boolean {
+  if(!modifier||typeof modifier!=='object') return false;
+  if(modifier.campaign==='caretaker') {
+    if(modifier.kind==='protect'||modifier.kind==='rescue') return nonEmpty(modifier.unitId);
+    return modifier.kind==='survive'&&positiveInteger(modifier.rounds);
+  }
+  if(modifier.campaign==='pathfinder') {
+    if(modifier.kind==='scout') return positiveInteger(modifier.revealCount);
+    if(modifier.kind==='turn-limit') return positiveInteger(modifier.maxRounds);
+    return modifier.kind==='escape'&&nonNegativeInteger(modifier.afterRounds);
+  }
+  if(modifier.campaign==='vanguard') {
+    if(modifier.kind==='elite') return nonNegativeInteger(modifier.levelBonus);
+    return modifier.kind==='chained-battle'&&nonEmpty(modifier.chainId)&&positiveInteger(modifier.index)&&positiveInteger(modifier.total)&&modifier.index<=modifier.total;
+  }
+  if(modifier.campaign==='arcanist') {
+    if(modifier.kind==='status-amplify') return statusIds.includes(modifier.statusId)&&Number.isFinite(modifier.multiplier)&&modifier.multiplier>0;
+    if(modifier.kind==='relic-resonance') return nonEmpty(modifier.relicId);
+    return modifier.kind==='rule-shift'&&nonEmpty(modifier.ruleId);
+  }
+  return false;
+}
+
 export function campaignEncounterToTacticalScenario(encounter:CampaignEncounterDefinition):TacticalScenario {
+  if(!Array.isArray(encounter.modifiers)||encounter.modifiers.some(modifier=>!validModifier(modifier))) {
+    throw new Error('invalid Tactical scenario modifier');
+  }
+  if(encounter.modifiers.some(modifier=>modifier.campaign!==encounter.campaign)) {
+    throw new Error('campaign modifier mismatch');
+  }
   return {
     id:encounter.id,
     campaign:encounter.campaign,
     stageId:encounter.stageId,
     battleNode:tacticalBattleNodeForStage(encounter.stageId),
     objective:encounter.objective,
-    modifiers:encounter.modifiers,
+    modifiers:encounter.modifiers.map(modifier=>({...modifier})),
     failForward:encounter.failForward,
   };
 }

--- a/src/tactical-scenario.ts
+++ b/src/tactical-scenario.ts
@@ -1,7 +1,15 @@
 import type { MainCampaignId } from './campaign-model';
+import { isBattleFinished, type BattleSession } from './tactical-battle';
 import { tacticalBattleNodeForStage, type TacticalBattleNode } from './tactical-expedition';
 
-export type TacticalScenarioObjective = { type:'standard' };
+export type TacticalScenarioObjective =
+  | { type:'standard' }
+  | { type:'protect'; unitId:string }
+  | { type:'survive'; rounds:number }
+  | { type:'escape'; afterRounds:number }
+  | { type:'target-elimination'; targetId:string };
+
+export type TacticalScenarioObjectiveResult = 'success'|'failure'|null;
 
 export type CampaignEncounterDefinition = {
   id:string;
@@ -32,4 +40,39 @@ export function campaignEncounterToTacticalScenario(encounter:CampaignEncounterD
     modifiers:encounter.modifiers,
     failForward:encounter.failForward,
   };
+}
+
+function living(session:BattleSession,id:string) {
+  const unit=session.units.find(entry=>entry.id===id);
+  return Boolean(unit&&Number.isFinite(unit.hp)&&unit.hp>0);
+}
+
+export function evaluateTacticalScenarioObjective(scenario:TacticalScenario,session:BattleSession):TacticalScenarioObjectiveResult {
+  const battleResult=isBattleFinished(session);
+  const completedRounds=Math.max(0,session.round-1);
+  const objective=scenario.objective;
+
+  if(objective.type==='standard') return battleResult==='victory'?'success':battleResult==='defeat'?'failure':null;
+
+  if(objective.type==='protect') {
+    if(!living(session,objective.unitId)) return 'failure';
+    return battleResult==='victory'?'success':battleResult==='defeat'?'failure':null;
+  }
+
+  if(objective.type==='survive') {
+    if(battleResult==='defeat') return 'failure';
+    if(completedRounds>=Math.max(1,Math.floor(objective.rounds))) return 'success';
+    return battleResult==='victory'?'success':null;
+  }
+
+  if(objective.type==='escape') {
+    if(battleResult==='defeat') return 'failure';
+    if(completedRounds>=Math.max(0,Math.floor(objective.afterRounds))) return 'success';
+    return battleResult==='victory'?'success':null;
+  }
+
+  const target=session.units.find(entry=>entry.id===objective.targetId);
+  if(target&&(!Number.isFinite(target.hp)||target.hp<=0)) return 'success';
+  if(battleResult==='defeat'||battleResult==='victory') return 'failure';
+  return null;
 }

--- a/src/tactical-scenario.ts
+++ b/src/tactical-scenario.ts
@@ -1,5 +1,5 @@
 import type { MainCampaignId } from './campaign-model';
-import { isBattleFinished, type BattleSession, type TacticalStatusId } from './tactical-battle';
+import { isBattleFinished, type BattleResult, type BattleSession, type TacticalStatusId } from './tactical-battle';
 import type { CompanionId, LeaderCombatProgression } from './tactical-companions';
 import { createTacticalExpeditionBattle, tacticalBattleNodeForStage, type TacticalBattleNode } from './tactical-expedition';
 
@@ -44,10 +44,24 @@ export type TacticalScenario = {
   failForward:boolean;
 };
 
+export type TacticalScenarioResult = {
+  scenarioId:string;
+  campaign:MainCampaignId;
+  attemptKey:string;
+  terminalKey:string;
+  objectiveResult:Exclude<TacticalScenarioObjectiveResult,null>;
+  battleResult:BattleResult|null;
+  failForward:boolean;
+  rounds:number;
+  survivingAllies:number;
+  damageTaken:number;
+};
+
 const statusIds:readonly TacticalStatusId[]=['guard','focus','break','regen'];
 const nonEmpty=(value:string)=>typeof value==='string'&&value.trim().length>0;
 const positiveInteger=(value:number)=>Number.isFinite(value)&&Number.isInteger(value)&&value>=1;
 const nonNegativeInteger=(value:number)=>Number.isFinite(value)&&Number.isInteger(value)&&value>=0;
+const safeInteger=(value:number)=>Number.isFinite(value)?Math.max(0,Math.min(Number.MAX_SAFE_INTEGER,Math.floor(value))):0;
 
 function validModifier(modifier:TacticalScenarioModifier):boolean {
   if(!modifier||typeof modifier!=='object') return false;
@@ -132,4 +146,38 @@ export function evaluateTacticalScenarioObjective(scenario:TacticalScenario,sess
   if(target&&(!Number.isFinite(target.hp)||target.hp<=0)) return 'success';
   if(battleResult==='defeat'||battleResult==='victory') return 'failure';
   return null;
+}
+
+export function resolveTacticalScenarioResult(
+  scenario:TacticalScenario,
+  session:BattleSession,
+  attemptKey:string,
+):TacticalScenarioResult|null {
+  const key=typeof attemptKey==='string'?attemptKey.trim():'';
+  if(!key) throw new Error('Tactical scenario attempt key is required');
+  const objectiveResult=evaluateTacticalScenarioObjective(scenario,session);
+  if(!objectiveResult) return null;
+
+  let damageTaken=0;
+  let survivingAllies=0;
+  for(const unit of session.units) {
+    if(unit.side!=='ally') continue;
+    const hp=safeInteger(unit.hp);
+    const maxHp=Number.isFinite(unit.maxHp)?Math.max(hp,safeInteger(unit.maxHp)):hp;
+    if(Number.isFinite(unit.hp)&&unit.hp>0) survivingAllies+=1;
+    damageTaken=Math.min(Number.MAX_SAFE_INTEGER,damageTaken+Math.max(0,maxHp-Math.min(hp,maxHp)));
+  }
+
+  return {
+    scenarioId:scenario.id,
+    campaign:scenario.campaign,
+    attemptKey:key,
+    terminalKey:`${scenario.id}:${key}`,
+    objectiveResult,
+    battleResult:isBattleFinished(session),
+    failForward:scenario.failForward,
+    rounds:Number.isFinite(session.round)?Math.max(0,Math.min(Number.MAX_SAFE_INTEGER,Math.floor(session.round)-1)):0,
+    survivingAllies,
+    damageTaken,
+  };
 }

--- a/src/tactical-terminal-handoff.test.ts
+++ b/src/tactical-terminal-handoff.test.ts
@@ -81,4 +81,16 @@ describe('V3 Tactical once-only terminal handoff',()=>{
     const malformed={...result('attempt-1'),terminalKey:'   '};
     expect(()=>handoffTacticalTerminalResult(createTacticalTerminalHandoffState(),malformed)).toThrow('terminal key');
   });
+
+  it('derives once-only identity from scenario and attempt so a tampered terminal key cannot bypass dedupe',()=>{
+    const firstInput={...result('attempt-1'),terminalKey:'tampered-key-a'};
+    const first=handoffTacticalTerminalResult(createTacticalTerminalHandoffState(),firstInput);
+    expect(first.result?.terminalKey).toBe('spring-vanguard-terminal:attempt-1');
+    expect(first.state.handedOffKeys).toEqual(['spring-vanguard-terminal:attempt-1']);
+
+    const secondInput={...result('attempt-1'),terminalKey:'tampered-key-b'};
+    const duplicate=handoffTacticalTerminalResult(first.state,secondInput);
+    expect(duplicate.result).toBeNull();
+    expect(duplicate.state).toBe(first.state);
+  });
 });

--- a/src/tactical-terminal-handoff.test.ts
+++ b/src/tactical-terminal-handoff.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTacticalTerminalHandoffState,
+  handoffTacticalTerminalResult,
+  type TacticalScenarioResult,
+  type TacticalTerminalHandoffState,
+} from './tactical-scenario';
+
+const result=(attemptKey:string):TacticalScenarioResult=>({
+  scenarioId:'spring-vanguard-terminal',
+  campaign:'vanguard',
+  attemptKey,
+  terminalKey:`spring-vanguard-terminal:${attemptKey}`,
+  objectiveResult:'success',
+  battleResult:'victory',
+  failForward:false,
+  rounds:4,
+  survivingAllies:2,
+  damageTaken:37,
+});
+
+describe('V3 Tactical once-only terminal handoff',()=>{
+  it('starts with an isolated empty handoff state',()=>{
+    const first=createTacticalTerminalHandoffState();
+    const second=createTacticalTerminalHandoffState();
+    expect(first).toEqual({handedOffKeys:[]});
+    expect(second).toEqual({handedOffKeys:[]});
+    expect(first).not.toBe(second);
+    expect(first.handedOffKeys).not.toBe(second.handedOffKeys);
+  });
+
+  it('passes a terminal result exactly once for its terminal key',()=>{
+    const state=createTacticalTerminalHandoffState();
+    const terminal=result('attempt-1');
+    const first=handoffTacticalTerminalResult(state,terminal);
+
+    expect(first.result).toEqual(terminal);
+    expect(first.result).not.toBe(terminal);
+    expect(first.state).toEqual({handedOffKeys:['spring-vanguard-terminal:attempt-1']});
+    expect(first.state).not.toBe(state);
+    expect(state).toEqual({handedOffKeys:[]});
+
+    const duplicate=handoffTacticalTerminalResult(first.state,terminal);
+    expect(duplicate.result).toBeNull();
+    expect(duplicate.state).toBe(first.state);
+    expect(duplicate.state.handedOffKeys).toEqual(['spring-vanguard-terminal:attempt-1']);
+  });
+
+  it('allows a different attempt key to hand off once independently',()=>{
+    const first=handoffTacticalTerminalResult(createTacticalTerminalHandoffState(),result('attempt-1'));
+    const second=handoffTacticalTerminalResult(first.state,result('attempt-2'));
+    expect(second.result?.attemptKey).toBe('attempt-2');
+    expect(second.state.handedOffKeys).toEqual([
+      'spring-vanguard-terminal:attempt-1',
+      'spring-vanguard-terminal:attempt-2',
+    ]);
+  });
+
+  it('does nothing for a non-terminal null result',()=>{
+    const state=createTacticalTerminalHandoffState();
+    const handed=handoffTacticalTerminalResult(state,null);
+    expect(handed).toEqual({state,result:null});
+    expect(handed.state).toBe(state);
+  });
+
+  it('sanitizes malformed runtime handoff keys so blanks and duplicates cannot poison dedupe',()=>{
+    const corrupted={handedOffKeys:['','  ','spring-vanguard-terminal:attempt-1','spring-vanguard-terminal:attempt-1',42]} as unknown as TacticalTerminalHandoffState;
+    const duplicate=handoffTacticalTerminalResult(corrupted,result('attempt-1'));
+    expect(duplicate.result).toBeNull();
+    expect(duplicate.state.handedOffKeys).toEqual(['spring-vanguard-terminal:attempt-1']);
+
+    const next=handoffTacticalTerminalResult(duplicate.state,result('attempt-2'));
+    expect(next.result?.attemptKey).toBe('attempt-2');
+    expect(next.state.handedOffKeys).toEqual([
+      'spring-vanguard-terminal:attempt-1',
+      'spring-vanguard-terminal:attempt-2',
+    ]);
+  });
+
+  it('rejects a malformed terminal key rather than collapsing different attempts together',()=>{
+    const malformed={...result('attempt-1'),terminalKey:'   '};
+    expect(()=>handoffTacticalTerminalResult(createTacticalTerminalHandoffState(),malformed)).toThrow('terminal key');
+  });
+});


### PR DESCRIPTION
## 상태
- **[04 Spring Tactical COMPLETE / Candidate]**
- Draft 유지 / 06 sequential integration 대기
- issue: #59
- parent control tower: #54
- base: `integration/v3@46faf9031a86ff09d92cc17ee043e9180414d510`
- head: `work/v3-spring-tactical@516f3e6b268f1ff4913868d11e7195b678e88b10`
- merge-ref verified: `3057fc5e50c9f64d8b7f477c399785697e0968e5`
- integration/main/prod merge 없음

## Spring Tactical 완료 범위
- `CampaignEncounterDefinition → TacticalScenario` adapter
- `TacticalScenario →` 기존 `createTacticalExpeditionBattle()` 위임 — **새 전투 엔진 없음**
- objective contracts: standard / protect / survive / escape / target-elimination
- campaign modifier contracts:
  - Caretaker: protect / survive / rescue
  - Pathfinder: scout / turn-limit / escape
  - Vanguard: elite / chained-battle
  - Arcanist: status-amplify / relic-resonance / rule-shift
- fail-forward Tactical result shape — combat facts/results only, Story/Campaign/Bond state 직접 수정 없음
- Bond Intervention I/O hook — Mira / Kael / Rex / Selene 지원 구조, `CharacterBondState` 직접 mutate/import 없음
- once-only terminal result handoff
- scenario/objective/modifier/result/handoff runtime sanitation + input ownership isolation
- existing 3v3 engine/stability/sanitize/terminal-state/resource/AI/AUTO behavior preserved

## Terminal handoff hardening
- `createTacticalTerminalHandoffState()` explicit session-local state; global/singleton 없음
- `handoffTacticalTerminalResult()` once-only/idempotent handoff
- malformed handoff state/key sanitation
- terminal identity를 `scenarioId + attemptKey`로 canonicalize하여 외부에서 `terminalKey`를 바꿔도 동일 attempt의 중복 handoff 우회 불가
- `tactical-terminal-handoff.test.ts`: **7/7 GREEN**

## Final verification
- CI #1485 / run `32545016460`: **GREEN**
- full suite: **344/344 test files, 1244/1244 tests GREEN**
- `tactical-stability.test.ts`: **13/13 GREEN**
- manual/AUTO 반복 전투 안정성: GREEN
- AUTO stress 10 / 50 / 100 battle checkpoints: **GREEN**
- `tsc -b`: **PASS**
- Vite production build: **PASS**
- 189 modules transformed

## Guardrails
- shared `App.tsx` / `Root.tsx` / game / save / vercel untouched
- 기존 Tactical 3v3 engine 유지
- Spring에서는 Summer Boss 본편 확장 없음
- Draft stays unmerged
- 06 owns sequential integration
- main/prod untouched

## Notes
- repository dependency install reports the pre-existing 1 high severity vulnerability; this Tactical change does not alter dependencies.
- Vite reports the existing >500 kB chunk-size warning; build itself is GREEN.