### PR TITLE
[Lane C] V3 Spring Season + State verification

### DIFF
--- a/docs/superpowers/plans/2026-08-22-v3-spring-seasonal-objectives.md
+++ b/docs/superpowers/plans/2026-08-22-v3-spring-seasonal-objectives.md
@@ -1,0 +1,79 @@
+# V3 Spring Campaign Seasonal Objectives Implementation Plan
+
+**Goal:** Add campaign-aware Spring/Summer Seasonal Objectives as a thin adapter over existing Season, Weekly Directive, World, Tactical, Bond, Relic, Astral, and Rift outcomes without adding a new daily/weekly chore loop.
+
+**Architecture:** Keep this wave self-contained in new pure Season-owned modules. Existing actions emit a normalized campaign-season signal; the adapter deterministically selects at most one matching objective per action. Objective completion emits a canonical season-scoped claim key and a Legacy hook payload. Persistence remains caller-owned; no shared save/game fields are added in 03. If persistent wiring is required, file a 06 Integration Request.
+
+**Baseline:** `integration/v3@46faf9031a86ff09d92cc17ee043e9180414d510`
+**Branch:** `work/v3-spring-season`
+
+## Constraints
+
+- Spring and Summer definitions only. No Autumn/Winter mainline implementation.
+- No second daily/weekly chore stack.
+- One existing action may advance at most one Seasonal Objective.
+- Rewards are season-scoped reward-once and remain claimed across week rollover/reload/re-entry.
+- Malformed campaign IDs, objective IDs, claim keys, and unsupported seasons are ignored/rejected safely.
+- Legacy/True support is contract-only. No True Campaign eligibility or story implementation.
+- Do not modify shared save/game/App/Root files.
+- Preserve existing Sanctuary/Astral/Celestial/Rift behavior by consuming their outcomes as signals only.
+- RED before production code; verify targeted Season tests, then full test and build (`build` includes TypeScript).
+- Push only to `work/v3-spring-season`; Draft PR targets `integration/v3`; do not merge.
+
+---
+
+### Task 1: Define adapter contracts and Spring/Summer sets
+
+**Files:**
+- Create: `src/campaign-seasonal-objectives.test.ts`
+- Create: `src/campaign-seasonal-objectives.ts`
+
+- [ ] RED: campaign IDs and Spring/Summer objective definitions cover Caretaker, Pathfinder, Vanguard, Arcanist.
+- [ ] RED: Autumn/Winter have no objective sets in this wave.
+- [ ] RED: Caretaker consumes Bond/rescue/protect/recovery signals.
+- [ ] RED: Pathfinder consumes Discovery/uncleared-region/action-limited exploration signals.
+- [ ] RED: Vanguard consumes Tactical challenge/streak/strong-opponent signals.
+- [ ] RED: Arcanist consumes Relic/Astral/Rift/status-combat signals.
+- [ ] Implement minimal typed definitions and signal adapter.
+
+### Task 2: Enforce single-objective action semantics
+
+**Files:**
+- Modify: `src/campaign-seasonal-objectives.test.ts`
+- Modify: `src/campaign-seasonal-objectives.ts`
+
+- [ ] RED: an action carrying multiple matching facts resolves to exactly one objective using stable definition priority.
+- [ ] RED: duplicate dispatch of the same action cannot fan out into another objective.
+- [ ] Implement deterministic first-match/single-result resolution; no aggregate multi-objective progress output.
+
+### Task 3: Reward-once and sanitation contracts
+
+**Files:**
+- Modify: `src/campaign-seasonal-objectives.test.ts`
+- Modify: `src/campaign-seasonal-objectives.ts`
+
+- [ ] RED: canonical claim keys are `year-season:campaign:objective` and use positive canonical years.
+- [ ] RED: claimed ledger blocks duplicate reward after reload/re-entry and duplicate action dispatch.
+- [ ] RED: week rollover does not reset season-scoped claims.
+- [ ] RED: malformed/unknown campaign IDs, objective IDs, noncanonical season keys, and malformed claim keys are rejected by hydration/sanitation helpers.
+- [ ] Implement pure claim-key validation/sanitation and reward-once resolver using caller-provided claimed keys.
+
+### Task 4: Legacy/True hook contract only
+
+**Files:**
+- Modify: `src/campaign-seasonal-objectives.test.ts`
+- Modify: `src/campaign-seasonal-objectives.ts`
+
+- [ ] RED: accepted objective completion emits a compact Legacy hook containing campaign, season key, objective, source domain, and optional True clue tag.
+- [ ] RED: duplicate/already-claimed completion emits no second reward/hook.
+- [ ] Ensure contract contains no True Campaign eligibility, path selection, state mutation, or story implementation.
+
+### Task 5: Regression and integration boundary
+
+- [ ] Run targeted Seasonal Objective tests.
+- [ ] Run existing Season/Weekly/Sanctuary/Astral/Celestial/Rift targeted suites.
+- [ ] Run full `npm run test`.
+- [ ] Run `npm run build` (TypeScript + Vite production build).
+- [ ] If persistent claim storage cannot be achieved without shared save/game changes, post a `[06 Integration Request]` on #58 with the exact minimal wiring contract.
+- [ ] Push candidate commits and create Draft PR against `integration/v3`.
+- [ ] Do not merge.

