### PR TITLE
[06] V3 Spring shared seasonal objective persistence

### DIFF
--- a/src/campaign-seasonal-claim-keys.ts
+++ b/src/campaign-seasonal-claim-keys.ts
@@ -1,0 +1,30 @@
+const campaignSeasonalObjectiveClaimTriples = new Set([
+  'spring:caretaker:spring_caretaker_bond',
+  'spring:caretaker:spring_caretaker_guardianship',
+  'spring:pathfinder:spring_pathfinder_discovery',
+  'spring:pathfinder:spring_pathfinder_frontier',
+  'spring:vanguard:spring_vanguard_challenge',
+  'spring:vanguard:spring_vanguard_streak',
+  'spring:arcanist:spring_arcanist_relic',
+  'spring:arcanist:spring_arcanist_resonance',
+  'summer:caretaker:summer_caretaker_rescue',
+  'summer:caretaker:summer_caretaker_recovery',
+  'summer:pathfinder:summer_pathfinder_uncharted',
+  'summer:pathfinder:summer_pathfinder_limited_route',
+  'summer:vanguard:summer_vanguard_elite',
+  'summer:vanguard:summer_vanguard_chain',
+  'summer:arcanist:summer_arcanist_rift',
+  'summer:arcanist:summer_arcanist_rule_shift',
+]);
+
+export function isValidCampaignSeasonalObjectiveClaimKey(value:unknown):value is string {
+  if(typeof value!=='string') return false;
+  const match=/^([1-9]\d*)-(spring|summer):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
+  if(!match) return false;
+  return campaignSeasonalObjectiveClaimTriples.has(`${match[2]}:${match[3]}:${match[4]}`);
+}
+
+export function sanitizeCampaignSeasonalObjectiveClaimKeys(raw:unknown):string[] {
+  if(!Array.isArray(raw)) return [];
+  return [...new Set(raw.filter(isValidCampaignSeasonalObjectiveClaimKey))];
+}

--- a/src/campaign-state.ts
+++ b/src/campaign-state.ts
@@ -19,6 +19,7 @@ import {
   type MajorEventId,
   type MajorOutcomeResult,
 } from './campaign-model';
+import {sanitizeCampaignSeasonalObjectiveClaimKeys} from './campaign-seasonal-claim-keys';
 import {isV3Record,safeNonNegativeInt,safePositiveInt,uniqueRegistered} from './v3-state-sanitize';
 
 export type CampaignRunState={
@@ -33,6 +34,7 @@ export type CampaignRunState={
   majorOutcomes:Partial<Record<MajorEventId,MajorOutcomeResult>>;
   failForwardOutcomes:MajorEventId[];
   claimedCampaignRewards:CampaignMilestoneId[];
+  claimedSeasonalObjectives:string[];
 };
 
 export function emptyCampaignRunState():CampaignRunState{
@@ -48,6 +50,7 @@ export function emptyCampaignRunState():CampaignRunState{
     majorOutcomes:{},
     failForwardOutcomes:[],
     claimedCampaignRewards:[],
+    claimedSeasonalObjectives:[],
   };
 }
 
@@ -103,5 +106,6 @@ export function hydrateCampaignRunState(raw:unknown):CampaignRunState{
     majorOutcomes,
     failForwardOutcomes:uniqueRegistered(source.failForwardOutcomes,majorEventIds),
     claimedCampaignRewards:uniqueRegistered(source.claimedCampaignRewards,campaignMilestoneIds),
+    claimedSeasonalObjectives:sanitizeCampaignSeasonalObjectiveClaimKeys(source.claimedSeasonalObjectives),
   };
 }

