### PR TITLE
[Lane C] V3 Summer Season + State verification

### DIFF
--- a/src/campaign-summer-season.test.ts
+++ b/src/campaign-summer-season.test.ts
@@ -53,12 +53,13 @@ describe('V3 Summer campaign season runtime',()=>{
     expect(resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'unknown'})).toEqual({accepted:false,reason:'invalid_result'});
   });
 
-  it('commits Summer result once and never lets replay overwrite authoritative history',()=>{
+  it('commits Summer result once, persists campaign identity, and never lets replay overwrite authoritative history',()=>{
     const initial=emptyCampaignRunState();
     const victory=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'victory'});
     expect(victory.accepted).toBe(true);
     if(!victory.accepted)return;
     const committed=commitSummerCampaignOutcome(initial,victory);
+    expect(committed.activeCampaign).toBe('vanguard');
     expect(committed.majorOutcomes.guardian_festival).toBe('victory');
     expect(committed.seasonMilestones).toEqual(['summer_resolved']);
 
@@ -69,6 +70,14 @@ describe('V3 Summer campaign season runtime',()=>{
     expect(afterReplay).toBe(committed);
     expect(afterReplay.majorOutcomes.guardian_festival).toBe('victory');
     expect(afterReplay.seasonMilestones).toEqual(['summer_resolved']);
+  });
+
+  it('rejects a Summer result that conflicts with an already authoritative campaign identity',()=>{
+    const caretaker={...emptyCampaignRunState(),activeCampaign:'caretaker' as const};
+    const vanguard=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'victory'});
+    expect(vanguard.accepted).toBe(true);
+    if(!vanguard.accepted)return;
+    expect(commitSummerCampaignOutcome(caretaker,vanguard)).toBe(caretaker);
   });
 
   it('rejects malformed context and unsupported cross-campaign facts',()=>{

--- a/src/campaign-summer-season.test.ts
+++ b/src/campaign-summer-season.test.ts
@@ -1,0 +1,80 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCampaignRunState} from './campaign-state';
+import {
+  commitSummerCampaignOutcome,
+  resolveSummerCampaignAction,
+  resolveSummerCampaignOutcome,
+} from './campaign-summer-season';
+
+const claimed=(key:string)=>[key];
+
+describe('V3 Summer campaign season runtime',()=>{
+  it.each([
+    ['caretaker',['protect'],'summer_caretaker_rescue'],
+    ['pathfinder',['limited_exploration'],'summer_pathfinder_limited_route'],
+    ['vanguard',['ally_survival'],'summer_vanguard_chain'],
+    ['vanguard',['defeat_recovery'],'summer_vanguard_chain'],
+    ['arcanist',['status_combat'],'summer_arcanist_rule_shift'],
+  ] as const)('maps %s Summer action facts onto the existing seasonal objective layer', (campaign,facts,objectiveId)=>{
+    const result=resolveSummerCampaignAction({year:2,week:2,campaign,facts,claimedKeys:[]});
+    expect(result.accepted).toBe(true);
+    if(!result.accepted)return;
+    expect(result.objective.id).toBe(objectiveId);
+    expect(result.reward.kind).toBe('campaign_memory');
+  });
+
+  it('keeps one action to one objective and blocks duplicate fallthrough',()=>{
+    const first=resolveSummerCampaignAction({
+      year:2,week:1,campaign:'caretaker',facts:['protect','bond','recovery'],claimedKeys:[],
+    });
+    expect(first.accepted).toBe(true);
+    if(!first.accepted)return;
+    expect(first.objective.id).toBe('summer_caretaker_rescue');
+
+    const duplicate=resolveSummerCampaignAction({
+      year:2,week:4,campaign:'caretaker',facts:['protect','bond','recovery'],claimedKeys:claimed(first.claimKey),
+    });
+    expect(duplicate).toEqual(expect.objectContaining({
+      accepted:false,
+      reason:'already_claimed',
+      claimKey:first.claimKey,
+    }));
+  });
+
+  it('emits a compact Summer result for existing CampaignRun fields without opening Autumn choices',()=>{
+    expect(resolveSummerCampaignOutcome({campaign:'pathfinder',outcome:'costly_victory'})).toEqual({
+      accepted:true,
+      campaignId:'pathfinder',
+      majorEvent:'guardian_festival',
+      outcome:'costly_victory',
+      milestone:'summer_resolved',
+    });
+    expect(resolveSummerCampaignOutcome({campaign:'true_path',outcome:'victory'})).toEqual({accepted:false,reason:'invalid_result'});
+    expect(resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'unknown'})).toEqual({accepted:false,reason:'invalid_result'});
+  });
+
+  it('commits Summer result once and never lets replay overwrite authoritative history',()=>{
+    const initial=emptyCampaignRunState();
+    const victory=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'victory'});
+    expect(victory.accepted).toBe(true);
+    if(!victory.accepted)return;
+    const committed=commitSummerCampaignOutcome(initial,victory);
+    expect(committed.majorOutcomes.guardian_festival).toBe('victory');
+    expect(committed.seasonMilestones).toEqual(['summer_resolved']);
+
+    const replay=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'defeat'});
+    expect(replay.accepted).toBe(true);
+    if(!replay.accepted)return;
+    const afterReplay=commitSummerCampaignOutcome(committed,replay);
+    expect(afterReplay).toBe(committed);
+    expect(afterReplay.majorOutcomes.guardian_festival).toBe('victory');
+    expect(afterReplay.seasonMilestones).toEqual(['summer_resolved']);
+  });
+
+  it('rejects malformed context and unsupported cross-campaign facts',()=>{
+    expect(resolveSummerCampaignAction({year:0,week:1,campaign:'caretaker',facts:['protect'],claimedKeys:[]}))
+      .toEqual({accepted:false,reason:'invalid_context'});
+    expect(resolveSummerCampaignAction({year:1,week:1,campaign:'vanguard',facts:['protect'],claimedKeys:[]}))
+      .toEqual({accepted:false,reason:'no_match'});
+  });
+});

