### PR TITLE
feat(v3): complete Spring Raising path convergence

### DIFF
--- a/src/character-bonds.ts
+++ b/src/character-bonds.ts
@@ -6,11 +6,12 @@ export type CharacterBondsState=Record<CharacterId,CharacterBondState>;
 type Registry={conflicts:readonly string[];promises:readonly string[];memories:readonly string[]};
 
 export const characterBondIdRegistry:Record<CharacterId,Registry>={
-  mira:{conflicts:['mira_self_sacrifice'],promises:['mira_share_the_burden'],memories:['mira_festival_rescue','mira_long_night']},
-  kael:{conflicts:[],promises:[],memories:[]},
-  rex:{conflicts:['rex_obsession_with_victory'],promises:['rex_fair_rivalry'],memories:['rex_first_defeat','rex_tournament_final']},
-  selene:{conflicts:[],promises:[],memories:[]},noa:{conflicts:[],promises:[],memories:[]},
-  eiden:{conflicts:[],promises:[],memories:[]},lyra:{conflicts:[],promises:[],memories:[]},veyr:{conflicts:[],promises:[],memories:[]},
+  mira:{conflicts:['mira_self_sacrifice'],promises:['mira_share_the_burden'],memories:['mira_first_commitment','mira_festival_rescue','mira_long_night']},
+  kael:{conflicts:[],promises:[],memories:['kael_first_commitment']},
+  rex:{conflicts:['rex_obsession_with_victory'],promises:['rex_fair_rivalry'],memories:['rex_first_commitment','rex_first_defeat','rex_tournament_final']},
+  selene:{conflicts:[],promises:[],memories:['selene_first_commitment']},
+  noa:{conflicts:[],promises:[],memories:[]},eiden:{conflicts:[],promises:[],memories:[]},
+  lyra:{conflicts:[],promises:[],memories:[]},veyr:{conflicts:[],promises:[],memories:[]},
 };
 
 const emptyBond=():CharacterBondState=>({trust:0,conflicts:[],promises:[],memories:[]});

--- a/src/spring-raising.test.ts
+++ b/src/spring-raising.test.ts
@@ -1,0 +1,14 @@
+import {describe,expect,it} from 'vitest';
+import {scoreSpringAffinityEvidence} from './spring-raising';
+
+describe('V3 Spring Raising',()=>{
+  it('aggregates finite positive affinity evidence by campaign',()=>{
+    expect(scoreSpringAffinityEvidence([
+      {campaign:'caretaker',source:'training',amount:2,reason:'protected an ally'},
+      {campaign:'caretaker',source:'dialogue',amount:3,reason:'shared responsibility'},
+      {campaign:'pathfinder',source:'exploration',amount:4,reason:'found a hidden route'},
+      {campaign:'vanguard',source:'tactical',amount:Infinity,reason:'corrupt'},
+      {campaign:'arcanist',source:'calling',amount:-3,reason:'invalid'},
+    ])).toEqual({caretaker:5,pathfinder:4,vanguard:0,arcanist:0});
+  });
+});

--- a/src/spring-raising.test.ts
+++ b/src/spring-raising.test.ts
@@ -1,6 +1,12 @@
 import {describe,expect,it} from 'vitest';
+import {emptyCampaignRunState} from './campaign-state';
+import {emptyCharacterBondsState,hydrateCharacterBondsState} from './character-bonds';
 import {
+  applyFirstCommitmentCharacterBond,
+  commitSpringCampaign,
+  openPathConvergence,
   pathConvergence,
+  resolveFirstCommitment,
   scoreCappedSpringAffinities,
   scoreSpringAffinityEvidence,
 } from './spring-raising';