--- a/src/v3-spring-shared-state.test.ts
+++ b/src/v3-spring-shared-state.test.ts
@@ -1,0 +1,62 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCampaignRunState,hydrateCampaignRunState} from './campaign-state';
+import {initialState,type GameState} from './game';
+import {createSaveEnvelope,inspectSavedGame,serializeSavedGame} from './save-schema';
+import {prepareNewRunState} from './v3-persistent-state';
+
+const validSpringClaim='1-spring:vanguard:spring_vanguard_challenge';
+const validSummerClaim='2-summer:caretaker:summer_caretaker_rescue';
+
+describe('V3 Spring shared seasonal objective persistence',()=>{
+  it('defaults the dedicated claim ledger and canonicalizes duplicate, malformed, stale and mismatched keys',()=>{
+    expect((emptyCampaignRunState() as any).claimedSeasonalObjectives).toEqual([]);
+
+    const hydrated=hydrateCampaignRunState({
+      claimedSeasonalObjectives:[
+        validSpringClaim,
+        validSpringClaim,
+        validSummerClaim,
+        '0-spring:vanguard:spring_vanguard_challenge',
+        '1-winter:vanguard:spring_vanguard_challenge',
+        '1-spring:caretaker:spring_vanguard_challenge',
+        '1-spring:vanguard:stale_objective',
+        42,
+        null,
+      ],
+    }) as any;
+
+    expect(hydrated.claimedSeasonalObjectives).toEqual([validSpringClaim,validSummerClaim]);
+  });
+
+  it('round-trips the ledger through schema v3 save/load idempotently',()=>{
+    const state={
+      ...initialState,
+      campaignRun:{...initialState.campaignRun,claimedSeasonalObjectives:[validSpringClaim]},
+    } as GameState;
+
+    const first=inspectSavedGame(serializeSavedGame(state));
+    expect(first.status).toBe('valid');
+    expect(first.schemaVersion).toBe(3);
+    expect((first.state.campaignRun as any).claimedSeasonalObjectives).toEqual([validSpringClaim]);
+
+    const second=inspectSavedGame(serializeSavedGame(first.state));
+    expect(second.status).toBe('valid');
+    expect(second.state).toEqual(first.state);
+  });
+
+  it('starts V2 migration empty and resets the ledger with CampaignRunState on a new run',()=>{
+    const legacyV2State={...initialState,campaignRun:{...initialState.campaignRun}};
+    const v2Envelope={...createSaveEnvelope(legacyV2State),schemaVersion:2};
+    const migrated=inspectSavedGame(JSON.stringify(v2Envelope));
+    expect(migrated.status).toBe('migrated-v2');
+    expect((migrated.state.campaignRun as any).claimedSeasonalObjectives).toEqual([]);
+
+    const current={
+      ...initialState,
+      campaignRun:{...initialState.campaignRun,claimedSeasonalObjectives:[validSpringClaim]},
+    } as GameState;
+    const nextRun=prepareNewRunState(current);
+    expect((nextRun.campaignRun as any).claimedSeasonalObjectives).toEqual([]);
+    expect(nextRun.legacy).toEqual(current.legacy);
+  });
+});


### PR DESCRIPTION
06 shared-support only. Base remains integration/v3@46faf9031a86ff09d92cc17ee043e9180414d510 and must NOT move for this PR.

## Shared support head
- branch: `work/v3-spring-shared-state`
- head: `a46cdc423ee1841113e570e5799137f12bdea937`
- verified merge-ref: `4d4b74c9a734be87950f702b39f63468dae4e0e7`
- CI: #1525 / run 32548438154

## Scope
Exactly 3 files:
- `src/campaign-seasonal-claim-keys.ts`
- `src/campaign-state.ts`
- `src/v3-spring-shared-state.test.ts`

Provides only:
- dedicated `CampaignRunState.claimedSeasonalObjectives: string[]`
- default `[]`
- canonical malformed/stale/mismatched/duplicate claim-key sanitation
- nested V3 save/load idempotency with schema version remaining 3
- V2 migration starts with an empty ledger
- CampaignRunState new-run reset through the existing `prepareNewRunState`/`emptyCampaignRunState` path

No changes to `game.ts`, save-schema version/meaning, App/Root, feature runtime orchestration, Seasonal signal/reward/Legacy application, lane composition, Summer gameplay, main, or prod.

## Verification
Fresh CI #1525 on merge-ref `4d4b74c9...`:
- 339/339 test files GREEN
- 1212/1212 tests GREEN
- shared targeted suite 3/3 GREEN
- save-schema 10/10 GREEN
- save-resilience 8/8 GREEN
- Foundation overlap regression 4/4 GREEN
- Tactical stability 13/13 GREEN including 10/50/100 checkpoints
- `npm run build` = `tsc -b && vite build` GREEN
- Vite 190 modules transformed

## Lane C handoff
Lane C (03) should consume this exact shared head/contract and use `sanitizeCampaignSeasonalObjectiveClaimKeys` from `src/campaign-seasonal-claim-keys.ts` rather than creating a divergent second shared ledger sanitizer. Seasonal Objective signals, reward-once application, and Legacy hooks remain Lane C-owned runtime work.

Do NOT merge this PR directly into `integration/v3`; it is a shared support input for lane composition. 06 will only compose A/B/C after all three lanes are independently GREEN, then run the single final Spring gate. Summer/integration-v3/main/prod remain closed.