### PR TITLE
[03] V3 Autumn campaign season + Major Choice runtime

### DIFF
--- a/src/campaign-autumn-season.test.ts
+++ b/src/campaign-autumn-season.test.ts
@@ -1,0 +1,113 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCampaignRunState} from './campaign-state';
+import {
+  commitAutumnMajorChoice,
+  resolveAutumnCampaignAction,
+  resolveAutumnMajorChoice,
+  resolveAutumnThirdOptionEligibility,
+  selectWinterCampaignInput,
+} from './campaign-autumn-season';
+
+describe('V3 Autumn campaign season runtime',()=>{
+  it.each([
+    ['caretaker',['great_expedition_protect'],'autumn_caretaker_guardianship'],
+    ['pathfinder',['great_expedition_discovery'],'autumn_pathfinder_route'],
+    ['vanguard',['great_expedition_command'],'autumn_vanguard_command'],
+    ['arcanist',['great_expedition_relic'],'autumn_arcanist_relic'],
+  ] as const)('maps %s Great Expedition facts into an Autumn seasonal objective', (campaign,facts,objectiveId)=>{
+    const result=resolveAutumnCampaignAction({year:3,week:2,campaign,facts,claimedKeys:[]});
+    expect(result.accepted).toBe(true);
+    if(!result.accepted)return;
+    expect(result.objective.id).toBe(objectiveId);
+    expect(result.claimKey).toBe(`3-autumn:${campaign}:${objectiveId}`);
+  });
+
+  it('keeps one Autumn action to one objective and blocks duplicate fallthrough across week rollover',()=>{
+    const first=resolveAutumnCampaignAction({
+      year:3,week:1,campaign:'caretaker',facts:['great_expedition_protect','bond_support'],claimedKeys:[],
+    });
+    expect(first.accepted).toBe(true);
+    if(!first.accepted)return;
+
+    const duplicate=resolveAutumnCampaignAction({
+      year:3,week:4,campaign:'caretaker',facts:['great_expedition_protect','bond_support'],claimedKeys:[first.claimKey],
+    });
+    expect(duplicate).toEqual(expect.objectContaining({accepted:false,reason:'already_claimed',claimKey:first.claimKey}));
+  });
+
+  it.each([
+    ['caretaker',['bond_support','protected_civilians'],'team_solution'],
+    ['pathfinder',['discovery_evidence','limited_route_evidence'],'limited_access'],
+    ['vanguard',['ally_support','independent_command_evidence'],'coalition_command'],
+    ['arcanist',['relic_control_evidence','astral_mastery'],'controlled_use'],
+  ] as const)('unlocks only the earned third option for %s from typed prior evidence', (campaign,evidence,thirdChoice)=>{
+    expect(resolveAutumnThirdOptionEligibility({campaign,evidence})).toEqual({
+      eligible:true,
+      campaignId:campaign,
+      choiceId:thirdChoice,
+    });
+    expect(resolveAutumnThirdOptionEligibility({campaign,evidence:[evidence[0]]})).toEqual({
+      eligible:false,
+      campaignId:campaign,
+      choiceId:thirdChoice,
+    });
+  });
+
+  it('allows either base choice, rejects an unearned third choice, and rejects cross-campaign choice IDs',()=>{
+    expect(resolveAutumnMajorChoice({campaign:'caretaker',choice:'save_one',thirdEligible:false})).toEqual(expect.objectContaining({accepted:true,choiceId:'save_one'}));
+    expect(resolveAutumnMajorChoice({campaign:'caretaker',choice:'spread_risk',thirdEligible:false})).toEqual(expect.objectContaining({accepted:true,choiceId:'spread_risk'}));
+    expect(resolveAutumnMajorChoice({campaign:'caretaker',choice:'team_solution',thirdEligible:false})).toEqual({accepted:false,reason:'choice_locked'});
+    expect(resolveAutumnMajorChoice({campaign:'caretaker',choice:'limited_access',thirdEligible:true})).toEqual({accepted:false,reason:'invalid_choice'});
+  });
+
+  it('commits a Major Choice exactly once, establishes campaign identity when absent, and blocks conflicting replay',()=>{
+    const choice=resolveAutumnMajorChoice({campaign:'vanguard',choice:'coalition_command',thirdEligible:true});
+    expect(choice.accepted).toBe(true);
+    if(!choice.accepted)return;
+
+    const first=commitAutumnMajorChoice(emptyCampaignRunState(),choice);
+    expect(first.committed).toBe(true);
+    expect(first.state.activeCampaign).toBe('vanguard');
+    expect(first.state.majorChoices.vanguard_autumn).toBe('coalition_command');
+    expect(first.state.seasonMilestones).toContain('autumn_resolved');
+
+    const replay=resolveAutumnMajorChoice({campaign:'vanguard',choice:'centralize',thirdEligible:false});
+    expect(replay.accepted).toBe(true);
+    if(!replay.accepted)return;
+    const second=commitAutumnMajorChoice(first.state,replay);
+    expect(second.committed).toBe(false);
+    expect(second.state).toBe(first.state);
+    expect(second.state.majorChoices.vanguard_autumn).toBe('coalition_command');
+  });
+
+  it('refuses to commit a choice for a campaign that conflicts with activeCampaign',()=>{
+    const state={...emptyCampaignRunState(),activeCampaign:'caretaker' as const};
+    const choice=resolveAutumnMajorChoice({campaign:'arcanist',choice:'destroy_relic',thirdEligible:false});
+    expect(choice.accepted).toBe(true);
+    if(!choice.accepted)return;
+    expect(commitAutumnMajorChoice(state,choice)).toEqual({committed:false,state,reason:'campaign_conflict'});
+  });
+
+  it('emits only compact registered Winter input after Autumn is authoritatively resolved',()=>{
+    const state={
+      ...emptyCampaignRunState(),
+      activeCampaign:'pathfinder' as const,
+      majorChoices:{pathfinder_autumn:'limited_access' as const},
+      majorOutcomes:{great_expedition:'costly_victory' as const},
+      seasonMilestones:['autumn_resolved' as const],
+    };
+    expect(selectWinterCampaignInput(state)).toEqual({
+      campaignId:'pathfinder',
+      autumnChoiceId:'limited_access',
+      greatExpeditionOutcome:'costly_victory',
+    });
+    expect(selectWinterCampaignInput(emptyCampaignRunState())).toBeNull();
+  });
+
+  it('rejects malformed campaign/action/evidence/choice input without opening True Campaign',()=>{
+    expect(resolveAutumnCampaignAction({year:3,week:1,campaign:'true_path',facts:['great_expedition_protect'],claimedKeys:[]})).toEqual({accepted:false,reason:'invalid_context'});
+    expect(resolveAutumnCampaignAction({year:3,week:1,campaign:'vanguard',facts:['great_expedition_protect'],claimedKeys:[]})).toEqual({accepted:false,reason:'no_match'});
+    expect(resolveAutumnThirdOptionEligibility({campaign:'true_path',evidence:['bond_support']})).toEqual({eligible:false,reason:'invalid_campaign'});
+    expect(resolveAutumnMajorChoice({campaign:'true_path',choice:'save_one',thirdEligible:true})).toEqual({accepted:false,reason:'invalid_choice'});
+  });
+});