--- a/src/campaign-seasonal-claim-keys.ts
+++ b/src/campaign-seasonal-claim-keys.ts
@@ -1,0 +1,30 @@
+const campaignSeasonalObjectiveClaimTriples = new Set([
+  'spring:caretaker:spring_caretaker_bond',
+  'spring:caretaker:spring_caretaker_guardianship',
+  'spring:pathfinder:spring_pathfinder_discovery',
+  'spring:pathfinder:spring_pathfinder_frontier',
+  'spring:vanguard:spring_vanguard_challenge',
+  'spring:vanguard:spring_vanguard_streak',
+  'spring:arcanist:spring_arcanist_relic',
+  'spring:arcanist:spring_arcanist_resonance',
+  'summer:caretaker:summer_caretaker_rescue',
+  'summer:caretaker:summer_caretaker_recovery',
+  'summer:pathfinder:summer_pathfinder_uncharted',
+  'summer:pathfinder:summer_pathfinder_limited_route',
+  'summer:vanguard:summer_vanguard_elite',
+  'summer:vanguard:summer_vanguard_chain',
+  'summer:arcanist:summer_arcanist_rift',
+  'summer:arcanist:summer_arcanist_rule_shift',
+]);
+
+export function isValidCampaignSeasonalObjectiveClaimKey(value:unknown):value is string {
+  if(typeof value!=='string') return false;
+  const match=/^([1-9]\d*)-(spring|summer):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
+  if(!match) return false;
+  return campaignSeasonalObjectiveClaimTriples.has(`${match[2]}:${match[3]}:${match[4]}`);
+}
+
+export function sanitizeCampaignSeasonalObjectiveClaimKeys(raw:unknown):string[] {
+  if(!Array.isArray(raw)) return [];
+  return [...new Set(raw.filter(isValidCampaignSeasonalObjectiveClaimKey))];
+}