@@ -43,5 +49,45 @@ describe('V3 Spring Raising',()=>{
     expect(candidates.every(candidate=>!('score' in candidate)&&!('affinity' in candidate))).toBe(true);
     expect(pathConvergence([])).toHaveLength(2);
     expect(pathConvergence(evidence,{eligibleThird:[]})).toHaveLength(2);
+  });
+
+  it('opens convergence, commits one candidate once, then locks the campaign',()=>{
+    const evidence=[
+      {campaign:'caretaker' as const,source:'bond' as const,amount:6,reason:'stood beside Mira'},
+      {campaign:'caretaker' as const,source:'dialogue' as const,amount:5,reason:'shared the burden'},
+      {campaign:'pathfinder' as const,source:'exploration' as const,amount:6,reason:'found a hidden route'},
+    ];
+    const opened=openPathConvergence(emptyCampaignRunState(),evidence);
+    expect(opened.state.phase).toBe('path_selection');
+    expect(opened.state.seasonMilestones).toContain('path_convergence');
+    expect(opened.candidates).toHaveLength(2);
+    const first=commitSpringCampaign(opened.state,opened.candidates,'caretaker');
+    expect(first.committed).toBe(true);
+    expect(first.state.activeCampaign).toBe('caretaker');
+    expect(first.state.campaignAffinities.caretaker).toBe(11);
+    const replay=commitSpringCampaign(first.state,opened.candidates,'pathfinder');
+    expect(replay.committed).toBe(false);
+    expect(replay.reason).toBe('locked');
+    expect(replay.state.activeCampaign).toBe('caretaker');
+  });
+
+  it('emits First Commitment once before Summer and applies an idempotent representative Character Bond',()=>{
+    const opened=openPathConvergence(emptyCampaignRunState(),[
+      {campaign:'caretaker',source:'bond',amount:6,reason:'stood beside Mira'},
+      {campaign:'pathfinder',source:'exploration',amount:5,reason:'found a hidden route'},
+    ]);
+    const committed=commitSpringCampaign(opened.state,opened.candidates,'caretaker');
+    const commitment=resolveFirstCommitment(committed.state);
+    expect(commitment.event).toMatchObject({type:'first_commitment',campaign:'caretaker',character:'mira'});
+    expect(commitment.state.phase).toBe('summer');
+    expect(resolveFirstCommitment(commitment.state).event).toBeNull();
+
+    const bonds=applyFirstCommitmentCharacterBond(emptyCharacterBondsState(),commitment.event!);
+    expect(bonds.mira.trust).toBe(3);
+    expect(bonds.mira.memories).toContain('mira_first_commitment');
+    const replay=applyFirstCommitmentCharacterBond(bonds,commitment.event!);
+    expect(replay.mira.trust).toBe(3);
+    expect(replay.mira.memories).toEqual(['mira_first_commitment']);
+    expect(hydrateCharacterBondsState(replay).mira.memories).toContain('mira_first_commitment');
   });
 });

--- a/src/spring-raising.test.ts
+++ b/src/spring-raising.test.ts
@@ -1,5 +1,9 @@
 import {describe,expect,it} from 'vitest';
-import {scoreCappedSpringAffinities,scoreSpringAffinityEvidence} from './spring-raising';
+import {
+  pathConvergence,
+  scoreCappedSpringAffinities,
+  scoreSpringAffinityEvidence,
+} from './spring-raising';
 
 describe('V3 Spring Raising',()=>{
   it('aggregates finite positive affinity evidence by campaign',()=>{
@@ -20,5 +24,24 @@ describe('V3 Spring Raising',()=>{
       {campaign:'caretaker',source:'dialogue',amount:5,reason:'shared responsibility'},
       {campaign:'pathfinder',source:'exploration',amount:7,reason:'mapped hidden routes'},
     ])).toEqual({caretaker:11,pathfinder:6,vanguard:0,arcanist:0});
+  });
+
+  it('always exposes two main paths and only a close eligible third without raw scores',()=>{
+    const evidence=[
+      {campaign:'caretaker' as const,source:'bond' as const,amount:6,reason:'stood beside Mira'},
+      {campaign:'caretaker' as const,source:'dialogue' as const,amount:5,reason:'shared the burden'},
+      {campaign:'pathfinder' as const,source:'exploration' as const,amount:6,reason:'found a hidden route'},
+      {campaign:'pathfinder' as const,source:'calling' as const,amount:4,reason:'followed the unknown'},
+      {campaign:'vanguard' as const,source:'tactical' as const,amount:6,reason:'won a difficult battle'},
+      {campaign:'vanguard' as const,source:'training' as const,amount:2,reason:'trained under pressure'},
+      {campaign:'arcanist' as const,source:'calling' as const,amount:1,reason:'studied a relic'},
+    ];
+    const candidates=pathConvergence(evidence,{eligibleThird:['vanguard']});
+    expect(candidates.map(candidate=>candidate.campaign)).toEqual(['caretaker','pathfinder','vanguard']);
+    expect(candidates).toHaveLength(3);
+    expect(candidates.every(candidate=>candidate.reasons.length>0)).toBe(true);
+    expect(candidates.every(candidate=>!('score' in candidate)&&!('affinity' in candidate))).toBe(true);
+    expect(pathConvergence([])).toHaveLength(2);
+    expect(pathConvergence(evidence,{eligibleThird:[]})).toHaveLength(2);
   });
 });

