### PR TITLE
[04] V3 Autumn: Great Expedition tactical climaxes

### DIFF
--- a/src/autumn-tactical-climax.test.ts
+++ b/src/autumn-tactical-climax.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  autumnGreatExpeditionTacticalClimaxes,
+  getAutumnGreatExpeditionTacticalClimax,
+} from './autumn-tactical-climax';
+import { createTacticalScenarioBattle } from './tactical-scenario';
+
+const campaigns = ['caretaker', 'pathfinder', 'vanguard', 'arcanist'] as const;
+const progression = { maxHp: 120, agility: 15, power: 24, magic: 20 };
+const companions = ['bear', 'owl'] as const;
+
+describe('V3 Autumn Great Expedition Tactical climaxes', () => {
+  it('defines one fail-forward climax for each main campaign using existing scenario vocabulary', () => {
+    expect(autumnGreatExpeditionTacticalClimaxes).toHaveLength(4);
+    expect(autumnGreatExpeditionTacticalClimaxes.map(item => item.campaign)).toEqual(campaigns);
+
+    const caretaker = getAutumnGreatExpeditionTacticalClimax('caretaker')!;
+    expect(caretaker.stageId).toBe('forest_guardian');
+    expect(caretaker.objective).toEqual({ type: 'survive', rounds: 4 });
+    expect(caretaker.modifiers.map(item => item.kind)).toEqual(['rescue', 'survive']);
+
+    const pathfinder = getAutumnGreatExpeditionTacticalClimax('pathfinder')!;
+    expect(pathfinder.stageId).toBe('city_core');
+    expect(pathfinder.objective).toEqual({ type: 'escape', afterRounds: 3 });
+    expect(pathfinder.modifiers.map(item => item.kind)).toEqual(['scout', 'turn-limit', 'escape']);
+
+    const vanguard = getAutumnGreatExpeditionTacticalClimax('vanguard')!;
+    expect(vanguard.stageId).toBe('city_core');
+    expect(vanguard.objective).toEqual({ type: 'target-elimination', targetId: 'city_core-enemy-1' });
+    expect(vanguard.modifiers.map(item => item.kind)).toEqual(['elite', 'chained-battle']);
+
+    const arcanist = getAutumnGreatExpeditionTacticalClimax('arcanist')!;
+    expect(arcanist.stageId).toBe('lake_tempest');
+    expect(arcanist.objective).toEqual({ type: 'standard' });
+    expect(arcanist.modifiers.map(item => item.kind)).toEqual(['relic-resonance', 'status-amplify', 'rule-shift']);
+
+    for (const scenario of autumnGreatExpeditionTacticalClimaxes) {
+      expect(scenario.failForward).toBe(true);
+    }
+  });
+
+  it('creates normal 3v3 battle sessions through the existing Tactical engine', () => {
+    for (const [index, scenario] of autumnGreatExpeditionTacticalClimaxes.entries()) {
+      const battle = createTacticalScenarioBattle(scenario, companions, progression, 201 + index);
+      expect(battle.units.filter(unit => unit.side === 'ally')).toHaveLength(3);
+      expect(battle.units.filter(unit => unit.side === 'enemy')).toHaveLength(3);
+    }
+  });
+
+  it('rejects malformed campaign lookup without fallback', () => {
+    expect(getAutumnGreatExpeditionTacticalClimax('not-a-campaign')).toBeNull();
+    expect(getAutumnGreatExpeditionTacticalClimax(null)).toBeNull();
+  });
+});

