### PR TITLE
[03] V3 Summer campaign season runtime

### DIFF
--- a/src/campaign-summer-season.test.ts
+++ b/src/campaign-summer-season.test.ts
@@ -53,12 +53,13 @@ describe('V3 Summer campaign season runtime',()=>{
     expect(resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'unknown'})).toEqual({accepted:false,reason:'invalid_result'});
   });
 
-  it('commits Summer result once and never lets replay overwrite authoritative history',()=>{
+  it('commits Summer result once, persists campaign identity, and never lets replay overwrite authoritative history',()=>{
     const initial=emptyCampaignRunState();
     const victory=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'victory'});
     expect(victory.accepted).toBe(true);
     if(!victory.accepted)return;
     const committed=commitSummerCampaignOutcome(initial,victory);
+    expect(committed.activeCampaign).toBe('vanguard');
     expect(committed.majorOutcomes.guardian_festival).toBe('victory');
     expect(committed.seasonMilestones).toEqual(['summer_resolved']);
 
@@ -69,6 +70,14 @@ describe('V3 Summer campaign season runtime',()=>{
     expect(afterReplay).toBe(committed);
     expect(afterReplay.majorOutcomes.guardian_festival).toBe('victory');
     expect(afterReplay.seasonMilestones).toEqual(['summer_resolved']);
+  });
+
+  it('rejects a Summer result that conflicts with an already authoritative campaign identity',()=>{
+    const caretaker={...emptyCampaignRunState(),activeCampaign:'caretaker' as const};
+    const vanguard=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'victory'});
+    expect(vanguard.accepted).toBe(true);
+    if(!vanguard.accepted)return;
+    expect(commitSummerCampaignOutcome(caretaker,vanguard)).toBe(caretaker);
   });
 
   it('rejects malformed context and unsupported cross-campaign facts',()=>{

--- a/src/campaign-summer-season.test.ts
+++ b/src/campaign-summer-season.test.ts
@@ -1,0 +1,80 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCampaignRunState} from './campaign-state';
+import {
+  commitSummerCampaignOutcome,
+  resolveSummerCampaignAction,
+  resolveSummerCampaignOutcome,
+} from './campaign-summer-season';
+
+const claimed=(key:string)=>[key];
+
+describe('V3 Summer campaign season runtime',()=>{
+  it.each([
+    ['caretaker',['protect'],'summer_caretaker_rescue'],
+    ['pathfinder',['limited_exploration'],'summer_pathfinder_limited_route'],
+    ['vanguard',['ally_survival'],'summer_vanguard_chain'],
+    ['vanguard',['defeat_recovery'],'summer_vanguard_chain'],
+    ['arcanist',['status_combat'],'summer_arcanist_rule_shift'],
+  ] as const)('maps %s Summer action facts onto the existing seasonal objective layer', (campaign,facts,objectiveId)=>{
+    const result=resolveSummerCampaignAction({year:2,week:2,campaign,facts,claimedKeys:[]});
+    expect(result.accepted).toBe(true);
+    if(!result.accepted)return;
+    expect(result.objective.id).toBe(objectiveId);
+    expect(result.reward.kind).toBe('campaign_memory');
+  });
+
+  it('keeps one action to one objective and blocks duplicate fallthrough',()=>{
+    const first=resolveSummerCampaignAction({
+      year:2,week:1,campaign:'caretaker',facts:['protect','bond','recovery'],claimedKeys:[],
+    });
+    expect(first.accepted).toBe(true);
+    if(!first.accepted)return;
+    expect(first.objective.id).toBe('summer_caretaker_rescue');
+
+    const duplicate=resolveSummerCampaignAction({
+      year:2,week:4,campaign:'caretaker',facts:['protect','bond','recovery'],claimedKeys:claimed(first.claimKey),
+    });
+    expect(duplicate).toEqual(expect.objectContaining({
+      accepted:false,
+      reason:'already_claimed',
+      claimKey:first.claimKey,
+    }));
+  });
+
+  it('emits a compact Summer result for existing CampaignRun fields without opening Autumn choices',()=>{
+    expect(resolveSummerCampaignOutcome({campaign:'pathfinder',outcome:'costly_victory'})).toEqual({
+      accepted:true,
+      campaignId:'pathfinder',
+      majorEvent:'guardian_festival',
+      outcome:'costly_victory',
+      milestone:'summer_resolved',
+    });
+    expect(resolveSummerCampaignOutcome({campaign:'true_path',outcome:'victory'})).toEqual({accepted:false,reason:'invalid_result'});
+    expect(resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'unknown'})).toEqual({accepted:false,reason:'invalid_result'});
+  });
+
+  it('commits Summer result once and never lets replay overwrite authoritative history',()=>{
+    const initial=emptyCampaignRunState();
+    const victory=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'victory'});
+    expect(victory.accepted).toBe(true);
+    if(!victory.accepted)return;
+    const committed=commitSummerCampaignOutcome(initial,victory);
+    expect(committed.majorOutcomes.guardian_festival).toBe('victory');
+    expect(committed.seasonMilestones).toEqual(['summer_resolved']);
+
+    const replay=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'defeat'});
+    expect(replay.accepted).toBe(true);
+    if(!replay.accepted)return;
+    const afterReplay=commitSummerCampaignOutcome(committed,replay);
+    expect(afterReplay).toBe(committed);
+    expect(afterReplay.majorOutcomes.guardian_festival).toBe('victory');
+    expect(afterReplay.seasonMilestones).toEqual(['summer_resolved']);
+  });
+
+  it('rejects malformed context and unsupported cross-campaign facts',()=>{
+    expect(resolveSummerCampaignAction({year:0,week:1,campaign:'caretaker',facts:['protect'],claimedKeys:[]}))
+      .toEqual({accepted:false,reason:'invalid_context'});
+    expect(resolveSummerCampaignAction({year:1,week:1,campaign:'vanguard',facts:['protect'],claimedKeys:[]}))
+      .toEqual({accepted:false,reason:'no_match'});
+  });
+});