--- a/src/campaign-seasonal-objectives.test.ts
+++ b/src/campaign-seasonal-objectives.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  campaignSeasonalObjectiveSets,
+  campaignSeasonalObjectives,
+  isValidCampaignSeasonalObjectiveClaimKey,
+  resolveCampaignSeasonalObjective,
+  sanitizeCampaignId,
+  sanitizeCampaignSeasonalObjectiveClaimKeys,
+  sanitizeCampaignSeasonalObjectiveId,
+} from './campaign-seasonal-objectives';
+
+describe('campaign seasonal objectives', () => {
+  it('defines only Spring and Summer objective sets for all four main campaigns', () => {
+    expect(Object.keys(campaignSeasonalObjectiveSets).sort()).toEqual(['spring','summer']);
+    for (const season of ['spring','summer'] as const) {
+      expect(Object.keys(campaignSeasonalObjectiveSets[season]).sort()).toEqual([
+        'arcanist',
+        'caretaker',
+        'pathfinder',
+        'vanguard',
+      ]);
+      for (const campaign of ['caretaker','pathfinder','vanguard','arcanist'] as const) {
+        expect(campaignSeasonalObjectiveSets[season][campaign].length).toBeGreaterThanOrEqual(2);
+      }
+    }
+    expect(campaignSeasonalObjectives('autumn' as never,'caretaker')).toEqual([]);
+    expect(campaignSeasonalObjectives('winter' as never,'arcanist')).toEqual([]);
+  });
+
+  it.each([
+    ['caretaker','spring',['bond'],'spring_caretaker_bond'],
+    ['caretaker','summer',['rescue'],'summer_caretaker_rescue'],
+    ['caretaker','summer',['protect'],'summer_caretaker_rescue'],
+    ['caretaker','spring',['recovery'],'spring_caretaker_guardianship'],
+    ['pathfinder','spring',['discovery'],'spring_pathfinder_discovery'],
+    ['pathfinder','spring',['uncleared_region'],'spring_pathfinder_frontier'],
+    ['pathfinder','summer',['limited_exploration'],'summer_pathfinder_limited_route'],
+    ['vanguard','spring',['tactical_challenge'],'spring_vanguard_challenge'],
+    ['vanguard','spring',['strong_opponent'],'spring_vanguard_challenge'],
+    ['vanguard','summer',['win_streak'],'summer_vanguard_chain'],
+    ['arcanist','spring',['relic'],'spring_arcanist_relic'],
+    ['arcanist','spring',['status_combat'],'spring_arcanist_resonance'],
+    ['arcanist','summer',['astral'],'summer_arcanist_rift'],
+    ['arcanist','summer',['rift'],'summer_arcanist_rift'],
+  ] as const)('maps %s %s existing action signals to one objective', (campaign,season,signals,objectiveId) => {
+    const result = resolveCampaignSeasonalObjective({
+      year:1,
+      week:1,
+      season,
+      campaign,
+      signals:[...signals],
+      claimedKeys:[],
+    });
+    expect(result.accepted).toBe(true);
+    if (!result.accepted) return;
+    expect(result.objective.id).toBe(objectiveId);
+    expect(result.claimKey).toBe(`1-${season}:${campaign}:${objectiveId}`);
+  });
+
+  it('lets one action resolve at most one objective even when it carries several matching facts', () => {
+    const first = resolveCampaignSeasonalObjective({
+      year:1,
+      week:1,
+      season:'summer',
+      campaign:'caretaker',
+      signals:['rescue','protect','recovery','bond'],
+      claimedKeys:[],
+    });
+    expect(first.accepted).toBe(true);
+    if (!first.accepted) return;
+    expect(first.objective.id).toBe('summer_caretaker_rescue');
+
+    const duplicate = resolveCampaignSeasonalObjective({
+      year:1,
+      week:1,
+      season:'summer',
+      campaign:'caretaker',
+      signals:['rescue','protect','recovery','bond'],
+      claimedKeys:[first.claimKey],
+    });
+    expect(duplicate).toEqual(expect.objectContaining({ accepted:false, reason:'already_claimed' }));
+  });
+
+  it('keeps rewards claimed across reload and weekly rollover because claims are season scoped', () => {
+    const first = resolveCampaignSeasonalObjective({
+      year:2,
+      week:1,
+      season:'spring',
+      campaign:'pathfinder',
+      signals:['discovery'],
+      claimedKeys:[],
+    });
+    expect(first.accepted).toBe(true);
+    if (!first.accepted) return;
+
+    const hydratedClaims = sanitizeCampaignSeasonalObjectiveClaimKeys([
+      first.claimKey,
+      first.claimKey,
+      'bad',
+    ]);
+    const afterReload = resolveCampaignSeasonalObjective({
+      year:2,
+      week:1,
+      season:'spring',
+      campaign:'pathfinder',
+      signals:['discovery'],
+      claimedKeys:hydratedClaims,
+    });
+    const nextWeek = resolveCampaignSeasonalObjective({
+      year:2,
+      week:2,
+      season:'spring',
+      campaign:'pathfinder',
+      signals:['discovery'],
+      claimedKeys:hydratedClaims,
+    });
+
+    expect(hydratedClaims).toEqual([first.claimKey]);
+    expect(afterReload).toEqual(expect.objectContaining({ accepted:false, reason:'already_claimed' }));
+    expect(nextWeek).toEqual(expect.objectContaining({ accepted:false, reason:'already_claimed' }));
+  });
+
+  it('sanitizes malformed Campaign, Objective, and claim IDs without aliasing noncanonical values', () => {
+    expect(sanitizeCampaignId('caretaker')).toBe('caretaker');
+    expect(sanitizeCampaignId('Caretaker')).toBeNull();
+    expect(sanitizeCampaignId('true_path')).toBeNull();
+    expect(sanitizeCampaignId('retired_campaign')).toBeNull();
+
+    expect(sanitizeCampaignSeasonalObjectiveId('spring_caretaker_bond')).toBe('spring_caretaker_bond');
+    expect(sanitizeCampaignSeasonalObjectiveId('retired_objective')).toBeNull();
+
+    expect(isValidCampaignSeasonalObjectiveClaimKey('1-spring:caretaker:spring_caretaker_bond')).toBe(true);
+    expect(isValidCampaignSeasonalObjectiveClaimKey('01-spring:caretaker:spring_caretaker_bond')).toBe(false);
+    expect(isValidCampaignSeasonalObjectiveClaimKey('1-autumn:caretaker:spring_caretaker_bond')).toBe(false);
+    expect(isValidCampaignSeasonalObjectiveClaimKey('1-spring:true_path:spring_caretaker_bond')).toBe(false);
+    expect(isValidCampaignSeasonalObjectiveClaimKey('1-spring:caretaker:retired_objective')).toBe(false);
+  });
+
+  it('emits a Legacy-compatible campaign result hook without implementing True Campaign clues', () => {
+    const result = resolveCampaignSeasonalObjective({
+      year:1,
+      week:3,
+      season:'summer',
+      campaign:'arcanist',
+      signals:['rift','status_combat'],
+      claimedKeys:[],
+    });
+    expect(result.accepted).toBe(true);
+    if (!result.accepted) return;
+
+    expect(result.legacyHook).toEqual({
+      kind:'campaign_seasonal_objective',
+      campaignResult:{
+        campaignId:'arcanist',
+        seasonKey:'1-summer',
+        objectiveId:'summer_arcanist_rift',
+        sourceDomain:'rift',
+      },
+      trueClue:undefined,
+    });
+  });
+
+  it('does not mutate or require Sanctuary/Astral/Celestial/Rift state to interpret Arcanist signals', () => {
+    const astral = resolveCampaignSeasonalObjective({
+      year:1,
+      week:2,
+      season:'summer',
+      campaign:'arcanist',
+      signals:['astral'],
+      claimedKeys:[],
+    });
+    expect(astral.accepted).toBe(true);
+    if (!astral.accepted) return;
+    expect(astral.objective.id).toBe('summer_arcanist_rift');
+    expect(Object.keys(astral)).not.toContain('sanctuaryState');
+    expect(Object.keys(astral)).not.toContain('astralState');
+    expect(Object.keys(astral)).not.toContain('celestialState');
+    expect(Object.keys(astral)).not.toContain('riftState');
+  });
+});