--- a/src/campaign-summer-season.ts
+++ b/src/campaign-summer-season.ts
@@ -1,0 +1,96 @@
+import {
+  mainCampaignIds,
+  majorOutcomeResults,
+  type MainCampaignId,
+  type MajorOutcomeResult,
+} from './campaign-model';
+import type {CampaignRunState} from './campaign-state';
+import {resolveCampaignSeasonalObjective,type CampaignSeasonalSignalKind} from './campaign-seasonal-objectives';
+
+export type SummerCampaignActionFact=
+  | 'bond'
+  | 'rescue'
+  | 'protect'
+  | 'recovery'
+  | 'discovery'
+  | 'uncleared_region'
+  | 'limited_exploration'
+  | 'strong_opponent'
+  | 'ally_survival'
+  | 'defeat_recovery'
+  | 'relic'
+  | 'astral'
+  | 'status_combat';
+
+const mainCampaignSet=new Set<string>(mainCampaignIds);
+const majorOutcomeSet=new Set<string>(majorOutcomeResults);
+
+function campaignId(value:unknown):MainCampaignId|null{
+  return typeof value==='string'&&mainCampaignSet.has(value)?value as MainCampaignId:null;
+}
+
+function factsToSignals(campaign:MainCampaignId,raw:unknown):CampaignSeasonalSignalKind[]{
+  if(!Array.isArray(raw))return [];
+  const facts=[...new Set(raw.filter((value):value is SummerCampaignActionFact=>typeof value==='string'))];
+  const signals:CampaignSeasonalSignalKind[]=[];
+  for(const fact of facts){
+    if(campaign==='caretaker'&&(['bond','rescue','protect','recovery'] as const).includes(fact as any)) signals.push(fact as CampaignSeasonalSignalKind);
+    else if(campaign==='pathfinder'&&(['discovery','uncleared_region','limited_exploration'] as const).includes(fact as any)) signals.push(fact as CampaignSeasonalSignalKind);
+    else if(campaign==='vanguard'&&fact==='strong_opponent') signals.push('strong_opponent');
+    else if(campaign==='vanguard'&&(fact==='ally_survival'||fact==='defeat_recovery')) signals.push('tactical_challenge');
+    else if(campaign==='arcanist'&&(['relic','astral','status_combat'] as const).includes(fact as any)) signals.push(fact as CampaignSeasonalSignalKind);
+  }
+  return [...new Set(signals)];
+}
+
+export function resolveSummerCampaignAction(input:{
+  year:unknown;
+  week:unknown;
+  campaign:unknown;
+  facts:unknown;
+  claimedKeys:unknown;
+}){
+  const campaign=campaignId(input.campaign);
+  if(!campaign)return {accepted:false as const,reason:'invalid_context' as const};
+  return resolveCampaignSeasonalObjective({
+    year:input.year,
+    week:input.week,
+    season:'summer',
+    campaign,
+    signals:factsToSignals(campaign,input.facts),
+    claimedKeys:input.claimedKeys,
+  });
+}
+
+export type SummerCampaignOutcome={
+  accepted:true;
+  campaignId:MainCampaignId;
+  majorEvent:'guardian_festival';
+  outcome:MajorOutcomeResult;
+  milestone:'summer_resolved';
+};
+
+export function resolveSummerCampaignOutcome(input:{campaign:unknown;outcome:unknown}):SummerCampaignOutcome|{accepted:false;reason:'invalid_result'}{
+  const campaign=campaignId(input.campaign);
+  if(!campaign||typeof input.outcome!=='string'||!majorOutcomeSet.has(input.outcome)){
+    return {accepted:false,reason:'invalid_result'};
+  }
+  return {
+    accepted:true,
+    campaignId:campaign,
+    majorEvent:'guardian_festival',
+    outcome:input.outcome as MajorOutcomeResult,
+    milestone:'summer_resolved',
+  };
+}
+
+export function commitSummerCampaignOutcome(state:CampaignRunState,result:SummerCampaignOutcome):CampaignRunState{
+  if(state.majorOutcomes.guardian_festival!==undefined)return state;
+  return {
+    ...state,
+    majorOutcomes:{...state.majorOutcomes,guardian_festival:result.outcome},
+    seasonMilestones:state.seasonMilestones.includes('summer_resolved')
+      ? state.seasonMilestones
+      : [...state.seasonMilestones,'summer_resolved'],
+  };
+}

