### PR TITLE
[01] V3 Autumn Raising — Major Choice + Bond

### DIFF
--- a/src/autumn-major-choice.test.ts
+++ b/src/autumn-major-choice.test.ts
@@ -1,0 +1,103 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCharacterBondsState} from './character-bonds';
+import {
+  applyAutumnChoiceBondConsequence,
+  autumnChoiceDefinition,
+  autumnChoicePresentation,
+  commitAutumnMajorChoice,
+  resolveAutumnChoiceOptions,
+  type AutumnChoiceContext,
+} from './autumn-major-choice';
+
+const context=(overrides:Partial<AutumnChoiceContext>={}):AutumnChoiceContext=>({
+  currentWorldFacts:[],
+  inheritedWorldFacts:[],
+  evidenceKeys:[],
+  characterBonds:emptyCharacterBondsState(),
+  ...overrides,
+});
+
+describe('V3 Autumn Major Choice domain',()=>{
+  it.each([
+    ['caretaker','caretaker_autumn',['save_one','spread_risk'],'team_solution'],
+    ['pathfinder','pathfinder_autumn',['open_route','seal_route'],'limited_access'],
+    ['vanguard','vanguard_autumn',['centralize','preserve_independence'],'coalition_command'],
+    ['arcanist','arcanist_autumn',['use_relic','destroy_relic'],'controlled_use'],
+  ] as const)('defines two base options and one earned option for %s',(campaign,choiceId,baseOptions,earned)=>{
+    const definition=autumnChoiceDefinition(campaign);
+    expect(definition).toMatchObject({campaign,choiceId,baseOptions,earnedOption:earned});
+    expect(new Set(definition?.baseOptions).size).toBe(2);
+  });
+
+  it('never grants an earned third option from inherited history alone',()=>{
+    const resolved=resolveAutumnChoiceOptions('caretaker',context({
+      inheritedWorldFacts:['festival_saved'],
+      evidenceKeys:['caretaker_team_solution_ready'],
+    }));
+    expect(resolved.options).toHaveLength(2);
+    expect(resolved.earned.available).toBe(false);
+  });
+
+  it.each([
+    ['caretaker','caretaker_team_solution_ready','mira_summer_share_responsibility','team_solution'],
+    ['pathfinder','pathfinder_limited_access_ready','kael_summer_respect_boundaries','limited_access'],
+    ['vanguard','vanguard_coalition_command_ready','rex_summer_lead_together','coalition_command'],
+    ['arcanist','arcanist_controlled_use_ready','selene_summer_restrain_power','controlled_use'],
+  ] as const)('unlocks the earned option only from current evidence plus lived Bond history for %s',(campaign,evidence,promise,earned)=>{
+    const bonds=emptyCharacterBondsState();
+    const character=campaign==='caretaker'?'mira':campaign==='pathfinder'?'kael':campaign==='vanguard'?'rex':'selene';
+    bonds[character].promises=[promise];
+    const resolved=resolveAutumnChoiceOptions(campaign,context({
+      currentWorldFacts:['festival_saved'],
+      evidenceKeys:[evidence],
+      characterBonds:bonds,
+    }));
+    expect(resolved.options).toHaveLength(3);
+    expect(resolved.earned).toMatchObject({available:true,optionId:earned});
+  });
+
+  it('rejects unavailable earned options and malformed choices without inventing progression',()=>{
+    expect(commitAutumnMajorChoice('caretaker','team_solution',context(),null).status).toBe('not_available');
+    expect(commitAutumnMajorChoice('caretaker','stale_option' as never,context(),null).status).toBe('invalid_option');
+    expect(commitAutumnMajorChoice('stale_campaign' as never,'save_one',context(),null).status).toBe('invalid_campaign');
+  });
+
+  it('locks the first valid commit and makes replay/re-entry idempotent',()=>{
+    const first=commitAutumnMajorChoice('pathfinder','seal_route',context(),null);
+    expect(first.status).toBe('committed');
+    const same=commitAutumnMajorChoice('pathfinder','seal_route',context(),first.commitment);
+    const conflict=commitAutumnMajorChoice('pathfinder','open_route',context(),first.commitment);
+    expect(same.status).toBe('already_committed');
+    expect(same.commitment).toEqual(first.commitment);
+    expect(conflict.status).toBe('locked');
+    expect(conflict.commitment).toEqual(first.commitment);
+  });
+
+  it.each(['exceptional_victory','victory','costly_victory','defeat'] as const)('keeps Autumn consequence fail-forward after Great Expedition %s',outcome=>{
+    const committed=commitAutumnMajorChoice('arcanist','destroy_relic',context(),null,outcome);
+    expect(committed.status).toBe('committed');
+    expect(committed.aftermath?.storyBeatKey).toContain(`autumn.arcanist.destroy_relic.${outcome}`);
+    expect(committed.aftermath?.winterTensionKey.length).toBeGreaterThan(0);
+  });
+
+  it('applies representative Bond consequence exactly once',()=>{
+    const committed=commitAutumnMajorChoice('vanguard','preserve_independence',context(),null,'costly_victory');
+    const initial=emptyCharacterBondsState();
+    const first=applyAutumnChoiceBondConsequence(initial,committed.aftermath);
+    const second=applyAutumnChoiceBondConsequence(first.bonds,committed.aftermath);
+    expect(first.applied).toBe(true);
+    expect(first.bonds.rex.memories.length).toBe(1);
+    expect(second.applied).toBe(false);
+    expect(second.bonds).toEqual(first.bonds);
+  });
+
+  it('exposes qualitative presentation without raw requirements, scores, or numeric trust',()=>{
+    const resolved=resolveAutumnChoiceOptions('caretaker',context());
+    const view=autumnChoicePresentation(resolved);
+    const serialized=JSON.stringify(view);
+    expect(view.options).toHaveLength(3);
+    expect(view.options[2]).toMatchObject({available:false});
+    expect(view.options[2].hint.length).toBeGreaterThan(0);
+    expect(serialized).not.toMatch(/trust|score|requirement|threshold|campaignAffinities|raw/i);
+  });
+});