--- a/src/campaign-seasonal-objectives.ts
+++ b/src/campaign-seasonal-objectives.ts
@@ -1,4 +1,5 @@
 import { mainCampaignIds, type MainCampaignId } from './campaign-model';
+import type { TrueClueId } from './legacy-state';
 import type { SeasonId } from './seasonal-cycle';
 
 export type CampaignSeasonalObjectiveSeason = 'spring'|'summer';
@@ -61,10 +62,7 @@ export type CampaignSeasonalLegacyHook = {
     objectiveId:CampaignSeasonalObjectiveId;
     sourceDomain:CampaignSeasonalSignalKind;
   };
-  trueClue:undefined|{
-    clueId:string;
-    domain:'season';
-  };
+  trueClue:TrueClueId|undefined;
 };
 
 const signalKinds = [

--- a/src/campaign-seasonal-objectives.ts
+++ b/src/campaign-seasonal-objectives.ts
@@ -1,0 +1,227 @@
+import { mainCampaignIds, type MainCampaignId } from './campaign-model';
+import type { SeasonId } from './seasonal-cycle';
+
+export type CampaignSeasonalObjectiveSeason = 'spring'|'summer';
+export type CampaignSeasonalSignalKind =
+  | 'bond'
+  | 'rescue'
+  | 'protect'
+  | 'recovery'
+  | 'discovery'
+  | 'uncleared_region'
+  | 'limited_exploration'
+  | 'tactical_challenge'
+  | 'win_streak'
+  | 'strong_opponent'
+  | 'relic'
+  | 'astral'
+  | 'rift'
+  | 'status_combat';
+
+export const campaignSeasonalObjectiveIds = [
+  'spring_caretaker_bond',
+  'spring_caretaker_guardianship',
+  'spring_pathfinder_discovery',
+  'spring_pathfinder_frontier',
+  'spring_vanguard_challenge',
+  'spring_vanguard_streak',
+  'spring_arcanist_relic',
+  'spring_arcanist_resonance',
+  'summer_caretaker_rescue',
+  'summer_caretaker_recovery',
+  'summer_pathfinder_uncharted',
+  'summer_pathfinder_limited_route',
+  'summer_vanguard_elite',
+  'summer_vanguard_chain',
+  'summer_arcanist_rift',
+  'summer_arcanist_rule_shift',
+] as const;
+
+export type CampaignSeasonalObjectiveId = typeof campaignSeasonalObjectiveIds[number];
+
+export type CampaignSeasonalObjectiveReward = {
+  kind:'campaign_memory';
+  memoryId:`${CampaignSeasonalObjectiveId}_memory`;
+};
+
+export type CampaignSeasonalObjectiveDefinition = {
+  id:CampaignSeasonalObjectiveId;
+  season:CampaignSeasonalObjectiveSeason;
+  campaign:MainCampaignId;
+  label:string;
+  signals:readonly CampaignSeasonalSignalKind[];
+  reward:CampaignSeasonalObjectiveReward;
+};
+
+export type CampaignSeasonalLegacyHook = {
+  kind:'campaign_seasonal_objective';
+  campaignResult:{
+    campaignId:MainCampaignId;
+    seasonKey:`${number}-${CampaignSeasonalObjectiveSeason}`;
+    objectiveId:CampaignSeasonalObjectiveId;
+    sourceDomain:CampaignSeasonalSignalKind;
+  };
+  trueClue:undefined|{
+    clueId:string;
+    domain:'season';
+  };
+};
+
+const signalKinds = [
+  'bond','rescue','protect','recovery',
+  'discovery','uncleared_region','limited_exploration',
+  'tactical_challenge','win_streak','strong_opponent',
+  'relic','astral','rift','status_combat',
+] as const satisfies readonly CampaignSeasonalSignalKind[];
+
+const mainCampaignIdSet = new Set<string>(mainCampaignIds);
+const objectiveIdSet = new Set<string>(campaignSeasonalObjectiveIds);
+const signalKindSet = new Set<string>(signalKinds);
+
+function objective(
+  id:CampaignSeasonalObjectiveId,
+  season:CampaignSeasonalObjectiveSeason,
+  campaign:MainCampaignId,
+  label:string,
+  signals:readonly CampaignSeasonalSignalKind[],
+):CampaignSeasonalObjectiveDefinition {
+  return { id, season, campaign, label, signals, reward:{ kind:'campaign_memory', memoryId:`${id}_memory` } };
+}
+
+export const campaignSeasonalObjectiveSets:Record<CampaignSeasonalObjectiveSeason,Record<MainCampaignId,readonly CampaignSeasonalObjectiveDefinition[]>> = {
+  spring:{
+    caretaker:[
+      objective('spring_caretaker_bond','spring','caretaker','마음을 지키는 약속',['bond']),
+      objective('spring_caretaker_guardianship','spring','caretaker','돌봄의 첫 선택',['rescue','protect','recovery']),
+    ],
+    pathfinder:[
+      objective('spring_pathfinder_discovery','spring','pathfinder','지도 밖의 발견',['discovery']),
+      objective('spring_pathfinder_frontier','spring','pathfinder','미답의 경계',['uncleared_region','limited_exploration']),
+    ],
+    vanguard:[
+      objective('spring_vanguard_challenge','spring','vanguard','강자에게 맞서기',['tactical_challenge','strong_opponent']),
+      objective('spring_vanguard_streak','spring','vanguard','흐름을 이어가기',['win_streak']),
+    ],
+    arcanist:[
+      objective('spring_arcanist_relic','spring','arcanist','유물의 첫 공명',['relic']),
+      objective('spring_arcanist_resonance','spring','arcanist','별빛 규칙 읽기',['astral','status_combat','rift']),
+    ],
+  },
+  summer:{
+    caretaker:[
+      objective('summer_caretaker_rescue','summer','caretaker','위기 속 보호',['rescue','protect']),
+      objective('summer_caretaker_recovery','summer','caretaker','다시 일어설 자리',['recovery','bond']),
+    ],
+    pathfinder:[
+      objective('summer_pathfinder_uncharted','summer','pathfinder','금지된 좌표',['discovery','uncleared_region']),
+      objective('summer_pathfinder_limited_route','summer','pathfinder','제한된 행동으로 길 찾기',['limited_exploration']),
+    ],
+    vanguard:[
+      objective('summer_vanguard_elite','summer','vanguard','강적 격파',['strong_opponent']),
+      objective('summer_vanguard_chain','summer','vanguard','연전의 압박',['win_streak','tactical_challenge']),
+    ],
+    arcanist:[
+      objective('summer_arcanist_rift','summer','arcanist','균열의 공명',['rift','astral']),
+      objective('summer_arcanist_rule_shift','summer','arcanist','바뀐 규칙을 이용하기',['status_combat','relic']),
+    ],
+  },
+};
+
+export function sanitizeCampaignId(value:unknown):MainCampaignId|null {
+  return typeof value === 'string' && mainCampaignIdSet.has(value) ? value as MainCampaignId : null;
+}
+
+export function sanitizeCampaignSeasonalObjectiveId(value:unknown):CampaignSeasonalObjectiveId|null {
+  return typeof value === 'string' && objectiveIdSet.has(value) ? value as CampaignSeasonalObjectiveId : null;
+}
+
+function sanitizeObjectiveSeason(value:unknown):CampaignSeasonalObjectiveSeason|null {
+  return value === 'spring' || value === 'summer' ? value : null;
+}
+
+function sanitizeSignals(raw:unknown):CampaignSeasonalSignalKind[] {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.filter((value):value is CampaignSeasonalSignalKind => typeof value === 'string' && signalKindSet.has(value)))];
+}
+
+function canonicalYear(value:unknown):number|null {
+  return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value) && value >= 1 ? value : null;
+}
+
+function validWeek(value:unknown):boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 4;
+}
+
+export function campaignSeasonalObjectives(season:SeasonId,campaign:MainCampaignId):readonly CampaignSeasonalObjectiveDefinition[] {
+  const objectiveSeason = sanitizeObjectiveSeason(season);
+  return objectiveSeason ? campaignSeasonalObjectiveSets[objectiveSeason][campaign] : [];
+}
+
+function definitionFor(
+  season:CampaignSeasonalObjectiveSeason,
+  campaign:MainCampaignId,
+  objectiveId:CampaignSeasonalObjectiveId,
+):CampaignSeasonalObjectiveDefinition|null {
+  return campaignSeasonalObjectiveSets[season][campaign].find(objective => objective.id === objectiveId) ?? null;
+}
+
+export function isValidCampaignSeasonalObjectiveClaimKey(value:string):boolean {
+  const match = /^([1-9]\d*)-(spring|summer):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
+  if (!match) return false;
+  const season = match[2] as CampaignSeasonalObjectiveSeason;
+  const campaign = sanitizeCampaignId(match[3]);
+  const objectiveId = sanitizeCampaignSeasonalObjectiveId(match[4]);
+  return Boolean(campaign && objectiveId && definitionFor(season,campaign,objectiveId));
+}
+
+export function sanitizeCampaignSeasonalObjectiveClaimKeys(raw:unknown):string[] {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.filter((value):value is string => typeof value === 'string' && isValidCampaignSeasonalObjectiveClaimKey(value)))];
+}
+
+export function resolveCampaignSeasonalObjective(input:{
+  year:unknown;
+  week:unknown;
+  season:unknown;
+  campaign:unknown;
+  signals:unknown;
+  claimedKeys:unknown;
+}) {
+  const year = canonicalYear(input.year);
+  const season = sanitizeObjectiveSeason(input.season);
+  const campaign = sanitizeCampaignId(input.campaign);
+  if (!year || !season || !campaign || !validWeek(input.week)) {
+    return { accepted:false as const, reason:'invalid_context' as const };
+  }
+
+  const signals = sanitizeSignals(input.signals);
+  const objective = campaignSeasonalObjectiveSets[season][campaign]
+    .find(candidate => candidate.signals.some(signal => signals.includes(signal)));
+  if (!objective) return { accepted:false as const, reason:'no_match' as const };
+
+  const claimKey = `${year}-${season}:${campaign}:${objective.id}` as const;
+  const claimedKeys = sanitizeCampaignSeasonalObjectiveClaimKeys(input.claimedKeys);
+  if (claimedKeys.includes(claimKey)) {
+    return { accepted:false as const, reason:'already_claimed' as const, objective, claimKey };
+  }
+
+  const sourceDomain = signals.find(signal => objective.signals.includes(signal))!;
+  const legacyHook:CampaignSeasonalLegacyHook = {
+    kind:'campaign_seasonal_objective',
+    campaignResult:{
+      campaignId:campaign,
+      seasonKey:`${year}-${season}`,
+      objectiveId:objective.id,
+      sourceDomain,
+    },
+    trueClue:undefined,
+  };
+
+  return {
+    accepted:true as const,
+    objective,
+    claimKey,
+    reward:objective.reward,
+    legacyHook,
+  };
+}