--- a/src/spring-raising.test.ts
+++ b/src/spring-raising.test.ts
@@ -1,5 +1,5 @@
 import {describe,expect,it} from 'vitest';
-import {scoreSpringAffinityEvidence} from './spring-raising';
+import {scoreCappedSpringAffinities,scoreSpringAffinityEvidence} from './spring-raising';
 
 describe('V3 Spring Raising',()=>{
   it('aggregates finite positive affinity evidence by campaign',()=>{
@@ -10,5 +10,15 @@ describe('V3 Spring Raising',()=>{
       {campaign:'vanguard',source:'tactical',amount:Infinity,reason:'corrupt'},
       {campaign:'arcanist',source:'calling',amount:-3,reason:'invalid'},
     ])).toEqual({caretaker:5,pathfinder:4,vanguard:0,arcanist:0});
+  });
+
+  it('caps each campaign source while preserving distinct behavioral sources',()=>{
+    expect(scoreCappedSpringAffinities([
+      {campaign:'caretaker',source:'training',amount:4,reason:'protected an ally'},
+      {campaign:'caretaker',source:'training',amount:4,reason:'protected an ally again'},
+      {campaign:'caretaker',source:'training',amount:4,reason:'protected an ally again'},
+      {campaign:'caretaker',source:'dialogue',amount:5,reason:'shared responsibility'},
+      {campaign:'pathfinder',source:'exploration',amount:7,reason:'mapped hidden routes'},
+    ])).toEqual({caretaker:11,pathfinder:6,vanguard:0,arcanist:0});
   });
 });

--- a/src/spring-raising.ts
+++ b/src/spring-raising.ts
@@ -1,0 +1,31 @@
+import type {MainCampaignId} from './campaign-model';
+
+export const springAffinitySources=['training','dialogue','bond','exploration','tactical','calling','personality'] as const;
+export type SpringAffinitySource=typeof springAffinitySources[number];
+
+export type SpringAffinityEvidence={
+  campaign:MainCampaignId;
+  source:SpringAffinitySource;
+  amount:number;
+  reason:string;
+};
+
+const emptyAffinities=():Record<MainCampaignId,number>=>({
+  caretaker:0,
+  pathfinder:0,
+  vanguard:0,
+  arcanist:0,
+});
+
+const safeAffinityAmount=(value:number):number=>
+  Number.isFinite(value)&&value>0?Math.floor(value):0;
+
+export function scoreSpringAffinityEvidence(
+  evidence:readonly SpringAffinityEvidence[],
+):Record<MainCampaignId,number>{
+  const scores=emptyAffinities();
+  for(const item of evidence){
+    scores[item.campaign]+=safeAffinityAmount(item.amount);
+  }
+  return scores;
+}

--- a/src/spring-raising.ts
+++ b/src/spring-raising.ts
@@ -1,4 +1,4 @@
-import type {MainCampaignId} from './campaign-model';
+import {mainCampaignIds,type MainCampaignId} from './campaign-model';
 
 export const springAffinitySources=['training','dialogue','bond','exploration','tactical','calling','personality'] as const;
 export type SpringAffinitySource=typeof springAffinitySources[number];
@@ -11,6 +11,15 @@ export type SpringAffinityEvidence={
 };
 
 export const SPRING_AFFINITY_SOURCE_CAP=6;
