### PR TITLE
02 V3 Summer: Guardian Festival world identities

### DIFF
--- a/src/summer-campaign-world.test.ts
+++ b/src/summer-campaign-world.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { campaignWorldObjectives } from './campaign-world';
+import {
+  getSummerGuardianFestivalWorldRoute,
+  summerGuardianFestivalWorldRoutes,
+} from './summer-campaign-world';
+
+describe('Summer Guardian Festival world routes', () => {
+  it('defines four distinct campaign identities on existing World objectives', () => {
+    expect(summerGuardianFestivalWorldRoutes).toHaveLength(4);
+    expect(summerGuardianFestivalWorldRoutes.map(route => route.campaign)).toEqual([
+      'caretaker',
+      'pathfinder',
+      'vanguard',
+      'arcanist',
+    ]);
+    expect(new Set(summerGuardianFestivalWorldRoutes.map(route => route.identity)).size).toBe(4);
+
+    for (const route of summerGuardianFestivalWorldRoutes) {
+      const objective = campaignWorldObjectives.find(candidate => candidate.id === route.objectiveId);
+      expect(objective).toBeDefined();
+      expect(objective?.season).toBe('summer');
+      expect(objective?.campaign).toBe(route.campaign);
+      expect(objective?.regionId).toBe(route.regionId);
+      expect(objective?.stageIds).toContain(route.stageId);
+      expect(route.failForward).toBe(true);
+    }
+  });
+
+  it('keeps the four World gameplay identities intentionally different', () => {
+    expect(getSummerGuardianFestivalWorldRoute('caretaker')).toMatchObject({
+      identity: 'rescue_protection',
+      objectiveId: 'summer_caretaker_festival_rescue',
+      stageId: 'forest_guardian',
+      pressure: 'civilian_survival',
+    });
+    expect(getSummerGuardianFestivalWorldRoute('pathfinder')).toMatchObject({
+      identity: 'hidden_route_escape',
+      objectiveId: 'summer_pathfinder_festival_routes',
+      stageId: 'city_gallery',
+      pressure: 'escape_traversal',
+    });
+    expect(getSummerGuardianFestivalWorldRoute('vanguard')).toMatchObject({
+      identity: 'grand_tournament',
+      objectiveId: 'summer_vanguard_festival_threat',
+      stageId: 'city_core',
+      pressure: 'elite_chain',
+    });
+    expect(getSummerGuardianFestivalWorldRoute('arcanist')).toMatchObject({
+      identity: 'relic_resonance',
+      objectiveId: 'summer_arcanist_festival_relic',
+      stageId: 'lake_tempest',
+      pressure: 'rule_shift',
+    });
+  });
+
+  it('returns null for malformed campaign input instead of inventing a route', () => {
+    expect(getSummerGuardianFestivalWorldRoute('unknown')).toBeNull();
+    expect(getSummerGuardianFestivalWorldRoute(null)).toBeNull();
+  });
+});

--- a/src/summer-campaign-world.ts
+++ b/src/summer-campaign-world.ts
@@ -1,0 +1,91 @@
+import type { MainCampaignId } from './campaign-model';
+import {
+  campaignWorldObjectives,
+  type CampaignWorldObjectiveId,
+} from './campaign-world';
+import type { ExpeditionRegionId, ExpeditionStageId } from './expedition-regions';
+
+export type SummerGuardianFestivalWorldIdentity =
+  | 'rescue_protection'
+  | 'hidden_route_escape'
+  | 'grand_tournament'
+  | 'relic_resonance';
+
+export type SummerGuardianFestivalWorldPressure =
+  | 'civilian_survival'
+  | 'escape_traversal'
+  | 'elite_chain'
+  | 'rule_shift';
+
+export type SummerGuardianFestivalWorldRoute = Readonly<{
+  campaign: MainCampaignId;
+  identity: SummerGuardianFestivalWorldIdentity;
+  objectiveId: CampaignWorldObjectiveId;
+  regionId: ExpeditionRegionId;
+  stageId: ExpeditionStageId;
+  pressure: SummerGuardianFestivalWorldPressure;
+  failForward: true;
+}>;
+
+const route = (
+  campaign: MainCampaignId,
+  identity: SummerGuardianFestivalWorldIdentity,
+  objectiveId: CampaignWorldObjectiveId,
+  stageId: ExpeditionStageId,
+  pressure: SummerGuardianFestivalWorldPressure,
+): SummerGuardianFestivalWorldRoute => {
+  const objective = campaignWorldObjectives.find(candidate => candidate.id === objectiveId);
+  if (!objective || objective.season !== 'summer' || objective.campaign !== campaign) {
+    throw new Error('Summer Guardian Festival route requires a matching Summer World objective');
+  }
+  if (!objective.stageIds.includes(stageId)) {
+    throw new Error('Summer Guardian Festival route must reuse an existing objective stage');
+  }
+  return {
+    campaign,
+    identity,
+    objectiveId,
+    regionId: objective.regionId,
+    stageId,
+    pressure,
+    failForward: true,
+  };
+};
+
+export const summerGuardianFestivalWorldRoutes: readonly SummerGuardianFestivalWorldRoute[] = [
+  route(
+    'caretaker',
+    'rescue_protection',
+    'summer_caretaker_festival_rescue',
+    'forest_guardian',
+    'civilian_survival',
+  ),
+  route(
+    'pathfinder',
+    'hidden_route_escape',
+    'summer_pathfinder_festival_routes',
+    'city_gallery',
+    'escape_traversal',
+  ),
+  route(
+    'vanguard',
+    'grand_tournament',
+    'summer_vanguard_festival_threat',
+    'city_core',
+    'elite_chain',
+  ),
+  route(
+    'arcanist',
+    'relic_resonance',
+    'summer_arcanist_festival_relic',
+    'lake_tempest',
+    'rule_shift',
+  ),
+] as const;
+
+export function getSummerGuardianFestivalWorldRoute(
+  campaign: unknown,
+): SummerGuardianFestivalWorldRoute | null {
+  if (typeof campaign !== 'string') return null;
+  return summerGuardianFestivalWorldRoutes.find(route => route.campaign === campaign) ?? null;
+}