--- a/src/campaign-state.ts
+++ b/src/campaign-state.ts
@@ -19,6 +19,7 @@ import {
   type MajorEventId,
   type MajorOutcomeResult,
 } from './campaign-model';
+import {sanitizeCampaignSeasonalObjectiveClaimKeys} from './campaign-seasonal-claim-keys';
 import {isV3Record,safeNonNegativeInt,safePositiveInt,uniqueRegistered} from './v3-state-sanitize';
 
 export type CampaignRunState={
@@ -33,6 +34,7 @@ export type CampaignRunState={
   majorOutcomes:Partial<Record<MajorEventId,MajorOutcomeResult>>;
   failForwardOutcomes:MajorEventId[];
   claimedCampaignRewards:CampaignMilestoneId[];
+  claimedSeasonalObjectives:string[];
 };
 
 export function emptyCampaignRunState():CampaignRunState{
@@ -48,6 +50,7 @@ export function emptyCampaignRunState():CampaignRunState{
     majorOutcomes:{},
     failForwardOutcomes:[],
     claimedCampaignRewards:[],
+    claimedSeasonalObjectives:[],
   };
 }
 
@@ -103,5 +106,6 @@ export function hydrateCampaignRunState(raw:unknown):CampaignRunState{
     majorOutcomes,
     failForwardOutcomes:uniqueRegistered(source.failForwardOutcomes,majorEventIds),
     claimedCampaignRewards:uniqueRegistered(source.claimedCampaignRewards,campaignMilestoneIds),
+    claimedSeasonalObjectives:sanitizeCampaignSeasonalObjectiveClaimKeys(source.claimedSeasonalObjectives),
   };
 }