--- a/src/campaign-autumn-season.ts
+++ b/src/campaign-autumn-season.ts
@@ -1,0 +1,179 @@
+import {
+  mainCampaignIds,
+  majorChoiceOptions,
+  type MainCampaignId,
+  type MajorChoiceId,
+  type MajorChoiceOptionId,
+} from './campaign-model';
+import type {CampaignRunState} from './campaign-state';
+import {sanitizeCampaignSeasonalObjectiveClaimKeys} from './campaign-seasonal-claim-keys';
+
+export type AutumnCampaignActionFact=
+  | 'great_expedition_protect'
+  | 'great_expedition_discovery'
+  | 'great_expedition_command'
+  | 'great_expedition_relic'
+  | 'bond_support'
+  | 'limited_route_evidence'
+  | 'ally_support'
+  | 'astral_mastery';
+
+export type AutumnEvidenceTag=
+  | 'bond_support'
+  | 'protected_civilians'
+  | 'discovery_evidence'
+  | 'limited_route_evidence'
+  | 'ally_support'
+  | 'independent_command_evidence'
+  | 'relic_control_evidence'
+  | 'astral_mastery';
+
+const mainCampaignSet=new Set<string>(mainCampaignIds);
+const factSet=new Set<string>([
+  'great_expedition_protect','great_expedition_discovery','great_expedition_command','great_expedition_relic',
+  'bond_support','limited_route_evidence','ally_support','astral_mastery',
+]);
+const evidenceSet=new Set<string>([
+  'bond_support','protected_civilians','discovery_evidence','limited_route_evidence',
+  'ally_support','independent_command_evidence','relic_control_evidence','astral_mastery',
+]);
+
+function campaignId(value:unknown):MainCampaignId|null{
+  return typeof value==='string'&&mainCampaignSet.has(value)?value as MainCampaignId:null;
+}
+
+function canonicalYear(value:unknown):number|null{
+  return typeof value==='number'&&Number.isInteger(value)&&Number.isFinite(value)&&value>=1?value:null;
+}
+
+function validWeek(value:unknown):boolean{
+  return typeof value==='number'&&Number.isInteger(value)&&value>=1&&value<=4;
+}
+
+function uniqueRegistered<T extends string>(raw:unknown,set:Set<string>):T[]{
+  if(!Array.isArray(raw))return [];
+  return [...new Set(raw.filter((value):value is T=>typeof value==='string'&&set.has(value)))];
+}
+
+const autumnObjectives={
+  caretaker:[
+    {id:'autumn_caretaker_guardianship',facts:['great_expedition_protect']},
+    {id:'autumn_caretaker_bond',facts:['bond_support']},
+  ],
+  pathfinder:[
+    {id:'autumn_pathfinder_route',facts:['great_expedition_discovery']},
+    {id:'autumn_pathfinder_limited_access',facts:['limited_route_evidence']},
+  ],
+  vanguard:[
+    {id:'autumn_vanguard_command',facts:['great_expedition_command']},
+    {id:'autumn_vanguard_coalition',facts:['ally_support']},
+  ],
+  arcanist:[
+    {id:'autumn_arcanist_relic',facts:['great_expedition_relic']},
+    {id:'autumn_arcanist_control',facts:['astral_mastery']},
+  ],
+} as const;
+
+export type AutumnCampaignObjectiveId=typeof autumnObjectives[MainCampaignId][number]['id'];
+
+export function resolveAutumnCampaignAction(input:{
+  year:unknown;
+  week:unknown;
+  campaign:unknown;
+  facts:unknown;
+  claimedKeys:unknown;
+}){
+  const year=canonicalYear(input.year);
+  const campaign=campaignId(input.campaign);
+  if(!year||!campaign||!validWeek(input.week))return {accepted:false as const,reason:'invalid_context' as const};
+  const facts=uniqueRegistered<AutumnCampaignActionFact>(input.facts,factSet);
+  const objective=autumnObjectives[campaign].find(candidate=>candidate.facts.some(fact=>facts.includes(fact as AutumnCampaignActionFact)));
+  if(!objective)return {accepted:false as const,reason:'no_match' as const};
+  const claimKey=`${year}-autumn:${campaign}:${objective.id}` as const;
+  const claimed=sanitizeCampaignSeasonalObjectiveClaimKeys(input.claimedKeys);
+  if(claimed.includes(claimKey))return {accepted:false as const,reason:'already_claimed' as const,objective,claimKey};
+  return {
+    accepted:true as const,
+    objective,
+    claimKey,
+    reward:{kind:'campaign_memory' as const,memoryId:`${objective.id}_memory` as const},
+  };
+}
+
+const thirdChoiceContracts={
+  caretaker:{choiceId:'team_solution',required:['bond_support','protected_civilians']},
+  pathfinder:{choiceId:'limited_access',required:['discovery_evidence','limited_route_evidence']},
+  vanguard:{choiceId:'coalition_command',required:['ally_support','independent_command_evidence']},
+  arcanist:{choiceId:'controlled_use',required:['relic_control_evidence','astral_mastery']},
+} as const;
+
+export function resolveAutumnThirdOptionEligibility(input:{campaign:unknown;evidence:unknown}){
+  const campaign=campaignId(input.campaign);
+  if(!campaign)return {eligible:false as const,reason:'invalid_campaign' as const};
+  const evidence=uniqueRegistered<AutumnEvidenceTag>(input.evidence,evidenceSet);
+  const contract=thirdChoiceContracts[campaign];
+  return {
+    eligible:contract.required.every(tag=>evidence.includes(tag as AutumnEvidenceTag)),
+    campaignId:campaign,
+    choiceId:contract.choiceId,
+  };
+}
+
+const majorChoiceIdByCampaign:Record<MainCampaignId,MajorChoiceId>={
+  caretaker:'caretaker_autumn',
+  pathfinder:'pathfinder_autumn',
+  vanguard:'vanguard_autumn',
+  arcanist:'arcanist_autumn',
+};
+
+export type AcceptedAutumnMajorChoice={
+  accepted:true;
+  campaignId:MainCampaignId;
+  majorChoiceId:MajorChoiceId;
+  choiceId:MajorChoiceOptionId;
+};
+
+export function resolveAutumnMajorChoice(input:{campaign:unknown;choice:unknown;thirdEligible:unknown}):AcceptedAutumnMajorChoice|{accepted:false;reason:'invalid_choice'|'choice_locked'}{
+  const campaign=campaignId(input.campaign);
+  if(!campaign||typeof input.choice!=='string')return {accepted:false,reason:'invalid_choice'};
+  const majorChoiceId=majorChoiceIdByCampaign[campaign];
+  const options=majorChoiceOptions[majorChoiceId] as readonly string[];
+  if(!options.includes(input.choice))return {accepted:false,reason:'invalid_choice'};
+  if(input.choice===options[2]&&input.thirdEligible!==true)return {accepted:false,reason:'choice_locked'};
+  return {accepted:true,campaignId:campaign,majorChoiceId,choiceId:input.choice as MajorChoiceOptionId};
+}
+
+export function commitAutumnMajorChoice(state:CampaignRunState,result:AcceptedAutumnMajorChoice):
+  | {committed:true;state:CampaignRunState}
+  | {committed:false;state:CampaignRunState;reason:'campaign_conflict'|'already_committed'}{
+  if(state.activeCampaign!==null&&state.activeCampaign!==result.campaignId){
+    return {committed:false,state,reason:'campaign_conflict'};
+  }
+  if(state.majorChoices[result.majorChoiceId]!==undefined){
+    return {committed:false,state,reason:'already_committed'};
+  }
+  return {
+    committed:true,
+    state:{
+      ...state,
+      activeCampaign:state.activeCampaign??result.campaignId,
+      majorChoices:{...state.majorChoices,[result.majorChoiceId]:result.choiceId},
+      seasonMilestones:state.seasonMilestones.includes('autumn_resolved')
+        ? state.seasonMilestones
+        : [...state.seasonMilestones,'autumn_resolved'],
+    },
+  };
+}
+
+export function selectWinterCampaignInput(state:CampaignRunState){
+  if(!state.seasonMilestones.includes('autumn_resolved'))return null;
+  const campaign=campaignId(state.activeCampaign);
+  if(!campaign)return null;
+  const choice=state.majorChoices[majorChoiceIdByCampaign[campaign]];
+  if(!choice)return null;
+  return {
+    campaignId:campaign,
+    autumnChoiceId:choice,
+    greatExpeditionOutcome:state.majorOutcomes.great_expedition,
+  };
+}