--- a/src/autumn-major-choice.test.ts
+++ b/src/autumn-major-choice.test.ts
@@ -10,9 +10,7 @@ import {
 } from './autumn-major-choice';
 
 const context=(overrides:Partial<AutumnChoiceContext>={}):AutumnChoiceContext=>({
-  currentWorldFacts:[],
-  inheritedWorldFacts:[],
-  evidenceKeys:[],
+  thirdEligible:false,
   characterBonds:emptyCharacterBondsState(),
   ...overrides,
 });
@@ -29,31 +27,18 @@ describe('V3 Autumn Major Choice domain',()=>{
     expect(new Set(definition?.baseOptions).size).toBe(2);
   });
 
-  it('never grants an earned third option from inherited history alone',()=>{
-    const resolved=resolveAutumnChoiceOptions('caretaker',context({
-      inheritedWorldFacts:['festival_saved'],
-      evidenceKeys:['caretaker_team_solution_ready'],
-    }));
-    expect(resolved.options).toHaveLength(2);
-    expect(resolved.earned.available).toBe(false);
-  });
-
   it.each([
-    ['caretaker','caretaker_team_solution_ready','mira_summer_share_responsibility','team_solution'],
-    ['pathfinder','pathfinder_limited_access_ready','kael_summer_respect_boundaries','limited_access'],
-    ['vanguard','vanguard_coalition_command_ready','rex_summer_lead_together','coalition_command'],
-    ['arcanist','arcanist_controlled_use_ready','selene_summer_restrain_power','controlled_use'],
-  ] as const)('unlocks the earned option only from current evidence plus lived Bond history for %s',(campaign,evidence,promise,earned)=>{
-    const bonds=emptyCharacterBondsState();
-    const character=campaign==='caretaker'?'mira':campaign==='pathfinder'?'kael':campaign==='vanguard'?'rex':'selene';
-    bonds[character].promises=[promise];
-    const resolved=resolveAutumnChoiceOptions(campaign,context({
-      currentWorldFacts:['festival_saved'],
-      evidenceKeys:[evidence],
-      characterBonds:bonds,
-    }));
-    expect(resolved.options).toHaveLength(3);
-    expect(resolved.earned).toMatchObject({available:true,optionId:earned});
+    ['caretaker','team_solution'],
+    ['pathfinder','limited_access'],
+    ['vanguard','coalition_command'],
+    ['arcanist','controlled_use'],
+  ] as const)('consumes the upstream third-option eligibility result without reinterpreting evidence for %s',(campaign,earned)=>{
+    const locked=resolveAutumnChoiceOptions(campaign,context({thirdEligible:false}));
+    const earnedResult=resolveAutumnChoiceOptions(campaign,context({thirdEligible:true}));
+    expect(locked.options).toHaveLength(2);
+    expect(locked.earned).toMatchObject({available:false,optionId:earned});
+    expect(earnedResult.options).toHaveLength(3);
+    expect(earnedResult.earned).toMatchObject({available:true,optionId:earned});
   });
 
   it('rejects unavailable earned options and malformed choices without inventing progression',()=>{
@@ -86,18 +71,26 @@ describe('V3 Autumn Major Choice domain',()=>{
     const first=applyAutumnChoiceBondConsequence(initial,committed.aftermath);
     const second=applyAutumnChoiceBondConsequence(first.bonds,committed.aftermath);
     expect(first.applied).toBe(true);
-    expect(first.bonds.rex.memories.length).toBe(1);
+    expect(first.bonds.rex.memories).toContain('rex_autumn_preserve_independence');
     expect(second.applied).toBe(false);
     expect(second.bonds).toEqual(first.bonds);
   });
 
-  it('exposes qualitative presentation without raw requirements, scores, or numeric trust',()=>{
+  it('keeps every earned choice commit-able when the upstream gate is open',()=>{
+    for(const [campaign,choice] of [
+      ['caretaker','team_solution'],['pathfinder','limited_access'],['vanguard','coalition_command'],['arcanist','controlled_use'],
+    ] as const){
+      expect(commitAutumnMajorChoice(campaign,choice,context({thirdEligible:true}),null).status).toBe('committed');
+    }
+  });
+
+  it('exposes qualitative presentation without raw eligibility internals, scores, or numeric trust',()=>{
     const resolved=resolveAutumnChoiceOptions('caretaker',context());
     const view=autumnChoicePresentation(resolved);
     const serialized=JSON.stringify(view);
     expect(view.options).toHaveLength(3);
     expect(view.options[2]).toMatchObject({available:false});
     expect(view.options[2].hint.length).toBeGreaterThan(0);
-    expect(serialized).not.toMatch(/trust|score|requirement|threshold|campaignAffinities|raw/i);
+    expect(serialized).not.toMatch(/trust|score|requirement|threshold|campaignAffinities|raw|evidence/i);
   });
 });

--- a/src/autumn-major-choice.test.ts
+++ b/src/autumn-major-choice.test.ts
@@ -1,5 +1,5 @@
 import {describe,expect,it} from 'vitest';
-import {emptyCharacterBondsState} from './character-bonds';
+import {emptyCharacterBondsState,hydrateCharacterBondsState} from './character-bonds';
 import {
   applyAutumnChoiceBondConsequence,
   autumnChoiceDefinition,
@@ -41,6 +41,12 @@ describe('V3 Autumn Major Choice domain',()=>{
     expect(earnedResult.earned).toMatchObject({available:true,optionId:earned});
   });
 
+  it('does not open the earned option for malformed truthy eligibility input',()=>{
+    const malformed=context({thirdEligible:'yes' as never});
+    expect(resolveAutumnChoiceOptions('caretaker',malformed).earned.available).toBe(false);
+    expect(commitAutumnMajorChoice('caretaker','team_solution',malformed,null).status).toBe('not_available');
+  });
+
   it('rejects unavailable earned options and malformed choices without inventing progression',()=>{
     expect(commitAutumnMajorChoice('caretaker','team_solution',context(),null).status).toBe('not_available');
     expect(commitAutumnMajorChoice('caretaker','stale_option' as never,context(),null).status).toBe('invalid_option');
@@ -74,6 +80,25 @@ describe('V3 Autumn Major Choice domain',()=>{
     expect(first.bonds.rex.memories).toContain('rex_autumn_preserve_independence');
     expect(second.applied).toBe(false);
     expect(second.bonds).toEqual(first.bonds);
+  });
+
+  it('keeps registered Autumn Bond consequences through hydration and strips stale ids',()=>{
+    const committed=commitAutumnMajorChoice('arcanist','controlled_use',context({thirdEligible:true}),null,'victory');
+    const applied=applyAutumnChoiceBondConsequence(emptyCharacterBondsState(),committed.aftermath).bonds;
+    const hydrated=hydrateCharacterBondsState({
+      ...applied,
+      selene:{
+        ...applied.selene,
+        memories:[...applied.selene.memories,'stale_memory'],
+        promises:[...applied.selene.promises,'stale_promise'],
+        conflicts:[...applied.selene.conflicts,'stale_conflict'],
+      },
+    });
+    expect(hydrated.selene.memories).toContain('selene_autumn_controlled_use');
+    expect(hydrated.selene.promises).toContain('selene_autumn_controlled_use');
+    expect(hydrated.selene.memories).not.toContain('stale_memory');
+    expect(hydrated.selene.promises).not.toContain('stale_promise');
+    expect(hydrated.selene.conflicts).not.toContain('stale_conflict');
   });
 
   it('keeps every earned choice commit-able when the upstream gate is open',()=>{

--- a/src/autumn-major-choice.ts
+++ b/src/autumn-major-choice.ts
@@ -8,15 +8,6 @@ import {
   type MajorOutcomeResult,
 } from './campaign-model';
 import type {CharacterBondsState} from './character-bonds';
-import {worldFactIds,type WorldFactId} from './world-history';
-
-export const autumnChoiceEvidenceKeys=[
-  'caretaker_team_solution_ready',
-  'pathfinder_limited_access_ready',
-  'vanguard_coalition_command_ready',
-  'arcanist_controlled_use_ready',
-] as const;
-export type AutumnChoiceEvidenceKey=typeof autumnChoiceEvidenceKeys[number];
 
 type AutumnCharacter='mira'|'kael'|'rex'|'selene';
 type AutumnDefinition={
@@ -25,15 +16,11 @@ type AutumnDefinition={
   baseOptions:readonly [MajorChoiceOptionId,MajorChoiceOptionId];
   earnedOption:MajorChoiceOptionId;
   character:AutumnCharacter;
-  evidenceKey:AutumnChoiceEvidenceKey;
-  bondPromise:string;
   earnedHint:string;
 };
 
 export type AutumnChoiceContext={
-  currentWorldFacts:readonly WorldFactId[];
-  inheritedWorldFacts:readonly WorldFactId[];
-  evidenceKeys:readonly AutumnChoiceEvidenceKey[];
+  thirdEligible:boolean;
   characterBonds:CharacterBondsState;
 };
 
@@ -68,23 +55,19 @@ export type AutumnChoiceResolution={
 const definitions:Record<MainCampaignId,AutumnDefinition>={
   caretaker:{
     campaign:'caretaker',choiceId:'caretaker_autumn',baseOptions:['save_one','spread_risk'],earnedOption:'team_solution',
-    character:'mira',evidenceKey:'caretaker_team_solution_ready',bondPromise:'mira_summer_share_responsibility',
-    earnedHint:'함께 짐을 나눠 온 선택들이 새로운 길을 암시합니다.',
+    character:'mira',earnedHint:'함께 짐을 나눠 온 선택들이 새로운 길을 암시합니다.',
   },
   pathfinder:{
     campaign:'pathfinder',choiceId:'pathfinder_autumn',baseOptions:['open_route','seal_route'],earnedOption:'limited_access',
-    character:'kael',evidenceKey:'pathfinder_limited_access_ready',bondPromise:'kael_summer_respect_boundaries',
-    earnedHint:'경계를 존중해 온 기록이 제3의 접근법을 암시합니다.',
+    character:'kael',earnedHint:'경계를 존중해 온 기록이 제3의 접근법을 암시합니다.',
   },
   vanguard:{
     campaign:'vanguard',choiceId:'vanguard_autumn',baseOptions:['centralize','preserve_independence'],earnedOption:'coalition_command',
-    character:'rex',evidenceKey:'vanguard_coalition_command_ready',bondPromise:'rex_summer_lead_together',
-    earnedHint:'함께 지휘해 온 경험이 다른 명령 체계를 떠올리게 합니다.',
+    character:'rex',earnedHint:'함께 지휘해 온 경험이 다른 명령 체계를 떠올리게 합니다.',
   },
   arcanist:{
     campaign:'arcanist',choiceId:'arcanist_autumn',baseOptions:['use_relic','destroy_relic'],earnedOption:'controlled_use',
-    character:'selene',evidenceKey:'arcanist_controlled_use_ready',bondPromise:'selene_summer_restrain_power',
-    earnedHint:'힘을 억제해 온 선택들이 통제된 방법의 가능성을 남깁니다.',
+    character:'selene',earnedHint:'힘을 억제해 온 선택들이 통제된 방법의 가능성을 남깁니다.',
   },
 };
 
@@ -105,24 +88,19 @@ const consequenceByOption:Record<MajorChoiceOptionId,{promiseId:string|null;conf
 
 const isMainCampaign=(value:unknown):value is MainCampaignId=>typeof value==='string'&&(mainCampaignIds as readonly string[]).includes(value);
 const isOutcome=(value:unknown):value is MajorOutcomeResult=>typeof value==='string'&&(majorOutcomeResults as readonly string[]).includes(value);
-const sanitizeWorldFacts=(values:readonly unknown[])=>values.filter((value):value is WorldFactId=>typeof value==='string'&&(worldFactIds as readonly string[]).includes(value));
-const sanitizeEvidence=(values:readonly unknown[])=>values.filter((value):value is AutumnChoiceEvidenceKey=>typeof value==='string'&&(autumnChoiceEvidenceKeys as readonly string[]).includes(value));
 
 export function autumnChoiceDefinition(campaign:unknown):AutumnDefinition|null{
   return isMainCampaign(campaign)?definitions[campaign]:null;
 }
 
-function earnedAvailable(definition:AutumnDefinition,context:AutumnChoiceContext):boolean{
-  const currentFacts=sanitizeWorldFacts(context.currentWorldFacts as readonly unknown[]);
-  const currentEvidence=sanitizeEvidence(context.evidenceKeys as readonly unknown[]);
-  const promises=context.characterBonds?.[definition.character]?.promises ?? [];
-  return currentFacts.length>0&&currentEvidence.includes(definition.evidenceKey)&&promises.includes(definition.bondPromise);
+function earnedAvailable(context:AutumnChoiceContext):boolean{
+  return context?.thirdEligible===true;
 }
 
 export function resolveAutumnChoiceOptions(campaign:unknown,context:AutumnChoiceContext):AutumnChoiceResolution{
   const definition=autumnChoiceDefinition(campaign);
   if(!definition) throw new Error('invalid_campaign');
-  const available=earnedAvailable(definition,context);
+  const available=earnedAvailable(context);
   return {
     campaign:definition.campaign,
     choiceId:definition.choiceId,

--- a/src/autumn-major-choice.ts
+++ b/src/autumn-major-choice.ts
@@ -1,0 +1,208 @@
+import {
+  mainCampaignIds,
+  majorChoiceOptions,
+  majorOutcomeResults,
+  type MainCampaignId,
+  type MajorChoiceId,
+  type MajorChoiceOptionId,
+  type MajorOutcomeResult,
+} from './campaign-model';
+import type {CharacterBondsState} from './character-bonds';
+import {worldFactIds,type WorldFactId} from './world-history';
+
+export const autumnChoiceEvidenceKeys=[
+  'caretaker_team_solution_ready',
+  'pathfinder_limited_access_ready',
+  'vanguard_coalition_command_ready',
+  'arcanist_controlled_use_ready',
+] as const;
+export type AutumnChoiceEvidenceKey=typeof autumnChoiceEvidenceKeys[number];
+
+type AutumnCharacter='mira'|'kael'|'rex'|'selene';
+type AutumnDefinition={
+  campaign:MainCampaignId;
+  choiceId:MajorChoiceId;
+  baseOptions:readonly [MajorChoiceOptionId,MajorChoiceOptionId];
+  earnedOption:MajorChoiceOptionId;
+  character:AutumnCharacter;
+  evidenceKey:AutumnChoiceEvidenceKey;
+  bondPromise:string;
+  earnedHint:string;
+};
+
+export type AutumnChoiceContext={
+  currentWorldFacts:readonly WorldFactId[];
+  inheritedWorldFacts:readonly WorldFactId[];
+  evidenceKeys:readonly AutumnChoiceEvidenceKey[];
+  characterBonds:CharacterBondsState;
+};
+
+export type AutumnChoiceCommitment={
+  campaign:MainCampaignId;
+  choiceId:MajorChoiceId;
+  optionId:MajorChoiceOptionId;
+};
+
+export type AutumnChoiceAftermath={
+  campaign:MainCampaignId;
+  optionId:MajorChoiceOptionId;
+  character:AutumnCharacter;
+  outcome:MajorOutcomeResult;
+  memoryId:string;
+  promiseId:string|null;
+  conflictId:string|null;
+  storyBeatKey:string;
+  winterTensionKey:string;
+  relationshipKey:string;
+  trustDelta:number;
+};
+
+export type AutumnChoiceResolution={
+  campaign:MainCampaignId;
+  choiceId:MajorChoiceId;
+  options:MajorChoiceOptionId[];
+  baseOptions:readonly [MajorChoiceOptionId,MajorChoiceOptionId];
+  earned:{optionId:MajorChoiceOptionId;available:boolean;hint:string};
+};
+
+const definitions:Record<MainCampaignId,AutumnDefinition>={
+  caretaker:{
+    campaign:'caretaker',choiceId:'caretaker_autumn',baseOptions:['save_one','spread_risk'],earnedOption:'team_solution',
+    character:'mira',evidenceKey:'caretaker_team_solution_ready',bondPromise:'mira_summer_share_responsibility',
+    earnedHint:'함께 짐을 나눠 온 선택들이 새로운 길을 암시합니다.',
+  },
+  pathfinder:{
+    campaign:'pathfinder',choiceId:'pathfinder_autumn',baseOptions:['open_route','seal_route'],earnedOption:'limited_access',
+    character:'kael',evidenceKey:'pathfinder_limited_access_ready',bondPromise:'kael_summer_respect_boundaries',
+    earnedHint:'경계를 존중해 온 기록이 제3의 접근법을 암시합니다.',
+  },
+  vanguard:{
+    campaign:'vanguard',choiceId:'vanguard_autumn',baseOptions:['centralize','preserve_independence'],earnedOption:'coalition_command',
+    character:'rex',evidenceKey:'vanguard_coalition_command_ready',bondPromise:'rex_summer_lead_together',
+    earnedHint:'함께 지휘해 온 경험이 다른 명령 체계를 떠올리게 합니다.',
+  },
+  arcanist:{
+    campaign:'arcanist',choiceId:'arcanist_autumn',baseOptions:['use_relic','destroy_relic'],earnedOption:'controlled_use',
+    character:'selene',evidenceKey:'arcanist_controlled_use_ready',bondPromise:'selene_summer_restrain_power',
+    earnedHint:'힘을 억제해 온 선택들이 통제된 방법의 가능성을 남깁니다.',
+  },
+};
+
+const consequenceByOption:Record<MajorChoiceOptionId,{promiseId:string|null;conflictId:string|null}>={
+  save_one:{promiseId:null,conflictId:'mira_autumn_single_rescue_burden'},
+  spread_risk:{promiseId:'mira_autumn_shared_risk',conflictId:null},
+  team_solution:{promiseId:'mira_autumn_team_solution',conflictId:null},
+  open_route:{promiseId:null,conflictId:'kael_autumn_route_overreach'},
+  seal_route:{promiseId:'kael_autumn_guarded_boundary',conflictId:null},
+  limited_access:{promiseId:'kael_autumn_limited_access',conflictId:null},
+  centralize:{promiseId:null,conflictId:'rex_autumn_command_pressure'},
+  preserve_independence:{promiseId:'rex_autumn_shared_command',conflictId:null},
+  coalition_command:{promiseId:'rex_autumn_coalition_command',conflictId:null},
+  use_relic:{promiseId:null,conflictId:'selene_autumn_forbidden_relic_cost'},
+  destroy_relic:{promiseId:'selene_autumn_refuse_relic',conflictId:null},
+  controlled_use:{promiseId:'selene_autumn_controlled_use',conflictId:null},
+};
+
+const isMainCampaign=(value:unknown):value is MainCampaignId=>typeof value==='string'&&(mainCampaignIds as readonly string[]).includes(value);
+const isOutcome=(value:unknown):value is MajorOutcomeResult=>typeof value==='string'&&(majorOutcomeResults as readonly string[]).includes(value);
+const sanitizeWorldFacts=(values:readonly unknown[])=>values.filter((value):value is WorldFactId=>typeof value==='string'&&(worldFactIds as readonly string[]).includes(value));
+const sanitizeEvidence=(values:readonly unknown[])=>values.filter((value):value is AutumnChoiceEvidenceKey=>typeof value==='string'&&(autumnChoiceEvidenceKeys as readonly string[]).includes(value));
+
+export function autumnChoiceDefinition(campaign:unknown):AutumnDefinition|null{
+  return isMainCampaign(campaign)?definitions[campaign]:null;
+}
+
+function earnedAvailable(definition:AutumnDefinition,context:AutumnChoiceContext):boolean{
+  const currentFacts=sanitizeWorldFacts(context.currentWorldFacts as readonly unknown[]);
+  const currentEvidence=sanitizeEvidence(context.evidenceKeys as readonly unknown[]);
+  const promises=context.characterBonds?.[definition.character]?.promises ?? [];
+  return currentFacts.length>0&&currentEvidence.includes(definition.evidenceKey)&&promises.includes(definition.bondPromise);
+}
+
+export function resolveAutumnChoiceOptions(campaign:unknown,context:AutumnChoiceContext):AutumnChoiceResolution{
+  const definition=autumnChoiceDefinition(campaign);
+  if(!definition) throw new Error('invalid_campaign');
+  const available=earnedAvailable(definition,context);
+  return {
+    campaign:definition.campaign,
+    choiceId:definition.choiceId,
+    options:[...definition.baseOptions,...(available?[definition.earnedOption]:[])],
+    baseOptions:definition.baseOptions,
+    earned:{optionId:definition.earnedOption,available,hint:definition.earnedHint},
+  };
+}
+
+function makeAftermath(definition:AutumnDefinition,optionId:MajorChoiceOptionId,outcome:MajorOutcomeResult):AutumnChoiceAftermath{
+  const consequence=consequenceByOption[optionId];
+  return {
+    campaign:definition.campaign,
+    optionId,
+    character:definition.character,
+    outcome,
+    memoryId:`${definition.character}_autumn_${optionId}`,
+    promiseId:consequence.promiseId,
+    conflictId:consequence.conflictId,
+    storyBeatKey:`autumn.${definition.campaign}.${optionId}.${outcome}`,
+    winterTensionKey:`autumn.${definition.campaign}.${optionId}.winter_tension`,
+    relationshipKey:`autumn.${definition.campaign}.${optionId}.relationship`,
+    trustDelta:outcome==='defeat'?1:2,
+  };
+}
+
+export function commitAutumnMajorChoice(
+  campaign:unknown,
+  optionId:unknown,
+  context:AutumnChoiceContext,
+  existing:AutumnChoiceCommitment|null,
+  outcome:MajorOutcomeResult='victory',
+):{status:'invalid_campaign'|'invalid_option'|'not_available'|'committed'|'already_committed'|'locked';commitment:AutumnChoiceCommitment|null;aftermath:AutumnChoiceAftermath|null}{
+  const definition=autumnChoiceDefinition(campaign);
+  if(!definition)return {status:'invalid_campaign',commitment:existing,aftermath:null};
+  const registered=majorChoiceOptions[definition.choiceId] as readonly string[];
+  if(typeof optionId!=='string'||!registered.includes(optionId))return {status:'invalid_option',commitment:existing,aftermath:null};
+  const typedOption=optionId as MajorChoiceOptionId;
+  if(existing){
+    if(existing.campaign===definition.campaign&&existing.choiceId===definition.choiceId&&existing.optionId===typedOption){
+      return {status:'already_committed',commitment:existing,aftermath:null};
+    }
+    return {status:'locked',commitment:existing,aftermath:null};
+  }
+  const resolution=resolveAutumnChoiceOptions(definition.campaign,context);
+  if(!resolution.options.includes(typedOption))return {status:'not_available',commitment:null,aftermath:null};
+  const safeOutcome=isOutcome(outcome)?outcome:'victory';
+  const commitment:AutumnChoiceCommitment={campaign:definition.campaign,choiceId:definition.choiceId,optionId:typedOption};
+  return {status:'committed',commitment,aftermath:makeAftermath(definition,typedOption,safeOutcome)};
+}
+
+export function applyAutumnChoiceBondConsequence(
+  bonds:CharacterBondsState,
+  aftermath:AutumnChoiceAftermath|null|undefined,
+):{bonds:CharacterBondsState;applied:boolean}{
+  if(!aftermath)return {bonds,applied:false};
+  const current=bonds[aftermath.character];
+  if(current.memories.includes(aftermath.memoryId))return {bonds,applied:false};
+  const updated={
+    ...current,
+    trust:Math.max(0,Math.trunc(current.trust+aftermath.trustDelta)),
+    memories:[...current.memories,aftermath.memoryId],
+    promises:aftermath.promiseId&&!current.promises.includes(aftermath.promiseId)?[...current.promises,aftermath.promiseId]:current.promises,
+    conflicts:aftermath.conflictId&&!current.conflicts.includes(aftermath.conflictId)?[...current.conflicts,aftermath.conflictId]:current.conflicts,
+  };
+  return {bonds:{...bonds,[aftermath.character]:updated},applied:true};
+}
+
+export function autumnChoicePresentation(resolution:AutumnChoiceResolution){
+  const definition=definitions[resolution.campaign];
+  const ordered=[...definition.baseOptions,definition.earnedOption];
+  return {
+    campaign:definition.campaign,
+    choiceId:definition.choiceId,
+    titleKey:`autumn.${definition.campaign}.major_choice`,
+    options:ordered.map(optionId=>({
+      id:optionId,
+      labelKey:`autumn.${definition.campaign}.choice.${optionId}`,
+      available:optionId!==definition.earnedOption||resolution.earned.available,
+      hint:optionId===definition.earnedOption?resolution.earned.hint:'',
+    })),
+  };
+}

--- a/src/character-bonds.ts
+++ b/src/character-bonds.ts
@@ -14,24 +14,24 @@ const festivalMemories=(character:'mira'|'kael'|'rex'|'selene')=>[
 
 export const characterBondIdRegistry:Record<CharacterId,Registry>={
   mira:{
-    conflicts:['mira_self_sacrifice','mira_summer_overextended_rescue'],
-    promises:['mira_share_the_burden','mira_summer_share_responsibility'],
-    memories:['mira_first_commitment','mira_festival_rescue',...festivalMemories('mira'),'mira_long_night'],
+    conflicts:['mira_self_sacrifice','mira_summer_overextended_rescue','mira_autumn_single_rescue_burden'],
+    promises:['mira_share_the_burden','mira_summer_share_responsibility','mira_autumn_shared_risk','mira_autumn_team_solution'],
+    memories:['mira_first_commitment','mira_festival_rescue',...festivalMemories('mira'),'mira_autumn_save_one','mira_autumn_spread_risk','mira_autumn_team_solution','mira_long_night'],
   },
   kael:{
-    conflicts:['kael_summer_crossed_boundary'],
-    promises:['kael_summer_respect_boundaries'],
-    memories:['kael_first_commitment',...festivalMemories('kael')],
+    conflicts:['kael_summer_crossed_boundary','kael_autumn_route_overreach'],
+    promises:['kael_summer_respect_boundaries','kael_autumn_guarded_boundary','kael_autumn_limited_access'],
+    memories:['kael_first_commitment',...festivalMemories('kael'),'kael_autumn_open_route','kael_autumn_seal_route','kael_autumn_limited_access'],
   },
   rex:{
-    conflicts:['rex_obsession_with_victory','rex_summer_victory_at_cost'],
-    promises:['rex_fair_rivalry','rex_summer_lead_together'],
-    memories:['rex_first_commitment','rex_first_defeat',...festivalMemories('rex'),'rex_tournament_final'],
+    conflicts:['rex_obsession_with_victory','rex_summer_victory_at_cost','rex_autumn_command_pressure'],
+    promises:['rex_fair_rivalry','rex_summer_lead_together','rex_autumn_shared_command','rex_autumn_coalition_command'],
+    memories:['rex_first_commitment','rex_first_defeat',...festivalMemories('rex'),'rex_autumn_centralize','rex_autumn_preserve_independence','rex_autumn_coalition_command','rex_tournament_final'],
   },
   selene:{
-    conflicts:['selene_summer_forbidden_overreach'],
-    promises:['selene_summer_restrain_power'],
-    memories:['selene_first_commitment',...festivalMemories('selene')],
+    conflicts:['selene_summer_forbidden_overreach','selene_autumn_forbidden_relic_cost'],
+    promises:['selene_summer_restrain_power','selene_autumn_refuse_relic','selene_autumn_controlled_use'],
+    memories:['selene_first_commitment',...festivalMemories('selene'),'selene_autumn_use_relic','selene_autumn_destroy_relic','selene_autumn_controlled_use'],
   },
   noa:{conflicts:[],promises:[],memories:[]},eiden:{conflicts:[],promises:[],memories:[]},
   lyra:{conflicts:[],promises:[],memories:[]},veyr:{conflicts:[],promises:[],memories:[]},


### PR DESCRIPTION
Parent: #109

## [01 Autumn Raising — independent GREEN candidate]

Authoritative baseline: `integration/v3@4933642fec103504ac7cf97192513058b37d20c3`
Candidate: `work/v3-autumn-raising@d58bab2e906fad5b37617f7f4ea7c09bbc5331af`
Status: **Draft / frozen for Lane A consumption / DO NOT MERGE DIRECTLY**

## Scope
- Caretaker / Pathfinder / Vanguard / Arcanist Autumn Major Choice story contracts
- two base options + one conditional earned third option per Campaign
- room 01 **does not derive third-option requirements**; it consumes upstream `thirdEligible`
- first valid story commit locks; same re-entry is idempotent; different re-entry remains locked
- all Great Expedition outcomes (`exceptional_victory | victory | costly_victory | defeat`) produce fail-forward aftermath keys
- representative Mira / Kael / Rex / Selene Character Bond Memory/Promise/Conflict consequences
- Bond aftermath applies exactly once and registered Autumn ids survive hydration while stale ids are stripped
- malformed campaign/choice/eligibility input cannot invent progression
- qualitative 05 presentation DTO exposes no raw eligibility evidence, thresholds, affinity scores, or numeric trust

## Ownership boundary discovered during cross-lane verification
03 Autumn already owns the third-option eligibility criteria and shared CampaignRunState persistence:
- `resolveAutumnThirdOptionEligibility(...)` owns criteria such as Bond/world/discovery/political/astral evidence
- 03 owns the persisted Major Choice and `autumn_resolved`

Therefore this candidate was corrected so 01 consumes only the boolean eligibility result and owns story/Bond interpretation. 02 owns authoritative Great Expedition world/tactical evidence/results. 05 owns presentation/composition. 06 owns final wave integration/save-reload E2E.

## TDD evidence
RED #1582 / run `32553435213`
- existing baseline: **368/368 test files, 1369/1369 existing tests GREEN**
- new Autumn suite failed only with `ERR_MODULE_NOT_FOUND` for `./autumn-major-choice`

First implementation GREEN
- Autumn suite **17/17 GREEN**
- full **369/369 files, 1386/1386 tests GREEN**
- build GREEN

Cross-lane architecture RED #1592 / run `32553655148`
- after tests were changed to consume upstream `thirdEligible`, old production gate failed **13 tests** as expected
- other **368 files / 1373 tests remained GREEN**
- production was then minimized to consume only `context.thirdEligible === true`

Final hardening GREEN #1597 / run `32553808010`
- `src/autumn-major-choice.test.ts`: **19/19 GREEN**
- full suite: **369/369 test files, 1388/1388 tests GREEN**
- `npm run build` = `tsc -b && vite build`: **GREEN**
- TypeScript: **GREEN**
- Vite 8.2.1 production build: **190 modules transformed**
- existing >500 kB chunk warning only

## Exact diff isolation
Compared with authoritative baseline:
- ahead: **6**
- behind: **0**
- changed files: **3**
  - `src/autumn-major-choice.ts`
  - `src/autumn-major-choice.test.ts`
  - `src/character-bonds.ts`

No shared `game.ts`, save schema/resilience, `App.tsx`, or `Root.tsx` changes. No integration/v3/main/prod merge.

## [05 Handoff — Lane A #109]
Consume exact candidate SHA `d58bab2e906fad5b37617f7f4ea7c09bbc5331af`.

01 presentation/story API:
- `autumnChoiceDefinition(campaign)`
- `resolveAutumnChoiceOptions(campaign, { thirdEligible, characterBonds })`
- `commitAutumnMajorChoice(campaign, optionId, context, existingStoryCommitment, greatExpeditionOutcome)`
- `applyAutumnChoiceBondConsequence(characterBonds, aftermath)`
- `autumnChoicePresentation(resolution)`

05 must obtain `thirdEligible` from 03's eligibility domain and must not derive/display raw criteria. Great Expedition outcome comes from the authoritative World/Tactical lane. Compose on `verify/v3-autumn-story-ui` until Story/UI E2E is GREEN.

## [06 Integration Request]
During final Autumn composite wiring, persist the Major Choice / `autumn_resolved` through 03's CampaignRunState contract, then apply 01's Character Bond aftermath exactly once. Save/reload/re-entry E2E must prove the persisted choice and Bond Memory/Promise/Conflict do not duplicate.

Keep this PR Draft. Room 01 does not merge `integration/v3`, `main`, or prod.