--- a/src/v3-spring-season-state-lane.test.ts
+++ b/src/v3-spring-season-state-lane.test.ts
@@ -1,0 +1,86 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCampaignRunState,hydrateCampaignRunState} from './campaign-state';
+import {resolveCampaignSeasonalObjective} from './campaign-seasonal-objectives';
+import {emptyV3PersistentState,hydrateV3PersistentState,prepareNewRunState} from './v3-persistent-state';
+
+const claimKey='1-spring:caretaker:spring_caretaker_bond';
+
+describe('V3 Spring Lane C season/state vertical slice',()=>{
+  it('stores Seasonal Objective claims in a dedicated CampaignRun ledger',()=>{
+    expect(emptyCampaignRunState().claimedSeasonalObjectives).toEqual([]);
+    expect(hydrateCampaignRunState({
+      claimedSeasonalObjectives:[claimKey,claimKey,'bad','01-spring:caretaker:spring_caretaker_bond'],
+    }).claimedSeasonalObjectives).toEqual([claimKey]);
+  });
+
+  it('keeps one-action/one-objective reward-once across save, load, reload and week rollover',()=>{
+    const initial=emptyV3PersistentState();
+    const first=resolveCampaignSeasonalObjective({
+      year:1,
+      week:1,
+      season:'spring',
+      campaign:'caretaker',
+      signals:['bond','rescue','protect','recovery'],
+      claimedKeys:initial.campaignRun.claimedSeasonalObjectives,
+    });
+    expect(first.accepted).toBe(true);
+    if(!first.accepted)return;
+    expect(first.objective.id).toBe('spring_caretaker_bond');
+
+    const saved={
+      ...initial,
+      campaignRun:{
+        ...initial.campaignRun,
+        claimedSeasonalObjectives:[...initial.campaignRun.claimedSeasonalObjectives,first.claimKey],
+      },
+    };
+    const loaded=hydrateV3PersistentState(JSON.parse(JSON.stringify(saved)));
+    const reloaded=hydrateV3PersistentState(JSON.parse(JSON.stringify(loaded)));
+
+    expect(reloaded).toEqual(loaded);
+    expect(reloaded.campaignRun.claimedSeasonalObjectives).toEqual([first.claimKey]);
+
+    const nextWeek=resolveCampaignSeasonalObjective({
+      year:1,
+      week:2,
+      season:'spring',
+      campaign:'caretaker',
+      signals:['bond','rescue','protect','recovery'],
+      claimedKeys:reloaded.campaignRun.claimedSeasonalObjectives,
+    });
+    expect(nextWeek).toEqual(expect.objectContaining({accepted:false,reason:'already_claimed'}));
+  });
+
+  it('resets the dedicated claim ledger on a new run without mutating Legacy',()=>{
+    const current={
+      ...emptyV3PersistentState(),
+      campaignRun:{...emptyCampaignRunState(),claimedSeasonalObjectives:[claimKey]},
+    };
+    const next=prepareNewRunState(current);
+    expect(next.campaignRun.claimedSeasonalObjectives).toEqual([]);
+    expect(next.legacy).toEqual(current.legacy);
+  });
+
+  it('emits only the Legacy hook contract and does not implement True Campaign',()=>{
+    const result=resolveCampaignSeasonalObjective({
+      year:1,
+      week:3,
+      season:'spring',
+      campaign:'caretaker',
+      signals:['bond'],
+      claimedKeys:[],
+    });
+    expect(result.accepted).toBe(true);
+    if(!result.accepted)return;
+    expect(result.legacyHook).toEqual({
+      kind:'campaign_seasonal_objective',
+      campaignResult:{
+        campaignId:'caretaker',
+        seasonKey:'1-spring',
+        objectiveId:'spring_caretaker_bond',
+        sourceDomain:'bond',
+      },
+      trueClue:undefined,
+    });
+  });
+});