--- a/src/campaign-seasonal-claim-keys.ts
+++ b/src/campaign-seasonal-claim-keys.ts
@@ -15,11 +15,19 @@ const campaignSeasonalObjectiveClaimTriples = new Set([
   'summer:vanguard:summer_vanguard_chain',
   'summer:arcanist:summer_arcanist_rift',
   'summer:arcanist:summer_arcanist_rule_shift',
+  'autumn:caretaker:autumn_caretaker_guardianship',
+  'autumn:caretaker:autumn_caretaker_bond',
+  'autumn:pathfinder:autumn_pathfinder_route',
+  'autumn:pathfinder:autumn_pathfinder_limited_access',
+  'autumn:vanguard:autumn_vanguard_command',
+  'autumn:vanguard:autumn_vanguard_coalition',
+  'autumn:arcanist:autumn_arcanist_relic',
+  'autumn:arcanist:autumn_arcanist_control',
 ]);
 
 export function isValidCampaignSeasonalObjectiveClaimKey(value:unknown):value is string {
   if(typeof value!=='string') return false;
-  const match=/^([1-9]\d*)-(spring|summer):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
+  const match=/^([1-9]\d*)-(spring|summer|autumn):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
   if(!match) return false;
   return campaignSeasonalObjectiveClaimTriples.has(`${match[2]}:${match[3]}:${match[4]}`);
 }