--- a/src/autumn-tactical-climax.ts
+++ b/src/autumn-tactical-climax.ts
@@ -1,0 +1,73 @@
+import type { MainCampaignId } from './campaign-model';
+import {
+  campaignEncounterToTacticalScenario,
+  type CampaignEncounterDefinition,
+  type TacticalScenario,
+} from './tactical-scenario';
+
+const definitions: readonly CampaignEncounterDefinition[] = [
+  {
+    id: 'autumn-great-expedition:caretaker',
+    campaign: 'caretaker',
+    stageId: 'forest_guardian',
+    objective: { type: 'survive', rounds: 4 },
+    modifiers: [
+      { campaign: 'caretaker', kind: 'rescue', unitId: 'great-expedition-critical-person' },
+      { campaign: 'caretaker', kind: 'survive', rounds: 4 },
+    ],
+    failForward: true,
+  },
+  {
+    id: 'autumn-great-expedition:pathfinder',
+    campaign: 'pathfinder',
+    stageId: 'city_core',
+    objective: { type: 'escape', afterRounds: 3 },
+    modifiers: [
+      { campaign: 'pathfinder', kind: 'scout', revealCount: 2 },
+      { campaign: 'pathfinder', kind: 'turn-limit', maxRounds: 6 },
+      { campaign: 'pathfinder', kind: 'escape', afterRounds: 3 },
+    ],
+    failForward: true,
+  },
+  {
+    id: 'autumn-great-expedition:vanguard',
+    campaign: 'vanguard',
+    stageId: 'city_core',
+    objective: { type: 'target-elimination', targetId: 'city_core-enemy-1' },
+    modifiers: [
+      { campaign: 'vanguard', kind: 'elite', levelBonus: 3 },
+      {
+        campaign: 'vanguard',
+        kind: 'chained-battle',
+        chainId: 'great-expedition-command-front',
+        index: 3,
+        total: 3,
+      },
+    ],
+    failForward: true,
+  },
+  {
+    id: 'autumn-great-expedition:arcanist',
+    campaign: 'arcanist',
+    stageId: 'lake_tempest',
+    objective: { type: 'standard' },
+    modifiers: [
+      { campaign: 'arcanist', kind: 'relic-resonance', relicId: 'forbidden-great-expedition-relic' },
+      { campaign: 'arcanist', kind: 'status-amplify', statusId: 'break', multiplier: 1.75 },
+      { campaign: 'arcanist', kind: 'rule-shift', ruleId: 'great-expedition-rift-shift' },
+    ],
+    failForward: true,
+  },
+] as const;
+
+export const autumnGreatExpeditionTacticalClimaxes: readonly TacticalScenario[] =
+  definitions.map(campaignEncounterToTacticalScenario);
+
+export function getAutumnGreatExpeditionTacticalClimax(
+  campaign: unknown,
+): TacticalScenario | null {
+  if (typeof campaign !== 'string') return null;
+  return autumnGreatExpeditionTacticalClimaxes.find(
+    climax => climax.campaign === (campaign as MainCampaignId),
+  ) ?? null;
+}


### PR DESCRIPTION
Parent: #110

## Status
**04 Autumn Tactical independent GREEN candidate**

- baseline: `integration/v3@4933642fec103504ac7cf97192513058b37d20c3`
- head: `work/v3-autumn-tactical@a42e7668e9ce312de156ccc011bee6a6e566110b`
- merge-ref: `c2f30d4f135e1f060f5ca6112a0d987a7f661237`
- Draft / unmerged

## Four Great Expedition climaxes
- Caretaker: `forest_guardian`, survive 4 + rescue pressure
- Pathfinder: `city_core`, escape after 3 + scout/turn-limit pressure
- Vanguard: `city_core`, target elimination + elite/chained-battle pressure
- Arcanist: `lake_tempest`, standard + relic-resonance/status-amplify/rule-shift
- all `failForward: true`
- existing `CampaignEncounterDefinition -> TacticalScenario` adapter and existing 3v3 engine only

## TDD evidence
- CI #1594 / run `32553707463`: expected RED; only new `autumn-tactical-climax.test.ts` failed because production module was intentionally absent.
- Existing baseline remained **368/368 files, 1369/1369 tests GREEN** during RED.
- Tactical stability 13/13, AUTO 10/50/100, and Expedition stress 4/4 were already GREEN in the RED run, isolating the failure to the missing Autumn adapter.

## Final GREEN verification
- CI **#1596** / run `32553769480`: **SUCCESS**
- `src/autumn-tactical-climax.test.ts`: **3/3 PASS**
- full suite: **369/369 test files, 1372/1372 tests PASS**
- `src/tactical-stability.test.ts`: **13/13 PASS**
- AUTO bounded/progressing through **10 / 50 / 100** battle checkpoints: GREEN
- `src/expedition-stress.test.ts`: **4/4 PASS**
- `npm run build` = `tsc -b && vite build`: PASS
- production build: PASS; 190 modules transformed

## Guardrails
- no World registry/objective edits in this branch
- no shared game/save/App/Root edits
- no new map/engine
- no Winter/Long Night
- no integration/v3/main/prod merge

Existing repository warnings remain: npm reports 1 high severity vulnerability; Vite reports >500 kB chunk warning.