+
+export type SpringPathTendency='faint_tendency'|'emerging_possibility'|'strongly_opening_path';
+export type SpringPathCandidate={
+  campaign:MainCampaignId;
+  tendency:SpringPathTendency;
+  reasons:string[];
+};
+
+export type PathConvergenceOptions={eligibleThird?:readonly MainCampaignId[]};
 
 const emptyAffinities=():Record<MainCampaignId,number>=>({
   caretaker:0,
@@ -50,4 +59,47 @@ export function scoreCappedSpringAffinities(
     scores[campaign]+=amount;
   }
   return scores;
+}
+
+const tendencyFor=(score:number):SpringPathTendency=>
+  score>=10?'strongly_opening_path':score>=4?'emerging_possibility':'faint_tendency';
+
+const fallbackReasons:Record<MainCampaignId,string>={
+  caretaker:'Your Spring still leaves room to protect what matters.',
+  pathfinder:'Your Spring still leaves an unexplored road open.',
+  vanguard:'Your Spring still leaves a challenge worth facing.',
+  arcanist:'Your Spring still leaves a mystery worth understanding.',
+};
+
+function reasonsFor(campaign:MainCampaignId,evidence:readonly SpringAffinityEvidence[]):string[]{
+  const reasons:string[]=[];
+  for(const item of evidence){
+    if(item.campaign!==campaign||safeAffinityAmount(item.amount)===0)continue;
+    const reason=item.reason.trim();
+    if(reason&&!reasons.includes(reason))reasons.push(reason);
+    if(reasons.length===2)break;
+  }
+  return reasons.length?reasons:[fallbackReasons[campaign]];
+}
+
+export function pathConvergence(
+  evidence:readonly SpringAffinityEvidence[],
+  options:PathConvergenceOptions={},
+):SpringPathCandidate[]{
+  const scores=scoreCappedSpringAffinities(evidence);
+  const ranked=[...mainCampaignIds].sort((left,right)=>{
+    const difference=scores[right]-scores[left];
+    return difference!==0?difference:mainCampaignIds.indexOf(left)-mainCampaignIds.indexOf(right);
+  });
+  const selected=ranked.slice(0,2);
+  const third=ranked[2];
+  const eligibleThird=new Set(options.eligibleThird??[]);
+  const secondScore=scores[ranked[1]];
+  const thirdScore=scores[third];
+  if(thirdScore>0&&thirdScore>=Math.max(1,secondScore*0.75)&&eligibleThird.has(third))selected.push(third);
+  return selected.map(campaign=>({
+    campaign,
+    tendency:tendencyFor(scores[campaign]),
+    reasons:reasonsFor(campaign,evidence),
+  }));
 }

--- a/src/spring-raising.ts
+++ b/src/spring-raising.ts
@@ -10,6 +10,8 @@ export type SpringAffinityEvidence={
   reason:string;
 };
 
+export const SPRING_AFFINITY_SOURCE_CAP=6;
+
 const emptyAffinities=():Record<MainCampaignId,number>=>({
   caretaker:0,
   pathfinder:0,
@@ -26,6 +28,26 @@ export function scoreSpringAffinityEvidence(
   const scores=emptyAffinities();
   for(const item of evidence){
     scores[item.campaign]+=safeAffinityAmount(item.amount);
+  }
+  return scores;
+}
+
+export function scoreCappedSpringAffinities(
+  evidence:readonly SpringAffinityEvidence[],
+  sourceCap=SPRING_AFFINITY_SOURCE_CAP,
+):Record<MainCampaignId,number>{
+  const scores=emptyAffinities();
+  const safeCap=Number.isFinite(sourceCap)&&sourceCap>0?Math.floor(sourceCap):SPRING_AFFINITY_SOURCE_CAP;
+  const sourceTotals=new Map<string,number>();
+  for(const item of evidence){
+    const amount=safeAffinityAmount(item.amount);
+    if(amount===0)continue;
+    const key=`${item.campaign}:${item.source}`;
+    sourceTotals.set(key,Math.min(safeCap,(sourceTotals.get(key)??0)+amount));
+  }
+  for(const [key,amount] of sourceTotals){
+    const campaign=key.slice(0,key.indexOf(':')) as MainCampaignId;
+    scores[campaign]+=amount;
   }
   return scores;
 }

--- a/src/spring-raising.ts
+++ b/src/spring-raising.ts
@@ -1,4 +1,6 @@
-import {mainCampaignIds,type MainCampaignId} from './campaign-model';
+import {mainCampaignIds,type CharacterId,type MainCampaignId} from './campaign-model';
+import type {CampaignRunState} from './campaign-state';
+import type {CharacterBondsState} from './character-bonds';
 
 export const springAffinitySources=['training','dialogue','bond','exploration','tactical','calling','personality'] as const;
 export type SpringAffinitySource=typeof springAffinitySources[number];
@@ -18,32 +20,33 @@ export type SpringPathCandidate={
   tendency:SpringPathTendency;
   reasons:string[];
 };
-
 export type PathConvergenceOptions={eligibleThird?:readonly MainCampaignId[]};
 
-const emptyAffinities=():Record<MainCampaignId,number>=>({
-  caretaker:0,
-  pathfinder:0,
-  vanguard:0,
-  arcanist:0,
-});
+export type CampaignCommitResult={
+  state:CampaignRunState;
+  committed:boolean;
+  reason?:'locked'|'not_candidate'|'not_ready';
+};
 
-const safeAffinityAmount=(value:number):number=>
-  Number.isFinite(value)&&value>0?Math.floor(value):0;
+export type FirstCommitmentEvent={
+  type:'first_commitment';
+  key:`first_commitment:${MainCampaignId}`;
+  campaign:MainCampaignId;
+  character:CharacterId;
+  memory:string;
+};
 
-export function scoreSpringAffinityEvidence(
-  evidence:readonly SpringAffinityEvidence[],
-):Record<MainCampaignId,number>{
+const emptyAffinities=():Record<MainCampaignId,number>=>({caretaker:0,pathfinder:0,vanguard:0,arcanist:0});
+const safeAffinityAmount=(value:number):number=>Number.isFinite(value)&&value>0?Math.floor(value):0;
+
+export function scoreSpringAffinityEvidence(evidence:readonly SpringAffinityEvidence[]):Record<MainCampaignId,number>{
   const scores=emptyAffinities();
-  for(const item of evidence){
-    scores[item.campaign]+=safeAffinityAmount(item.amount);
-  }
+  for(const item of evidence)scores[item.campaign]+=safeAffinityAmount(item.amount);
   return scores;
 }
 
 export function scoreCappedSpringAffinities(
-  evidence:readonly SpringAffinityEvidence[],
-  sourceCap=SPRING_AFFINITY_SOURCE_CAP,
+  evidence:readonly SpringAffinityEvidence[],sourceCap=SPRING_AFFINITY_SOURCE_CAP,
 ):Record<MainCampaignId,number>{
   const scores=emptyAffinities();
   const safeCap=Number.isFinite(sourceCap)&&sourceCap>0?Math.floor(sourceCap):SPRING_AFFINITY_SOURCE_CAP;
@@ -61,16 +64,13 @@ export function scoreCappedSpringAffinities(
   return scores;
 }
 
-const tendencyFor=(score:number):SpringPathTendency=>
-  score>=10?'strongly_opening_path':score>=4?'emerging_possibility':'faint_tendency';
-
+const tendencyFor=(score:number):SpringPathTendency=>score>=10?'strongly_opening_path':score>=4?'emerging_possibility':'faint_tendency';
 const fallbackReasons:Record<MainCampaignId,string>={
   caretaker:'Your Spring still leaves room to protect what matters.',
   pathfinder:'Your Spring still leaves an unexplored road open.',
   vanguard:'Your Spring still leaves a challenge worth facing.',
   arcanist:'Your Spring still leaves a mystery worth understanding.',
 };
-
 function reasonsFor(campaign:MainCampaignId,evidence:readonly SpringAffinityEvidence[]):string[]{
   const reasons:string[]=[];
   for(const item of evidence){
@@ -83,23 +83,51 @@ function reasonsFor(campaign:MainCampaignId,evidence:readonly SpringAffinityEvid
 }
 
 export function pathConvergence(
-  evidence:readonly SpringAffinityEvidence[],
-  options:PathConvergenceOptions={},
+  evidence:readonly SpringAffinityEvidence[],options:PathConvergenceOptions={},
 ):SpringPathCandidate[]{
   const scores=scoreCappedSpringAffinities(evidence);
-  const ranked=[...mainCampaignIds].sort((left,right)=>{
-    const difference=scores[right]-scores[left];
-    return difference!==0?difference:mainCampaignIds.indexOf(left)-mainCampaignIds.indexOf(right);
-  });
+  const ranked=[...mainCampaignIds].sort((left,right)=>scores[right]-scores[left]||mainCampaignIds.indexOf(left)-mainCampaignIds.indexOf(right));
   const selected=ranked.slice(0,2);
   const third=ranked[2];
-  const eligibleThird=new Set(options.eligibleThird??[]);
   const secondScore=scores[ranked[1]];
   const thirdScore=scores[third];
-  if(thirdScore>0&&thirdScore>=Math.max(1,secondScore*0.75)&&eligibleThird.has(third))selected.push(third);
-  return selected.map(campaign=>({
-    campaign,
-    tendency:tendencyFor(scores[campaign]),
-    reasons:reasonsFor(campaign,evidence),
-  }));
+  if(thirdScore>0&&thirdScore>=Math.max(1,secondScore*0.75)&&new Set(options.eligibleThird??[]).has(third))selected.push(third);
+  return selected.map(campaign=>({campaign,tendency:tendencyFor(scores[campaign]),reasons:reasonsFor(campaign,evidence)}));
+}
+
+export function openPathConvergence(
+  state:CampaignRunState,evidence:readonly SpringAffinityEvidence[],options:PathConvergenceOptions={},
+):{state:CampaignRunState;candidates:SpringPathCandidate[]}{
+  const candidates=pathConvergence(evidence,options);
+  if(state.activeCampaign!==null||state.phase!=='spring_exploration')return {state,candidates};
+  return {state:{...state,phase:'path_selection',campaignAffinities:scoreCappedSpringAffinities(evidence),seasonMilestones:state.seasonMilestones.includes('path_convergence')?state.seasonMilestones:[...state.seasonMilestones,'path_convergence']},candidates};
+}
+
+export function commitSpringCampaign(
+  state:CampaignRunState,candidates:readonly SpringPathCandidate[],selection:MainCampaignId,
+):CampaignCommitResult{
+  if(state.activeCampaign!==null)return {state,committed:false,reason:'locked'};
+  if(state.phase!=='path_selection')return {state,committed:false,reason:'not_ready'};
+  if(!candidates.some(candidate=>candidate.campaign===selection))return {state,committed:false,reason:'not_candidate'};
+  return {state:{...state,activeCampaign:selection},committed:true};
+}
+
+const representativeByCampaign:Record<MainCampaignId,CharacterId>={caretaker:'mira',pathfinder:'kael',vanguard:'rex',arcanist:'selene'};
+
+export function resolveFirstCommitment(state:CampaignRunState):{state:CampaignRunState;event:FirstCommitmentEvent|null}{
+  if(state.phase!=='path_selection'||state.activeCampaign===null||state.activeCampaign==='true_path')return {state,event:null};
+  const campaign=state.activeCampaign;
+  const character=representativeByCampaign[campaign];
+  return {
+    state:{...state,phase:'summer'},
+    event:{type:'first_commitment',key:`first_commitment:${campaign}`,campaign,character,memory:`${character}_first_commitment`},
+  };
+}
+
+export function applyFirstCommitmentCharacterBond(
+  bonds:CharacterBondsState,event:FirstCommitmentEvent,
+):CharacterBondsState{
+  const current=bonds[event.character];
+  if(current.memories.includes(event.memory))return bonds;
+  return {...bonds,[event.character]:{...current,trust:current.trust+3,memories:[...current.memories,event.memory]}};
 }


### PR DESCRIPTION
## Baseline
`integration/v3@46faf9031a86ff09d92cc17ee043e9180414d510`

## Scope — GREEN
01 Spring Raising only:
- [x] Affinity evidence scoring
- [x] per-campaign/per-source cap
- [x] Path Convergence: deterministic 2 candidates + eligible close third; behavioral rationale only, no raw affinity exposure
- [x] Campaign commit + replay lock
- [x] one-shot First Commitment domain event before Summer
- [x] representative Character Bond trust/memory effect + replay/hydration safety

## TDD / verification
- Initial RED: CI run #1486 failed only because `./spring-raising` did not exist; baseline 338 files / 1209 tests remained green.
- Final Spring targeted suite: `src/spring-raising.test.ts` — 5/5 GREEN.
- Final full suite: 339/339 files, 1214/1214 tests GREEN.
- `npm run build` GREEN; script is `tsc -b && vite build`.
- Production build: 189 modules transformed.
- Final CI run #1494 / job `test-build`: GREEN.

## Isolation
Compared to exact baseline: 9 commits ahead, 0 behind. Changed files only:
- `src/spring-raising.ts`
- `src/spring-raising.test.ts`
- `src/character-bonds.ts`

No shared `game*`, `save*`, `App*`, or `Root*` files were modified. No integration/main merge and no production deploy.

## [06 Integration Request]
1. Translate normal Spring runtime outcomes from training/dialogue/Bond/exploration/Tactical/Calling/Personality into `SpringAffinityEvidence` and feed them into this domain adapter at the deterministic convergence checkpoint.
2. Persist/consume returned existing `campaignRun` and `characterBonds` slices from the shared reducer; no new save field is required by this PR.
3. Path Convergence UI must render only candidate `tendency`/`reasons`, never raw `campaignAffinities` values.