--- a/src/campaign-summer-season.ts
+++ b/src/campaign-summer-season.ts
@@ -1,0 +1,96 @@
+import {
+  mainCampaignIds,
+  majorOutcomeResults,
+  type MainCampaignId,
+  type MajorOutcomeResult,
+} from './campaign-model';
+import type {CampaignRunState} from './campaign-state';
+import {resolveCampaignSeasonalObjective,type CampaignSeasonalSignalKind} from './campaign-seasonal-objectives';
+
+export type SummerCampaignActionFact=
+  | 'bond'
+  | 'rescue'
+  | 'protect'
+  | 'recovery'
+  | 'discovery'
+  | 'uncleared_region'
+  | 'limited_exploration'
+  | 'strong_opponent'
+  | 'ally_survival'
+  | 'defeat_recovery'
+  | 'relic'
+  | 'astral'
+  | 'status_combat';
+
+const mainCampaignSet=new Set<string>(mainCampaignIds);
+const majorOutcomeSet=new Set<string>(majorOutcomeResults);
+
+function campaignId(value:unknown):MainCampaignId|null{
+  return typeof value==='string'&&mainCampaignSet.has(value)?value as MainCampaignId:null;
+}
+
+function factsToSignals(campaign:MainCampaignId,raw:unknown):CampaignSeasonalSignalKind[]{
+  if(!Array.isArray(raw))return [];
+  const facts=[...new Set(raw.filter((value):value is SummerCampaignActionFact=>typeof value==='string'))];
+  const signals:CampaignSeasonalSignalKind[]=[];
+  for(const fact of facts){
+    if(campaign==='caretaker'&&(['bond','rescue','protect','recovery'] as const).includes(fact as any)) signals.push(fact as CampaignSeasonalSignalKind);
+    else if(campaign==='pathfinder'&&(['discovery','uncleared_region','limited_exploration'] as const).includes(fact as any)) signals.push(fact as CampaignSeasonalSignalKind);
+    else if(campaign==='vanguard'&&fact==='strong_opponent') signals.push('strong_opponent');
+    else if(campaign==='vanguard'&&(fact==='ally_survival'||fact==='defeat_recovery')) signals.push('tactical_challenge');
+    else if(campaign==='arcanist'&&(['relic','astral','status_combat'] as const).includes(fact as any)) signals.push(fact as CampaignSeasonalSignalKind);
+  }
+  return [...new Set(signals)];
+}
+
+export function resolveSummerCampaignAction(input:{
+  year:unknown;
+  week:unknown;
+  campaign:unknown;
+  facts:unknown;
+  claimedKeys:unknown;
+}){
+  const campaign=campaignId(input.campaign);
+  if(!campaign)return {accepted:false as const,reason:'invalid_context' as const};
+  return resolveCampaignSeasonalObjective({
+    year:input.year,
+    week:input.week,
+    season:'summer',
+    campaign,
+    signals:factsToSignals(campaign,input.facts),
+    claimedKeys:input.claimedKeys,
+  });
+}
+
+export type SummerCampaignOutcome={
+  accepted:true;
+  campaignId:MainCampaignId;
+  majorEvent:'guardian_festival';
+  outcome:MajorOutcomeResult;
+  milestone:'summer_resolved';
+};
+
+export function resolveSummerCampaignOutcome(input:{campaign:unknown;outcome:unknown}):SummerCampaignOutcome|{accepted:false;reason:'invalid_result'}{
+  const campaign=campaignId(input.campaign);
+  if(!campaign||typeof input.outcome!=='string'||!majorOutcomeSet.has(input.outcome)){
+    return {accepted:false,reason:'invalid_result'};
+  }
+  return {
+    accepted:true,
+    campaignId:campaign,
+    majorEvent:'guardian_festival',
+    outcome:input.outcome as MajorOutcomeResult,
+    milestone:'summer_resolved',
+  };
+}
+
+export function commitSummerCampaignOutcome(state:CampaignRunState,result:SummerCampaignOutcome):CampaignRunState{
+  if(state.majorOutcomes.guardian_festival!==undefined)return state;
+  return {
+    ...state,
+    majorOutcomes:{...state.majorOutcomes,guardian_festival:result.outcome},
+    seasonMilestones:state.seasonMilestones.includes('summer_resolved')
+      ? state.seasonMilestones
+      : [...state.seasonMilestones,'summer_resolved'],
+  };
+}