### PR DESCRIPTION
Parent: #111

Autumn Lane C room candidate.

Implemented:
- campaign-aware Autumn Seasonal Objective adapter from Great Expedition / existing-action facts
- deterministic one-action/one-objective and dedicated reward-once claim keys
- four campaign-specific conditional third-option eligibility contracts from typed prior evidence
- stable existing Major Choice IDs/options from `campaign-model.ts`
- exactly-once Major Choice commit with explicit `committed` side-effect gate
- `activeCampaign` establishment when absent; conflicting campaign/replay cannot overwrite committed history
- `autumn_resolved` milestone
- compact Winter selector (`campaignId`, Autumn choice, Great Expedition outcome) only
- Autumn claim-key hydration registration in the existing dedicated claim ledger

Verified RED before implementation:
- existing 368/368 test files and 1369/1369 tests GREEN
- new Autumn suite failed only because `campaign-autumn-season` did not exist

Final independent verification on head `baf6ad5c579f3c2fd60b28cad156eb5f7471986c`:
- 369/369 test files GREEN
- 1383/1383 tests GREEN
- `src/campaign-autumn-season.test.ts`: 14/14 GREEN
- `npm run build` GREEN (`tsc -b && vite build`)

No new CampaignRun/save fields. No Winter Long Night implementation. No True Campaign expansion. Keep Draft; do not merge integration/v3 here.