--- a/src/campaign-summer-season.ts
+++ b/src/campaign-summer-season.ts
@@ -86,8 +86,10 @@ export function resolveSummerCampaignOutcome(input:{campaign:unknown;outcome:unk
 
 export function commitSummerCampaignOutcome(state:CampaignRunState,result:SummerCampaignOutcome):CampaignRunState{
   if(state.majorOutcomes.guardian_festival!==undefined)return state;
+  if(state.activeCampaign!==null&&state.activeCampaign!==result.campaignId)return state;
   return {
     ...state,
+    activeCampaign:state.activeCampaign??result.campaignId,
     majorOutcomes:{...state.majorOutcomes,guardian_festival:result.outcome},
     seasonMilestones:state.seasonMilestones.includes('summer_resolved')
       ? state.seasonMilestones

--- a/src/v3-summer-season-state-lane.test.ts
+++ b/src/v3-summer-season-state-lane.test.ts
@@ -1,0 +1,103 @@
+import {describe,expect,it} from 'vitest';
+import {initialState,type GameState} from './game';
+import {inspectSavedGame,serializeSavedGame} from './save-schema';
+import {
+  commitSummerCampaignOutcome,
+  resolveSummerCampaignAction,
+  resolveSummerCampaignOutcome,
+} from './campaign-summer-season';
+import {prepareNewRunState} from './v3-persistent-state';
+
+const summerClaim='2-summer:vanguard:summer_vanguard_chain';
+
+describe('V3 Summer Lane C season/state vertical slice',()=>{
+  it('persists Summer objective claim and compact campaign result through save/load/reload',()=>{
+    const action=resolveSummerCampaignAction({
+      year:2,week:2,campaign:'vanguard',facts:['ally_survival'],claimedKeys:[],
+    });
+    expect(action.accepted).toBe(true);
+    if(!action.accepted)return;
+    expect(action.claimKey).toBe(summerClaim);
+
+    const outcome=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'costly_victory'});
+    expect(outcome.accepted).toBe(true);
+    if(!outcome.accepted)return;
+
+    const campaignRun=commitSummerCampaignOutcome({
+      ...initialState.campaignRun,
+      claimedSeasonalObjectives:[action.claimKey],
+    },outcome);
+    const state={...initialState,campaignRun} as GameState;
+
+    const loaded=inspectSavedGame(serializeSavedGame(state));
+    expect(loaded.status).toBe('valid');
+    expect(loaded.state.campaignRun.claimedSeasonalObjectives).toEqual([summerClaim]);
+    expect(loaded.state.campaignRun.majorOutcomes.guardian_festival).toBe('costly_victory');
+    expect(loaded.state.campaignRun.seasonMilestones).toContain('summer_resolved');
+
+    const reloaded=inspectSavedGame(serializeSavedGame(loaded.state));
+    expect(reloaded.status).toBe('valid');
+    expect(reloaded.state).toEqual(loaded.state);
+  });
+
+  it('blocks duplicate objective reward and Summer result overwrite after reload',()=>{
+    const state={
+      ...initialState,
+      campaignRun:{
+        ...initialState.campaignRun,
+        claimedSeasonalObjectives:[summerClaim],
+        majorOutcomes:{...initialState.campaignRun.majorOutcomes,guardian_festival:'victory' as const},
+        seasonMilestones:['summer_resolved' as const],
+      },
+    } as GameState;
+    const loaded=inspectSavedGame(serializeSavedGame(state)).state;
+
+    const duplicate=resolveSummerCampaignAction({
+      year:2,week:4,campaign:'vanguard',facts:['ally_survival','defeat_recovery'],
+      claimedKeys:loaded.campaignRun.claimedSeasonalObjectives,
+    });
+    expect(duplicate).toEqual(expect.objectContaining({accepted:false,reason:'already_claimed',claimKey:summerClaim}));
+
+    const replay=resolveSummerCampaignOutcome({campaign:'vanguard',outcome:'defeat'});
+    expect(replay.accepted).toBe(true);
+    if(!replay.accepted)return;
+    const afterReplay=commitSummerCampaignOutcome(loaded.campaignRun,replay);
+    expect(afterReplay).toBe(loaded.campaignRun);
+    expect(afterReplay.majorOutcomes.guardian_festival).toBe('victory');
+  });
+
+  it('sanitizes malformed persisted Summer claims/results and preserves only registered Autumn inputs',()=>{
+    const raw={
+      ...initialState,
+      campaignRun:{
+        ...initialState.campaignRun,
+        claimedSeasonalObjectives:[summerClaim,summerClaim,'02-summer:vanguard:summer_vanguard_chain','bad'],
+        majorOutcomes:{guardian_festival:'unknown'},
+        seasonMilestones:['summer_resolved','not_a_milestone'],
+        majorChoices:{vanguard_autumn:'not_a_choice'},
+      },
+    };
+    const hydrated=inspectSavedGame(serializeSavedGame(raw as GameState)).state.campaignRun;
+    expect(hydrated.claimedSeasonalObjectives).toEqual([summerClaim]);
+    expect(hydrated.majorOutcomes.guardian_festival).toBeUndefined();
+    expect(hydrated.seasonMilestones).toEqual(['summer_resolved']);
+    expect(hydrated.majorChoices.vanguard_autumn).toBeUndefined();
+  });
+
+  it('resets Summer run facts on a new run while preserving Legacy',()=>{
+    const current={
+      ...initialState,
+      campaignRun:{
+        ...initialState.campaignRun,
+        claimedSeasonalObjectives:[summerClaim],
+        majorOutcomes:{...initialState.campaignRun.majorOutcomes,guardian_festival:'victory' as const},
+        seasonMilestones:['summer_resolved' as const],
+      },
+    };
+    const next=prepareNewRunState(current);
+    expect(next.campaignRun.claimedSeasonalObjectives).toEqual([]);
+    expect(next.campaignRun.majorOutcomes.guardian_festival).toBeUndefined();
+    expect(next.campaignRun.seasonMilestones).toEqual([]);
+    expect(next.legacy).toEqual(current.legacy);
+  });
+});


### PR DESCRIPTION
Parent: #90

Verification-only Summer Lane C branch.

Composed:
- PR #93 Summer campaign runtime candidate
- existing Spring-introduced dedicated Seasonal Objective claim ledger
- existing CampaignRun `activeCampaign`, `majorOutcomes.guardian_festival`, and `seasonMilestones.summer_resolved`
- Summer save/load/reload/new-run E2E contract

Lane scope verified GREEN:
- Summer existing-action facts -> campaign-aware Seasonal Objective
- deterministic one-action/one-objective
- reward-once via dedicated claim ledger
- Vanguard ally-survival / defeat-recovery mapping
- compact Summer outcome + milestone persisted without new shared fields
- campaign identity established once; conflicting campaign/replay cannot overwrite history
- schema v3 save/load/reload idempotency
- malformed claim/outcome/milestone/Autumn-choice hydration sanitation
- new-run reset while Legacy remains preserved
- Autumn input contract only; no Autumn Major Choice implementation
- Sanctuary/Astral/Celestial/Rift regressions remain GREEN

Final verification on head `73b8cddafb761c9b9a3c7fa80c231ad93f0cda34` / PR merge ref `651425cb8a5e6271e2d2d9328a60a23ff81da2e2`:
- 360/360 test files GREEN
- 1329/1329 tests GREEN
- `src/campaign-summer-season.test.ts`: 10/10 GREEN
- `src/v3-summer-season-state-lane.test.ts`: 4/4 GREEN
- `npm run build` GREEN (`tsc -b && vite build`)

`work/v3-summer-shared-state` remains identical to authoritative baseline, and Lane E2E proves no additional Summer shared-state/save delta is required. Reuse existing CampaignRun persistence.

Lane C #90 is GREEN. Keep Draft/verification-only. Do not merge integration/v3 here. No True Campaign expansion.