--- a/src/campaign-summer-season.ts
+++ b/src/campaign-summer-season.ts
@@ -86,8 +86,10 @@ export function resolveSummerCampaignOutcome(input:{campaign:unknown;outcome:unk
 
 export function commitSummerCampaignOutcome(state:CampaignRunState,result:SummerCampaignOutcome):CampaignRunState{
   if(state.majorOutcomes.guardian_festival!==undefined)return state;
+  if(state.activeCampaign!==null&&state.activeCampaign!==result.campaignId)return state;
   return {
     ...state,
+    activeCampaign:state.activeCampaign??result.campaignId,
     majorOutcomes:{...state.majorOutcomes,guardian_festival:result.outcome},
     seasonMilestones:state.seasonMilestones.includes('summer_resolved')
       ? state.seasonMilestones


### PR DESCRIPTION
Parent: #90

Summer Lane C room candidate.

Implemented:
- maps Summer campaign action facts onto the existing Seasonal Objective resolver
- Caretaker Bond/rescue/protection/recovery
- Pathfinder discovery/uncleared/limited-action exploration
- Vanguard stronger opponent + ally survival + defeat recovery
- Arcanist relic/astral/status-combat
- preserves deterministic one-action/one-objective and reward-once through the existing dedicated claim ledger
- emits compact Summer campaign result into existing `guardian_festival` outcome + `summer_resolved` milestone
- first committed Summer result establishes `activeCampaign` when missing
- conflicting campaign identity or replay cannot overwrite authoritative Summer history
- malformed campaign/outcome/context rejected

Verified RED before implementation:
- existing 358/358 test files and 1315/1315 tests GREEN
- new Summer suite failed only because `campaign-summer-season` did not exist

Final independent verification on head `b8d47c1ad96f1b2d23a181306cc1a7c93298730a`:
- 359/359 test files GREEN
- 1325/1325 tests GREEN
- `src/campaign-summer-season.test.ts`: 10/10 GREEN
- `npm run build` GREEN (`tsc -b && vite build`)

No shared save/game changes. No Autumn Major Choice implementation. No True Campaign expansion. Keep Draft; do not merge integration/v3 here.