--- a/src/v3-spring-season-state-lane.test.ts
+++ b/src/v3-spring-season-state-lane.test.ts
@@ -1,6 +1,10 @@
 import {describe,expect,it} from 'vitest';
 import {emptyCampaignRunState,hydrateCampaignRunState} from './campaign-state';
-import {resolveCampaignSeasonalObjective} from './campaign-seasonal-objectives';
+import {
+  resolveCampaignSeasonalObjective,
+  sanitizeCampaignSeasonalObjectiveClaimKeys as sanitizeObjectiveClaimKeysFromAdapter,
+} from './campaign-seasonal-objectives';
+import {sanitizeCampaignSeasonalObjectiveClaimKeys as sanitizeObjectiveClaimKeysFromState} from './campaign-seasonal-claim-keys';
 import {emptyV3PersistentState,hydrateV3PersistentState,prepareNewRunState} from './v3-persistent-state';
 
 const claimKey='1-spring:caretaker:spring_caretaker_bond';
@@ -11,6 +15,22 @@ describe('V3 Spring Lane C season/state vertical slice',()=>{
     expect(hydrateCampaignRunState({
       claimedSeasonalObjectives:[claimKey,claimKey,'bad','01-spring:caretaker:spring_caretaker_bond'],
     }).claimedSeasonalObjectives).toEqual([claimKey]);
+  });
+
+  it('keeps adapter and persistent claim sanitizers in lockstep',()=>{
+    const raw=[
+      claimKey,
+      claimKey,
+      '2-summer:arcanist:summer_arcanist_rift',
+      '0-spring:caretaker:spring_caretaker_bond',
+      '01-spring:caretaker:spring_caretaker_bond',
+      '1-winter:caretaker:spring_caretaker_bond',
+      '1-spring:vanguard:spring_caretaker_bond',
+      '1-spring:caretaker:stale_objective',
+      7,
+      null,
+    ];
+    expect(sanitizeObjectiveClaimKeysFromState(raw)).toEqual(sanitizeObjectiveClaimKeysFromAdapter(raw));
   });
 
   it('keeps one-action/one-objective reward-once across save, load, reload and week rollover',()=>{

--- a/src/v3-spring-shared-state.test.ts
+++ b/src/v3-spring-shared-state.test.ts
@@ -1,0 +1,62 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCampaignRunState,hydrateCampaignRunState} from './campaign-state';
+import {initialState,type GameState} from './game';
+import {createSaveEnvelope,inspectSavedGame,serializeSavedGame} from './save-schema';
+import {prepareNewRunState} from './v3-persistent-state';
+
+const validSpringClaim='1-spring:vanguard:spring_vanguard_challenge';
+const validSummerClaim='2-summer:caretaker:summer_caretaker_rescue';
+
+describe('V3 Spring shared seasonal objective persistence',()=>{
+  it('defaults the dedicated claim ledger and canonicalizes duplicate, malformed, stale and mismatched keys',()=>{
+    expect((emptyCampaignRunState() as any).claimedSeasonalObjectives).toEqual([]);
+
+    const hydrated=hydrateCampaignRunState({
+      claimedSeasonalObjectives:[
+        validSpringClaim,
+        validSpringClaim,
+        validSummerClaim,
+        '0-spring:vanguard:spring_vanguard_challenge',
+        '1-winter:vanguard:spring_vanguard_challenge',
+        '1-spring:caretaker:spring_vanguard_challenge',
+        '1-spring:vanguard:stale_objective',
+        42,
+        null,
+      ],
+    }) as any;
+
+    expect(hydrated.claimedSeasonalObjectives).toEqual([validSpringClaim,validSummerClaim]);
+  });
+
+  it('round-trips the ledger through schema v3 save/load idempotently',()=>{
+    const state={
+      ...initialState,
+      campaignRun:{...initialState.campaignRun,claimedSeasonalObjectives:[validSpringClaim]},
+    } as GameState;
+
+    const first=inspectSavedGame(serializeSavedGame(state));
+    expect(first.status).toBe('valid');
+    expect(first.schemaVersion).toBe(3);
+    expect((first.state.campaignRun as any).claimedSeasonalObjectives).toEqual([validSpringClaim]);
+
+    const second=inspectSavedGame(serializeSavedGame(first.state));
+    expect(second.status).toBe('valid');
+    expect(second.state).toEqual(first.state);
+  });
+
+  it('starts V2 migration empty and resets the ledger with CampaignRunState on a new run',()=>{
+    const legacyV2State={...initialState,campaignRun:{...initialState.campaignRun}};
+    const v2Envelope={...createSaveEnvelope(legacyV2State),schemaVersion:2};
+    const migrated=inspectSavedGame(JSON.stringify(v2Envelope));
+    expect(migrated.status).toBe('migrated-v2');
+    expect((migrated.state.campaignRun as any).claimedSeasonalObjectives).toEqual([]);
+
+    const current={
+      ...initialState,
+      campaignRun:{...initialState.campaignRun,claimedSeasonalObjectives:[validSpringClaim]},
+    } as GameState;
+    const nextRun=prepareNewRunState(current);
+    expect((nextRun.campaignRun as any).claimedSeasonalObjectives).toEqual([]);
+    expect(nextRun.legacy).toEqual(current.legacy);
+  });
+});


### PR DESCRIPTION
Parent: #76

Verification-only Lane C branch for the composed Spring Season/State vertical slice.

Composed:
- PR #64 Seasonal Objective / one-action-one-objective / reward-once adapter candidate
- 06 `work/v3-spring-shared-state` dedicated `campaignRun.claimedSeasonalObjectives` persistence patch
- Lane C save/load/reload/idempotency E2E contract
- adapter/shared-state claim sanitizer parity regression

Lane scope verified GREEN:
- Campaign-aware Seasonal Objective adapter
- deterministic one-action -> one-objective
- reward-once through dedicated claim ledger
- malformed/duplicate claim hydration sanitation
- schema v3 save/load/reload idempotency
- week rollover preserves claim and blocks duplicate reward
- new run resets claim ledger
- Legacy hook contract only; no True Campaign implementation
- Sanctuary/Astral/Celestial/Rift regressions remain GREEN

RED evidence before shared-state composition:
- 339 existing files / 1230 existing tests GREEN
- only 3 Lane C tests failed, all because `claimedSeasonalObjectives` was absent

Final verification on head `930e5fb8432e0b494cc715f2d4501b506be4b937` / PR merge ref `0efb2ff439f8fa1fc29b76b340de6ff634403e77`:
- 341/341 test files GREEN
- 1237/1237 tests GREEN
- `src/v3-spring-season-state-lane.test.ts`: 5/5 GREEN
- `src/v3-spring-shared-state.test.ts`: 3/3 GREEN
- `npm run build` GREEN (`tsc -b && vite build`)

Lane C #76 is GREEN. Keep this PR Draft/verification-only. Do not merge integration/v3 here. main/prod untouched. No next Wave opened.