### PR DESCRIPTION
## Status
- **02 Summer World independent GREEN candidate**
- Parent: #54
- Lane B: #89
- base: `integration/v3@9d5f6b711a806fd04af1497fb723d205019cfe92`
- head: `work/v3-summer-world@31d5277d598640beb9f3a6660b22f3c6858721fd`
- merge-ref verified: `af6d0656ae901e5ff93408341b9eb0f2b5b631bb`
- Draft / unmerged

## Scope
World-owned Summer Guardian Festival identity contracts only:
- Caretaker: `rescue_protection` / `civilian_survival` on existing `summer_caretaker_festival_rescue` → `forest_guardian`
- Pathfinder: `hidden_route_escape` / `escape_traversal` on existing `summer_pathfinder_festival_routes` → `city_gallery`
- Vanguard: `grand_tournament` / `elite_chain` on existing `summer_vanguard_festival_threat` → `city_core`
- Arcanist: `relic_resonance` / `rule_shift` on existing `summer_arcanist_festival_relic` → `lake_tempest`
- all routes reuse existing Campaign World objectives, regions, and Expedition stages
- `failForward: true` on all four World route contracts
- malformed campaign input returns null; no invented fallback route

No new map, no new stage, no battle engine, no Tactical implementation in 02.

## TDD evidence
### RED
- commit `2211ce84626eaa0d7bfaa7139ef9ca966cce6312`
- CI #1540 / run `32550296327`
- new `summer-campaign-world.test.ts` failed exactly because `./summer-campaign-world` did not exist
- all pre-existing tests remained GREEN: 358 files / 1315 tests

### GREEN
- candidate `31d5277d598640beb9f3a6660b22f3c6858721fd`
- CI #1541 / run `32550308787`: **GREEN**
- `src/summer-campaign-world.test.ts`: **3/3 PASS**
- full suite: **359/359 test files, 1318/1318 tests PASS**
- `src/tactical-stability.test.ts`: **13/13 PASS**
- manual/AUTO repeated battle stability: GREEN
- AUTO stress 10 / 50 / 100 battle checkpoints: GREEN
- `npm run build` = `tsc -b && vite build`: PASS
- Vite production build: PASS
- 190 modules transformed

## Lane B handoff contract
04 is the Lane B lead and should consume only the exported World route identity/pressure contract when composing `verify/v3-summer-world-tactical`.
The existing Spring Guardian Festival resolver remains authoritative for `exceptional_victory | victory | costly_victory | defeat` → canonical World Fact/fail-forward reconciliation.

## Guardrails
- no shared `App.tsx` / `Root.tsx` / game / save edits
- no direct `integration/v3` merge
- main/prod untouched
- Autumn remains closed
- new World feature expansion stops here unless Lane B composition exposes a concrete World-owned contract gap

## Notes
- repository install still reports the pre-existing `1 high severity vulnerability`; this candidate changes no dependencies
- Vite still reports the existing >500 kB chunk-size warning; build itself is GREEN
