### PR TITLE
[Lane B] V3 Autumn Great Expedition + Tactical verification

### DIFF
--- a/docs/superpowers/plans/2026-08-22-v3-autumn-great-expedition-world-tactical.md
+++ b/docs/superpowers/plans/2026-08-22-v3-autumn-great-expedition-world-tactical.md
@@ -1,0 +1,189 @@
+# V3 Autumn Great Expedition World + Tactical Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver four campaign-specific Great Expedition World/Tactical paths with typed outcome evidence and typed Major Choice consequence mappings, then compose Lane B to GREEN without implementing Major Choice state or Winter.
+
+**Architecture:** Extend the existing campaign-world and central WorldFact registries minimally, add Autumn route and Tactical climax adapters patterned after Summer, then compose both room candidates on the Autumn Lane B verify branch. Existing Expedition stages, TacticalScenario adapter, terminal handoff, and 3v3 engine remain authoritative.
+
+**Tech Stack:** TypeScript, Vitest, React/Vite repository build, GitHub Actions CI.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-v3-autumn-great-expedition-world-tactical-design.md`
+
+## Global Constraints
+- Baseline is `integration/v3@4933642fec103504ac7cf97192513058b37d20c3`.
+- No direct `integration/v3` merge from feature/lane branches.
+- No main/prod changes.
+- No shared `App.tsx`, `Root.tsx`, game/save persistence edits in Lane B.
+- No Winter/Long Night implementation.
+- No Major Choice commit/runtime ownership; Lane C owns exactly-once choice state.
+- No free-form World history strings.
+- Reuse existing Expedition stages and current 3v3 engine only.
+
+---
+
+### Task 1: Autumn World objective and typed fact contracts
+
+**Files:**
+- Modify: `src/campaign-world.ts`
+- Modify: `src/world-history.ts`
+- Create: `src/autumn-campaign-world.ts`
+- Create: `src/autumn-campaign-world.test.ts`
+
+**Interfaces:**
+- Consumes: `buildGreatExpeditionWorldPrerequisite(input)` and existing Expedition region/stage IDs.
+- Produces: `AutumnGreatExpeditionWorldRoute`, `autumnGreatExpeditionWorldRoutes`, `getAutumnGreatExpeditionWorldRoute(campaign, prerequisite?)` and the missing stable Autumn `WorldFactId` values.
+
+- [ ] **Step 1: Write failing World tests**
+
+Create tests asserting exactly four Autumn routes, existing stage reuse, Guardian Festival prerequisite gating, malformed campaign rejection, and presence/sanitation of the five new stable facts.
+
+- [ ] **Step 2: Run the targeted tests and record RED**
+
+Run: `npm run test -- src/autumn-campaign-world.test.ts`
+Expected: FAIL because Autumn route module/objectives/facts are not implemented.
+
+- [ ] **Step 3: Implement minimal World contracts**
+
+Extend `CampaignWorldSeason` with `'autumn'`, add four Great Expedition objective IDs/definitions, add only the five spec WorldFact IDs, and implement a validated Autumn route lookup patterned after `summer-campaign-world.ts`.
+
+- [ ] **Step 4: Re-run targeted World tests**
+
+Run: `npm run test -- src/autumn-campaign-world.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit World candidate slice**
+
+Commit message: `feat: add Autumn Great Expedition world routes`
+
+### Task 2: Typed Major Choice consequence mapping
+
+**Files:**
+- Create: `src/autumn-world-consequences.ts`
+- Create: `src/autumn-world-consequences.test.ts`
+
+**Interfaces:**
+- Consumes: `MainCampaignId`, `MajorChoiceOptionId`, `WorldFactId`.
+- Produces: `getAutumnMajorChoiceWorldFacts(campaign, choice): readonly WorldFactId[] | null`.
+
+- [ ] **Step 1: Write failing mapping tests**
+
+Cover all twelve campaign choice options and reject cross-campaign options. Assert no free-form strings and exact expected typed facts.
+
+- [ ] **Step 2: Run targeted consequence tests and record RED**
+
+Run: `npm run test -- src/autumn-world-consequences.test.ts`
+Expected: FAIL because mapping module is absent.
+
+- [ ] **Step 3: Implement minimal pure mapping**
+
+Map Caretaker to the three new caretaker facts; Pathfinder to `ancient_route_opened|sealed|limited`; Vanguard to `eiden_central_command|regional_alliance|coalition_command`; Arcanist to `forbidden_relic_used|forbidden_relic_destroyed|forbidden_relic_controlled`.
+
+- [ ] **Step 4: Re-run targeted consequence tests**
+
+Run: `npm run test -- src/autumn-world-consequences.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit World consequence slice**
+
+Commit message: `feat: add typed Autumn world consequences`
+
+### Task 3: Four Autumn Tactical climax definitions
+
+**Files:**
+- Create: `src/autumn-tactical-climax.ts`
+- Create: `src/autumn-tactical-climax.test.ts`
+
+**Interfaces:**
+- Consumes: `CampaignEncounterDefinition`, `campaignEncounterToTacticalScenario`.
+- Produces: `autumnGreatExpeditionTacticalClimaxes`, `getAutumnGreatExpeditionTacticalClimax(campaign)`.
+
+- [ ] **Step 1: Write failing Tactical tests**
+
+Assert four campaign scenarios, correct campaign/stage identity, only existing objective/modifier vocabulary, `failForward: true`, malformed lookup null, and battle creation yields the normal 3v3 shape.
+
+- [ ] **Step 2: Run targeted Tactical tests and record RED**
+
+Run: `npm run test -- src/autumn-tactical-climax.test.ts`
+Expected: FAIL because module is absent.
+
+- [ ] **Step 3: Implement minimal Tactical definitions**
+
+Caretaker uses rescue/protect-or-survive pressure; Pathfinder escape + scout + turn-limit; Vanguard elite + chained-battle; Arcanist relic-resonance + status-amplify + rule-shift. Reuse only existing stages from the matching Autumn World objective.
+
+- [ ] **Step 4: Re-run targeted Tactical tests**
+
+Run: `npm run test -- src/autumn-tactical-climax.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run Tactical stability gates**
+
+Run targeted Tactical scenario/stability suites and verify AUTO 10/50/100 remains bounded.
+
+- [ ] **Step 6: Commit Tactical candidate slice**
+
+Commit message: `feat: add Autumn Great Expedition tactical climaxes`
+
+### Task 4: Independent room verification and Draft PRs
+
+**Files:**
+- No production changes unless verification exposes an owned regression.
+
+**Interfaces:**
+- Produces exact GREEN 02 World head and exact GREEN 04 Tactical head for Lane composition.
+
+- [ ] **Step 1: Run 02 targeted + full + build**
+
+Run World targeted tests, full `npm run test`, then `npm run build` (`tsc -b && vite build`).
+
+- [ ] **Step 2: Create/update 02 Draft PR**
+
+Base: `integration/v3`. Record RED/GREEN evidence and exact head.
+
+- [ ] **Step 3: Run 04 targeted/stress + full + build**
+
+Run Tactical climax/scenario/stability tests, full `npm run test`, then `npm run build`.
+
+- [ ] **Step 4: Create/update 04 Draft PR**
+
+Base: `integration/v3`. Record stress/full/build evidence and exact head.
+
+### Task 5: Lane B composition and Great Expedition E2E
+
+**Files:**
+- Create: `src/autumn-world-tactical-lane.ts`
+- Create: `src/autumn-world-tactical-lane.test.ts`
+
+**Interfaces:**
+- Consumes exact GREEN World/Tactical candidate heads, existing terminal handoff helpers, and typed Autumn consequence mapping.
+- Produces lane adapter/evidence contract and exact GREEN `verify/v3-autumn-world-tactical` head.
+
+- [ ] **Step 1: Compose exact room heads on verify branch**
+
+Do not reconstruct room commits manually; use the exact independently GREEN heads.
+
+- [ ] **Step 2: Write failing Lane E2E tests**
+
+For Caretaker, Pathfinder, Vanguard, Arcanist, assert route -> Tactical scenario -> 3v3 -> terminal -> once-only handoff -> bounded Great Expedition evidence. Assert second handoff is null, campaign/stage mismatches reject, current/inherited history remains distinct, and all twelve choice mappings return typed facts only.
+
+- [ ] **Step 3: Run Lane E2E and record RED**
+
+Run: `npm run test -- src/autumn-world-tactical-lane.test.ts`
+Expected: FAIL until the lane adapter exists.
+
+- [ ] **Step 4: Implement minimal lane adapter**
+
+Validate route/climax identity, convert terminal result into bounded Great Expedition evidence, and call the pure typed consequence mapping without committing Major Choice state.
+
+- [ ] **Step 5: Run Lane E2E targeted**
+
+Run: `npm run test -- src/autumn-world-tactical-lane.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Run full lane verification**
+
+Run full tests, Tactical stability/AUTO 10/50/100, `tsc -b`, and production build.
+
+- [ ] **Step 7: Open/update Draft Lane PR and hand off to #110/#112**
+
+Record exact verify head, test counts, stress evidence, build evidence, and freeze Lane B unless final composite exposes a concrete regression.

--- a/docs/superpowers/specs/2026-08-22-v3-autumn-great-expedition-world-tactical-design.md
+++ b/docs/superpowers/specs/2026-08-22-v3-autumn-great-expedition-world-tactical-design.md
@@ -1,0 +1,71 @@
+# V3 Autumn Great Expedition World + Tactical Design
+
+## Scope
+Autumn Lane B delivers one shared Great Expedition event with four campaign-specific objectives. It reuses existing Expedition regions/stages, the existing `CampaignEncounterDefinition -> TacticalScenario` adapter, and the current 3v3 engine. It does not implement Major Choice commit, Winter/Long Night, a new map, a new battle engine, or shared save wiring.
+
+Authoritative baseline: `integration/v3@4933642fec103504ac7cf97192513058b37d20c3`.
+Lane: #110. Work branches: `work/v3-autumn-world`, `work/v3-autumn-tactical`. Verify branch: `verify/v3-autumn-world-tactical`.
+
+## Architecture
+The implementation follows the Summer Lane B pattern with a thin Autumn layer.
+
+1. `campaign-world.ts` gains Autumn Great Expedition objective definitions that reuse existing Expedition stages.
+2. `world-history.ts` remains the single typed WorldFact registry. Add only stable facts required by Autumn consequences that are not already represented.
+3. `autumn-campaign-world.ts` maps each campaign to a Great Expedition route and exposes a validated lookup. It consumes the existing `buildGreatExpeditionWorldPrerequisite` so no route is ready without a valid active campaign plus resolved Guardian Festival history.
+4. `autumn-tactical-climax.ts` maps the four routes to existing TacticalScenario objective/modifier vocabulary. No new tactical engine behavior is introduced.
+5. `autumn-world-tactical-lane.ts` is verification/lane glue only: it ensures World and Tactical campaign/stage identity match, maps terminal results to Great Expedition evidence, and exposes a pure canonical mapping from Autumn Major Choice option IDs to typed WorldFact IDs. It does not commit the Major Choice itself.
+
+## Campaign identities
+- Caretaker: rescue/protection/resource-sharing pressure. Great Expedition evidence records whether the team protected the critical person and shared responsibility. Choice-facing typed facts distinguish `save_one`, `spread_risk`, and earned `team_solution`.
+- Pathfinder: ancient-route discovery/traversal under limited-action pressure. Reuse `ancient_route_opened`, `ancient_route_sealed`, `ancient_route_limited` for the three Autumn choices.
+- Vanguard: elite/chained command pressure. Reuse `eiden_central_command` and `regional_alliance`; add one stable coalition-command fact for the earned third option.
+- Arcanist: forbidden Relic/Rift/rule-shift pressure. Reuse `forbidden_relic_used`, `forbidden_relic_destroyed`, and add one controlled-use fact for the earned third option while preserving existing rift facts for environmental evidence.
+
+## Stable World Facts
+Add only these missing consequence IDs to the central registry:
+- `caretaker_critical_person_saved`
+- `caretaker_risk_shared`
+- `caretaker_team_solution`
+- `coalition_command`
+- `forbidden_relic_controlled`
+
+Existing facts remain authoritative where already available. Current/inherited arrays continue to hydrate through the central registry and remain separate.
+
+## Great Expedition outcome/evidence contract
+Lane B owns Great Expedition gameplay result and evidence, not Major Choice persistence. Terminal Tactical results use existing objective/battle result fields and once-only handoff semantics. Lane tests derive a bounded outcome/evidence record containing campaign, objective success/failure, battle result, surviving allies, damage, and typed evidence. Replayed terminal results must not produce a second handoff or overwrite the first result.
+
+Major Choice consequence mapping is pure and typed:
+`(campaign, choiceOptionId) -> readonly WorldFactId[]`.
+Invalid cross-campaign option IDs return no mapping or throw at the boundary; they never synthesize a fallback string.
+
+## Tactical mapping
+Use only existing objective/modifier vocabulary already supported by `tactical-scenario.ts`.
+- Caretaker: protect/survive + rescue pressure.
+- Pathfinder: escape/traversal + scout + turn-limit pressure.
+- Vanguard: target-elimination/standard with elite + chained-battle pressure.
+- Arcanist: standard/target-elimination with relic-resonance + status-amplify + rule-shift pressure.
+
+All scenarios set `failForward: true` and reuse existing Expedition stage IDs.
+
+## Guardrails
+- No direct `integration/v3` merge from feature/lane branches.
+- No main/prod changes.
+- No `App.tsx`, `Root.tsx`, shared game/save persistence edits in Lane B.
+- No Winter/Long Night implementation.
+- No Major Choice commit/runtime ownership; Lane C owns exactly-once choice state.
+- No free-form World history strings.
+- Preserve Guardian Festival history, current/inherited separation, Tactical sanitation, terminal once-only behavior, and AUTO boundedness.
+
+## Verification
+TDD order:
+1. World objective/route contracts and typed WorldFact registry.
+2. Great Expedition prerequisite gating and malformed campaign lookup.
+3. Four Tactical climax definitions using existing stages/engine.
+4. Lane E2E for all four campaigns: World route -> Tactical battle -> objective terminal -> once-only handoff -> Great Expedition evidence.
+5. Choice-to-typed-fact mapping for all twelve Autumn options, including cross-campaign rejection.
+6. Replay/re-entry cannot overwrite terminal evidence.
+7. Current/inherited facts remain distinct and sanitation removes stale IDs.
+8. Tactical stability and 10/50/100 AUTO stress remain GREEN.
+9. Full test suite, `tsc -b`, and production build GREEN.
+
+Lane B is complete only when exact 02/04 candidates are composed on `verify/v3-autumn-world-tactical` and the lane E2E is GREEN.

--- a/src/autumn-campaign-world.test.ts
+++ b/src/autumn-campaign-world.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  autumnGreatExpeditionWorldRoutes,
+  getAutumnGreatExpeditionWorldRoute,
+} from './autumn-campaign-world';
+import { worldFactIds } from './world-history';
+
+const campaigns = ['caretaker', 'pathfinder', 'vanguard', 'arcanist'] as const;
+
+describe('V3 Autumn Great Expedition World routes', () => {
+  it('defines one existing-stage Great Expedition route for each main campaign', () => {
+    expect(autumnGreatExpeditionWorldRoutes).toHaveLength(4);
+    expect(autumnGreatExpeditionWorldRoutes.map(route => route.campaign)).toEqual(campaigns);
+    for (const route of autumnGreatExpeditionWorldRoutes) {
+      expect(route.eventId).toBe('great_expedition');
+      expect(route.failForward).toBe(true);
+      expect(route.stageId.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('requires a resolved Guardian Festival prerequisite before a route is ready', () => {
+    expect(getAutumnGreatExpeditionWorldRoute('caretaker', {
+      activeCampaign: 'caretaker',
+      worldHistory: { currentFacts: ['festival_saved'], inheritedFacts: [] },
+      majorOutcomes: { guardian_festival: 'victory' },
+      failForwardOutcomes: [],
+    })?.campaign).toBe('caretaker');
+
+    expect(getAutumnGreatExpeditionWorldRoute('caretaker', {
+      activeCampaign: 'caretaker',
+      worldHistory: { currentFacts: [], inheritedFacts: [] },
+      majorOutcomes: {},
+      failForwardOutcomes: [],
+    })).toBeNull();
+
+    expect(getAutumnGreatExpeditionWorldRoute('not-a-campaign', null)).toBeNull();
+  });
+
+  it('registers only the missing stable Autumn consequence facts in the central registry', () => {
+    expect(worldFactIds).toEqual(expect.arrayContaining([
+      'caretaker_critical_person_saved',
+      'caretaker_risk_shared',
+      'caretaker_team_solution',
+      'coalition_command',
+      'forbidden_relic_controlled',
+    ]));
+  });
+});

--- a/src/autumn-campaign-world.ts
+++ b/src/autumn-campaign-world.ts
@@ -1,0 +1,98 @@
+import type { MainCampaignId } from './campaign-model';
+import {
+  buildGreatExpeditionWorldPrerequisite,
+  campaignWorldObjectives,
+  type CampaignWorldObjectiveId,
+  type GreatExpeditionWorldPrerequisiteInput,
+} from './campaign-world';
+import type { ExpeditionRegionId, ExpeditionStageId } from './expedition-regions';
+
+export type AutumnGreatExpeditionWorldIdentity =
+  | 'rescue_resource_sharing'
+  | 'ancient_route_traversal'
+  | 'coalition_command_pressure'
+  | 'forbidden_relic_rift';
+
+export type AutumnGreatExpeditionWorldPressure =
+  | 'critical_person_protection'
+  | 'limited_action_traversal'
+  | 'elite_chain_command'
+  | 'relic_rule_shift';
+
+export type AutumnGreatExpeditionWorldRoute = Readonly<{
+  eventId: 'great_expedition';
+  campaign: MainCampaignId;
+  identity: AutumnGreatExpeditionWorldIdentity;
+  objectiveId: CampaignWorldObjectiveId;
+  regionId: ExpeditionRegionId;
+  stageId: ExpeditionStageId;
+  pressure: AutumnGreatExpeditionWorldPressure;
+  failForward: true;
+}>;
+
+const route = (
+  campaign: MainCampaignId,
+  identity: AutumnGreatExpeditionWorldIdentity,
+  objectiveId: CampaignWorldObjectiveId,
+  stageId: ExpeditionStageId,
+  pressure: AutumnGreatExpeditionWorldPressure,
+): AutumnGreatExpeditionWorldRoute => {
+  const objective = campaignWorldObjectives.find(candidate => candidate.id === objectiveId);
+  if (!objective || objective.season !== 'autumn' || objective.campaign !== campaign) {
+    throw new Error('Autumn Great Expedition route requires a matching Autumn World objective');
+  }
+  if (!objective.stageIds.includes(stageId)) {
+    throw new Error('Autumn Great Expedition route must reuse an existing objective stage');
+  }
+  return {
+    eventId: 'great_expedition',
+    campaign,
+    identity,
+    objectiveId,
+    regionId: objective.regionId,
+    stageId,
+    pressure,
+    failForward: true,
+  };
+};
+
+export const autumnGreatExpeditionWorldRoutes: readonly AutumnGreatExpeditionWorldRoute[] = [
+  route(
+    'caretaker',
+    'rescue_resource_sharing',
+    'autumn_caretaker_great_expedition_rescue',
+    'forest_guardian',
+    'critical_person_protection',
+  ),
+  route(
+    'pathfinder',
+    'ancient_route_traversal',
+    'autumn_pathfinder_great_expedition_route',
+    'city_core',
+    'limited_action_traversal',
+  ),
+  route(
+    'vanguard',
+    'coalition_command_pressure',
+    'autumn_vanguard_great_expedition_command',
+    'city_core',
+    'elite_chain_command',
+  ),
+  route(
+    'arcanist',
+    'forbidden_relic_rift',
+    'autumn_arcanist_great_expedition_relic',
+    'lake_tempest',
+    'relic_rule_shift',
+  ),
+] as const;
+
+export function getAutumnGreatExpeditionWorldRoute(
+  campaign: unknown,
+  prerequisiteInput: GreatExpeditionWorldPrerequisiteInput | null,
+): AutumnGreatExpeditionWorldRoute | null {
+  if (typeof campaign !== 'string' || !prerequisiteInput) return null;
+  const prerequisite = buildGreatExpeditionWorldPrerequisite(prerequisiteInput);
+  if (!prerequisite.ready || prerequisite.campaign !== campaign) return null;
+  return autumnGreatExpeditionWorldRoutes.find(route => route.campaign === campaign) ?? null;
+}

--- a/src/autumn-tactical-climax.test.ts
+++ b/src/autumn-tactical-climax.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  autumnGreatExpeditionTacticalClimaxes,
+  getAutumnGreatExpeditionTacticalClimax,
+} from './autumn-tactical-climax';
+import { createTacticalScenarioBattle } from './tactical-scenario';
+
+const campaigns = ['caretaker', 'pathfinder', 'vanguard', 'arcanist'] as const;
+const progression = { maxHp: 120, agility: 15, power: 24, magic: 20 };
+const companions = ['bear', 'owl'] as const;
+
+describe('V3 Autumn Great Expedition Tactical climaxes', () => {
+  it('defines one fail-forward climax for each main campaign using existing scenario vocabulary', () => {
+    expect(autumnGreatExpeditionTacticalClimaxes).toHaveLength(4);
+    expect(autumnGreatExpeditionTacticalClimaxes.map(item => item.campaign)).toEqual(campaigns);
+
+    const caretaker = getAutumnGreatExpeditionTacticalClimax('caretaker')!;
+    expect(caretaker.stageId).toBe('forest_guardian');
+    expect(caretaker.objective).toEqual({ type: 'survive', rounds: 4 });
+    expect(caretaker.modifiers.map(item => item.kind)).toEqual(['rescue', 'survive']);
+
+    const pathfinder = getAutumnGreatExpeditionTacticalClimax('pathfinder')!;
+    expect(pathfinder.stageId).toBe('city_core');
+    expect(pathfinder.objective).toEqual({ type: 'escape', afterRounds: 3 });
+    expect(pathfinder.modifiers.map(item => item.kind)).toEqual(['scout', 'turn-limit', 'escape']);
+
+    const vanguard = getAutumnGreatExpeditionTacticalClimax('vanguard')!;
+    expect(vanguard.stageId).toBe('city_core');
+    expect(vanguard.objective).toEqual({ type: 'target-elimination', targetId: 'city_core-enemy-1' });
+    expect(vanguard.modifiers.map(item => item.kind)).toEqual(['elite', 'chained-battle']);
+
+    const arcanist = getAutumnGreatExpeditionTacticalClimax('arcanist')!;
+    expect(arcanist.stageId).toBe('lake_tempest');
+    expect(arcanist.objective).toEqual({ type: 'standard' });
+    expect(arcanist.modifiers.map(item => item.kind)).toEqual(['relic-resonance', 'status-amplify', 'rule-shift']);
+
+    for (const scenario of autumnGreatExpeditionTacticalClimaxes) {
+      expect(scenario.failForward).toBe(true);
+    }
+  });
+
+  it('creates normal 3v3 battle sessions through the existing Tactical engine', () => {
+    for (const [index, scenario] of autumnGreatExpeditionTacticalClimaxes.entries()) {
+      const battle = createTacticalScenarioBattle(scenario, companions, progression, 201 + index);
+      expect(battle.units.filter(unit => unit.side === 'ally')).toHaveLength(3);
+      expect(battle.units.filter(unit => unit.side === 'enemy')).toHaveLength(3);
+    }
+  });
+
+  it('rejects malformed campaign lookup without fallback', () => {
+    expect(getAutumnGreatExpeditionTacticalClimax('not-a-campaign')).toBeNull();
+    expect(getAutumnGreatExpeditionTacticalClimax(null)).toBeNull();
+  });
+});

--- a/src/autumn-tactical-climax.ts
+++ b/src/autumn-tactical-climax.ts
@@ -1,0 +1,73 @@
+import type { MainCampaignId } from './campaign-model';
+import {
+  campaignEncounterToTacticalScenario,
+  type CampaignEncounterDefinition,
+  type TacticalScenario,
+} from './tactical-scenario';
+
+const definitions: readonly CampaignEncounterDefinition[] = [
+  {
+    id: 'autumn-great-expedition:caretaker',
+    campaign: 'caretaker',
+    stageId: 'forest_guardian',
+    objective: { type: 'survive', rounds: 4 },
+    modifiers: [
+      { campaign: 'caretaker', kind: 'rescue', unitId: 'great-expedition-critical-person' },
+      { campaign: 'caretaker', kind: 'survive', rounds: 4 },
+    ],
+    failForward: true,
+  },
+  {
+    id: 'autumn-great-expedition:pathfinder',
+    campaign: 'pathfinder',
+    stageId: 'city_core',
+    objective: { type: 'escape', afterRounds: 3 },
+    modifiers: [
+      { campaign: 'pathfinder', kind: 'scout', revealCount: 2 },
+      { campaign: 'pathfinder', kind: 'turn-limit', maxRounds: 6 },
+      { campaign: 'pathfinder', kind: 'escape', afterRounds: 3 },
+    ],
+    failForward: true,
+  },
+  {
+    id: 'autumn-great-expedition:vanguard',
+    campaign: 'vanguard',
+    stageId: 'city_core',
+    objective: { type: 'target-elimination', targetId: 'city_core-enemy-1' },
+    modifiers: [
+      { campaign: 'vanguard', kind: 'elite', levelBonus: 3 },
+      {
+        campaign: 'vanguard',
+        kind: 'chained-battle',
+        chainId: 'great-expedition-command-front',
+        index: 3,
+        total: 3,
+      },
+    ],
+    failForward: true,
+  },
+  {
+    id: 'autumn-great-expedition:arcanist',
+    campaign: 'arcanist',
+    stageId: 'lake_tempest',
+    objective: { type: 'standard' },
+    modifiers: [
+      { campaign: 'arcanist', kind: 'relic-resonance', relicId: 'forbidden-great-expedition-relic' },
+      { campaign: 'arcanist', kind: 'status-amplify', statusId: 'break', multiplier: 1.75 },
+      { campaign: 'arcanist', kind: 'rule-shift', ruleId: 'great-expedition-rift-shift' },
+    ],
+    failForward: true,
+  },
+] as const;
+
+export const autumnGreatExpeditionTacticalClimaxes: readonly TacticalScenario[] =
+  definitions.map(campaignEncounterToTacticalScenario);
+
+export function getAutumnGreatExpeditionTacticalClimax(
+  campaign: unknown,
+): TacticalScenario | null {
+  if (typeof campaign !== 'string') return null;
+  return autumnGreatExpeditionTacticalClimaxes.find(
+    climax => climax.campaign === (campaign as MainCampaignId),
+  ) ?? null;
+}

--- a/src/autumn-world-consequences.test.ts
+++ b/src/autumn-world-consequences.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getAutumnMajorChoiceWorldFacts } from './autumn-world-consequences';
+
+describe('V3 Autumn typed Major Choice world consequences', () => {
+  it('maps every campaign choice to stable typed World facts', () => {
+    expect(getAutumnMajorChoiceWorldFacts('caretaker', 'save_one')).toEqual(['caretaker_critical_person_saved']);
+    expect(getAutumnMajorChoiceWorldFacts('caretaker', 'spread_risk')).toEqual(['caretaker_risk_shared']);
+    expect(getAutumnMajorChoiceWorldFacts('caretaker', 'team_solution')).toEqual(['caretaker_team_solution']);
+
+    expect(getAutumnMajorChoiceWorldFacts('pathfinder', 'open_route')).toEqual(['ancient_route_opened']);
+    expect(getAutumnMajorChoiceWorldFacts('pathfinder', 'seal_route')).toEqual(['ancient_route_sealed']);
+    expect(getAutumnMajorChoiceWorldFacts('pathfinder', 'limited_access')).toEqual(['ancient_route_limited']);
+
+    expect(getAutumnMajorChoiceWorldFacts('vanguard', 'centralize')).toEqual(['eiden_central_command']);
+    expect(getAutumnMajorChoiceWorldFacts('vanguard', 'preserve_independence')).toEqual(['regional_alliance']);
+    expect(getAutumnMajorChoiceWorldFacts('vanguard', 'coalition_command')).toEqual(['coalition_command']);
+
+    expect(getAutumnMajorChoiceWorldFacts('arcanist', 'use_relic')).toEqual(['forbidden_relic_used']);
+    expect(getAutumnMajorChoiceWorldFacts('arcanist', 'destroy_relic')).toEqual(['forbidden_relic_destroyed']);
+    expect(getAutumnMajorChoiceWorldFacts('arcanist', 'controlled_use')).toEqual(['forbidden_relic_controlled']);
+  });
+
+  it('rejects malformed and cross-campaign choices instead of inventing fallback history', () => {
+    expect(getAutumnMajorChoiceWorldFacts('caretaker', 'open_route')).toBeNull();
+    expect(getAutumnMajorChoiceWorldFacts('arcanist', 'team_solution')).toBeNull();
+    expect(getAutumnMajorChoiceWorldFacts('not-a-campaign', 'save_one')).toBeNull();
+    expect(getAutumnMajorChoiceWorldFacts('caretaker', 'not-a-choice')).toBeNull();
+  });
+});

--- a/src/autumn-world-consequences.ts
+++ b/src/autumn-world-consequences.ts
@@ -1,0 +1,35 @@
+import type { MainCampaignId } from './campaign-model';
+import type { WorldFactId } from './world-history';
+
+const consequenceFacts: Readonly<Record<MainCampaignId, Readonly<Record<string, readonly WorldFactId[]>>>> = {
+  caretaker: {
+    save_one: ['caretaker_critical_person_saved'],
+    spread_risk: ['caretaker_risk_shared'],
+    team_solution: ['caretaker_team_solution'],
+  },
+  pathfinder: {
+    open_route: ['ancient_route_opened'],
+    seal_route: ['ancient_route_sealed'],
+    limited_access: ['ancient_route_limited'],
+  },
+  vanguard: {
+    centralize: ['eiden_central_command'],
+    preserve_independence: ['regional_alliance'],
+    coalition_command: ['coalition_command'],
+  },
+  arcanist: {
+    use_relic: ['forbidden_relic_used'],
+    destroy_relic: ['forbidden_relic_destroyed'],
+    controlled_use: ['forbidden_relic_controlled'],
+  },
+};
+
+export function getAutumnMajorChoiceWorldFacts(
+  campaign: unknown,
+  choice: unknown,
+): readonly WorldFactId[] | null {
+  if (typeof campaign !== 'string' || typeof choice !== 'string') return null;
+  if (!(campaign in consequenceFacts)) return null;
+  const facts = consequenceFacts[campaign as MainCampaignId][choice];
+  return facts ? [...facts] : null;
+}

--- a/src/autumn-world-tactical-lane.test.ts
+++ b/src/autumn-world-tactical-lane.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { MainCampaignId } from './campaign-model';
+import { buildGreatExpeditionWorldPrerequisite } from './campaign-world';
+import { getAutumnGreatExpeditionWorldRoute } from './autumn-campaign-world';
+import { getAutumnGreatExpeditionTacticalClimax } from './autumn-tactical-climax';
+import {
+  createTacticalScenarioBattle,
+  createTacticalTerminalHandoffState,
+  handoffTacticalTerminalResult,
+  resolveTacticalScenarioResult,
+  type TacticalScenario,
+} from './tactical-scenario';
+import {
+  autumnWorldRouteToTacticalClimax,
+  greatExpeditionEvidenceFromTacticalResult,
+} from './autumn-world-tactical-lane';
+
+const progression = { maxHp: 120, agility: 15, power: 24, magic: 20 };
+const companions = ['bear', 'owl'] as const;
+
+function prerequisiteFor(campaign: MainCampaignId) {
+  const input = {
+    activeCampaign: campaign,
+    worldHistory: {
+      currentFacts: ['festival_saved'],
+      inheritedFacts: ['rift_stabilized'],
+    },
+    majorOutcomes: { guardian_festival: 'victory' },
+    failForwardOutcomes: [],
+  } as const;
+  return { input, snapshot: buildGreatExpeditionWorldPrerequisite(input) };
+}
+
+function battleFor(campaign: MainCampaignId, seed: number) {
+  const prerequisite = prerequisiteFor(campaign);
+  const route = getAutumnGreatExpeditionWorldRoute(campaign, prerequisite.input)!;
+  const climax = autumnWorldRouteToTacticalClimax(route);
+  expect(climax).toEqual(getAutumnGreatExpeditionTacticalClimax(campaign));
+  expect(climax.stageId).toBe(route.stageId);
+  expect(climax.failForward).toBe(true);
+  const battle = createTacticalScenarioBattle(climax, companions, progression, seed);
+  expect(battle.units.filter(unit => unit.side === 'ally')).toHaveLength(3);
+  expect(battle.units.filter(unit => unit.side === 'enemy')).toHaveLength(3);
+  return { prerequisite, route, climax, battle };
+}
+
+function handoffEvidence(
+  route: ReturnType<typeof getAutumnGreatExpeditionWorldRoute> extends infer T ? Exclude<T, null> : never,
+  climax: TacticalScenario,
+  session: ReturnType<typeof createTacticalScenarioBattle>,
+  prerequisite: ReturnType<typeof buildGreatExpeditionWorldPrerequisite>,
+  attemptKey: string,
+) {
+  const terminal = resolveTacticalScenarioResult(climax, session, attemptKey);
+  expect(terminal).not.toBeNull();
+  const handed = handoffTacticalTerminalResult(createTacticalTerminalHandoffState(), terminal);
+  expect(handed.result).not.toBeNull();
+  const evidence = greatExpeditionEvidenceFromTacticalResult(route, handed.result!, prerequisite);
+  const replay = handoffTacticalTerminalResult(handed.state, terminal);
+  expect(replay.result).toBeNull();
+  return { terminal: handed.result!, evidence };
+}
+
+describe('V3 Autumn Lane B Great Expedition World + Tactical E2E', () => {
+  it('Caretaker flawless rescue/survival yields exceptional Great Expedition evidence', () => {
+    const { prerequisite, route, climax, battle } = battleFor('caretaker', 301);
+    const flawless = {
+      ...battle,
+      round: 5,
+      units: battle.units.map(unit => unit.side === 'enemy'
+        ? { ...unit, hp: 0 }
+        : { ...unit, hp: unit.maxHp }),
+    };
+    const { terminal, evidence } = handoffEvidence(route, climax, flawless, prerequisite.snapshot, 'autumn-caretaker-1');
+    expect(terminal.objectiveResult).toBe('success');
+    expect(evidence.outcome).toBe('exceptional_victory');
+    expect(evidence.currentFacts).toEqual(['festival_saved']);
+    expect(evidence.inheritedFacts).toEqual(['rift_stabilized']);
+  });
+
+  it('Pathfinder successful traversal without full battle victory yields costly evidence', () => {
+    const { prerequisite, route, climax, battle } = battleFor('pathfinder', 302);
+    const escaped = { ...battle, round: 4 };
+    const { terminal, evidence } = handoffEvidence(route, climax, escaped, prerequisite.snapshot, 'autumn-pathfinder-1');
+    expect(terminal.objectiveResult).toBe('success');
+    expect(terminal.battleResult).toBeNull();
+    expect(evidence.outcome).toBe('costly_victory');
+    expect(evidence.failForward).toBe(true);
+  });
+
+  it('Vanguard elite command victory with damage yields normal victory evidence', () => {
+    const { prerequisite, route, climax, battle } = battleFor('vanguard', 303);
+    const wonWithDamage = {
+      ...battle,
+      round: 2,
+      units: battle.units.map(unit => {
+        if (unit.side === 'enemy') return { ...unit, hp: 0 };
+        if (unit.id === 'runa') return { ...unit, hp: Math.max(1, unit.maxHp - 1) };
+        return unit;
+      }),
+    };
+    const { evidence } = handoffEvidence(route, climax, wonWithDamage, prerequisite.snapshot, 'autumn-vanguard-1');
+    expect(evidence.outcome).toBe('victory');
+    expect(evidence.damageTaken).toBeGreaterThan(0);
+  });
+
+  it('Arcanist relic/rift defeat yields defeat evidence without inventing a choice consequence', () => {
+    const { prerequisite, route, climax, battle } = battleFor('arcanist', 304);
+    const defeated = {
+      ...battle,
+      round: 2,
+      units: battle.units.map(unit => unit.side === 'ally' ? { ...unit, hp: 0 } : unit),
+    };
+    const { terminal, evidence } = handoffEvidence(route, climax, defeated, prerequisite.snapshot, 'autumn-arcanist-1');
+    expect(terminal.objectiveResult).toBe('failure');
+    expect(evidence.outcome).toBe('defeat');
+    expect(evidence.eventId).toBe('great_expedition');
+    expect('choice' in evidence).toBe(false);
+  });
+
+  it('rejects World/Tactical campaign or stage mismatch instead of cross-route fallback', () => {
+    const prerequisite = prerequisiteFor('caretaker');
+    const caretaker = getAutumnGreatExpeditionWorldRoute('caretaker', prerequisite.input)!;
+    expect(() => autumnWorldRouteToTacticalClimax({ ...caretaker, stageId: 'city_core' })).toThrow();
+  });
+});

--- a/src/autumn-world-tactical-lane.ts
+++ b/src/autumn-world-tactical-lane.ts
@@ -1,0 +1,73 @@
+import type { MainCampaignId, MajorOutcomeResult } from './campaign-model';
+import type { GreatExpeditionWorldPrerequisite } from './campaign-world';
+import type { AutumnGreatExpeditionWorldRoute } from './autumn-campaign-world';
+import { getAutumnGreatExpeditionTacticalClimax } from './autumn-tactical-climax';
+import type { TacticalScenario, TacticalScenarioResult } from './tactical-scenario';
+import type { WorldFactId } from './world-history';
+
+export type GreatExpeditionTacticalEvidence = Readonly<{
+  eventId: 'great_expedition';
+  campaign: MainCampaignId;
+  scenarioId: string;
+  outcome: MajorOutcomeResult;
+  objectiveResult: TacticalScenarioResult['objectiveResult'];
+  battleResult: TacticalScenarioResult['battleResult'];
+  failForward: boolean;
+  rounds: number;
+  survivingAllies: number;
+  damageTaken: number;
+  currentFacts: WorldFactId[];
+  inheritedFacts: WorldFactId[];
+  festivalFailForward: boolean;
+}>;
+
+export function autumnWorldRouteToTacticalClimax(
+  route: AutumnGreatExpeditionWorldRoute,
+): TacticalScenario {
+  const climax = getAutumnGreatExpeditionTacticalClimax(route.campaign);
+  if (!climax || climax.stageId !== route.stageId || !climax.failForward || !route.failForward) {
+    throw new Error('Autumn Great Expedition World/Tactical route mismatch');
+  }
+  return climax;
+}
+
+function outcomeFromTacticalResult(result: TacticalScenarioResult): MajorOutcomeResult {
+  if (result.objectiveResult === 'failure' || result.battleResult === 'defeat') return 'defeat';
+  if (result.battleResult === 'victory') {
+    return result.survivingAllies === 3 && result.damageTaken === 0
+      ? 'exceptional_victory'
+      : 'victory';
+  }
+  return 'costly_victory';
+}
+
+export function greatExpeditionEvidenceFromTacticalResult(
+  route: AutumnGreatExpeditionWorldRoute,
+  result: TacticalScenarioResult,
+  prerequisite: GreatExpeditionWorldPrerequisite,
+): GreatExpeditionTacticalEvidence {
+  const climax = autumnWorldRouteToTacticalClimax(route);
+  if (!prerequisite.ready || prerequisite.campaign !== route.campaign) {
+    throw new Error('Autumn Great Expedition prerequisite is not ready for this campaign');
+  }
+  if (result.campaign !== route.campaign || result.scenarioId !== climax.id) {
+    throw new Error('Autumn Great Expedition terminal result does not match the World route');
+  }
+
+  const outcome = outcomeFromTacticalResult(result);
+  return {
+    eventId: 'great_expedition',
+    campaign: route.campaign,
+    scenarioId: result.scenarioId,
+    outcome,
+    objectiveResult: result.objectiveResult,
+    battleResult: result.battleResult,
+    failForward: outcome === 'costly_victory' || outcome === 'defeat',
+    rounds: result.rounds,
+    survivingAllies: result.survivingAllies,
+    damageTaken: result.damageTaken,
+    currentFacts: [...prerequisite.currentFacts],
+    inheritedFacts: [...prerequisite.inheritedFacts],
+    festivalFailForward: prerequisite.festivalFailForward,
+  };
+}

--- a/src/campaign-world-objectives.test.ts
+++ b/src/campaign-world-objectives.test.ts
@@ -4,8 +4,8 @@ import { expeditionRegionDefinitions } from './expedition-regions';
 import { campaignWorldObjectives } from './campaign-world';
 
 describe('V3 campaign world objective overlays', () => {
-  it('defines one Spring and one Summer objective for each main campaign', () => {
-    for (const season of ['spring', 'summer'] as const) {
+  it('defines one Spring, Summer and Autumn objective for each main campaign', () => {
+    for (const season of ['spring', 'summer', 'autumn'] as const) {
       const seasonObjectives = campaignWorldObjectives.filter(item => item.season === season);
       expect(seasonObjectives).toHaveLength(4);
       expect(seasonObjectives.map(item => item.campaign).sort()).toEqual([...mainCampaignIds].sort());
@@ -39,7 +39,7 @@ describe('V3 campaign world objective overlays', () => {
     }
   });
 
-  it('uses stable canonical objective ids for Spring evidence and Summer Guardian Festival setup', () => {
+  it('uses stable canonical objective ids through Autumn Great Expedition setup', () => {
     expect(campaignWorldObjectives.map(item => item.id)).toEqual([
       'spring_caretaker_resident_guard',
       'spring_pathfinder_hidden_route',
@@ -49,6 +49,10 @@ describe('V3 campaign world objective overlays', () => {
       'summer_pathfinder_festival_routes',
       'summer_vanguard_festival_threat',
       'summer_arcanist_festival_relic',
+      'autumn_caretaker_great_expedition_rescue',
+      'autumn_pathfinder_great_expedition_route',
+      'autumn_vanguard_great_expedition_command',
+      'autumn_arcanist_great_expedition_relic',
     ]);
   });
 });

--- a/src/campaign-world.ts
+++ b/src/campaign-world.ts
@@ -15,7 +15,7 @@ import {
   type WorldHistoryState,
 } from './world-history';
 
-export type CampaignWorldSeason = 'spring' | 'summer';
+export type CampaignWorldSeason = 'spring' | 'summer' | 'autumn';
 export type CampaignWorldObjectiveKind =
   | 'protect_residents'
   | 'discover_route'
@@ -30,7 +30,11 @@ export type CampaignWorldObjectiveId =
   | 'summer_caretaker_festival_rescue'
   | 'summer_pathfinder_festival_routes'
   | 'summer_vanguard_festival_threat'
-  | 'summer_arcanist_festival_relic';
+  | 'summer_arcanist_festival_relic'
+  | 'autumn_caretaker_great_expedition_rescue'
+  | 'autumn_pathfinder_great_expedition_route'
+  | 'autumn_vanguard_great_expedition_command'
+  | 'autumn_arcanist_great_expedition_relic';
 
 export type CampaignWorldObjectiveDefinition = {
   id: CampaignWorldObjectiveId;
@@ -101,6 +105,38 @@ export const campaignWorldObjectives: readonly CampaignWorldObjectiveDefinition[
   {
     id: 'summer_arcanist_festival_relic',
     season: 'summer',
+    campaign: 'arcanist',
+    kind: 'investigate_relic_rift',
+    regionId: 'wind_lakes',
+    stageIds: ['lake_cliff', 'lake_tempest'],
+  },
+  {
+    id: 'autumn_caretaker_great_expedition_rescue',
+    season: 'autumn',
+    campaign: 'caretaker',
+    kind: 'protect_residents',
+    regionId: 'starlight_forest',
+    stageIds: ['forest_glade', 'forest_guardian'],
+  },
+  {
+    id: 'autumn_pathfinder_great_expedition_route',
+    season: 'autumn',
+    campaign: 'pathfinder',
+    kind: 'discover_route',
+    regionId: 'ancient_city',
+    stageIds: ['city_gallery', 'city_core'],
+  },
+  {
+    id: 'autumn_vanguard_great_expedition_command',
+    season: 'autumn',
+    campaign: 'vanguard',
+    kind: 'remove_threat',
+    regionId: 'ancient_city',
+    stageIds: ['city_square', 'city_core'],
+  },
+  {
+    id: 'autumn_arcanist_great_expedition_relic',
+    season: 'autumn',
     campaign: 'arcanist',
     kind: 'investigate_relic_rift',
     regionId: 'wind_lakes',

--- a/src/world-history.ts
+++ b/src/world-history.ts
@@ -3,6 +3,7 @@ import {isV3Record,uniqueRegistered} from './v3-state-sanitize';
 export const worldFactIds=[
   'festival_saved','festival_heavy_losses','ancient_route_opened','ancient_route_sealed','ancient_route_limited',
   'eiden_central_command','regional_alliance','forbidden_relic_used','forbidden_relic_destroyed','rift_stabilized','rift_unstable',
+  'caretaker_critical_person_saved','caretaker_risk_shared','caretaker_team_solution','coalition_command','forbidden_relic_controlled',
 ] as const;
 
 export type WorldFactId=typeof worldFactIds[number];


### PR DESCRIPTION
Parent: #110

## Status
**Autumn Lane B GREEN candidate**

- baseline: `integration/v3@4933642fec103504ac7cf97192513058b37d20c3`
- 02 World input: `work/v3-autumn-world@0af4f21b7ba00055ed8ba8ce09848f899f73422c` / PR #115
- 04 Tactical input: `work/v3-autumn-tactical@a42e7668e9ce312de156ccc011bee6a6e566110b` / PR #117
- exact 2-parent composition commit: `e279c15fcae8d2f0b3f1d25e34d2f1c594fc44e7`
- verify head: `verify/v3-autumn-world-tactical@3a735856f5a3cc7248e1ad24b6bc1523bcf8d304`
- verified merge-ref: `fc5658370803ca50def1d7e8d88ef8004ad692ee`
- Draft / unmerged

## Lane B flow
`Guardian Festival/Summer prerequisite -> Autumn Great Expedition World route -> campaign Tactical climax -> existing 3v3 -> objective terminal -> once-only handoff -> bounded Great Expedition outcome/evidence -> typed Autumn Major Choice world consequence mapping`

Major Choice commit/runtime is intentionally NOT owned here; Lane C owns exactly-once choice persistence. Lane B supplies typed World evidence and pure typed consequence mapping only.

## Four campaign paths
- Caretaker: rescue/protection/resource-sharing pressure on `forest_guardian`
- Pathfinder: ancient-route traversal + limited-action escape pressure on `city_core`
- Vanguard: command/elite/chained-battle pressure on `city_core`
- Arcanist: forbidden Relic/Rift + rule-shift pressure on `lake_tempest`
- all reuse existing Expedition stages, existing `CampaignEncounterDefinition -> TacticalScenario`, and current 3v3 engine

## Typed Autumn history contract
New stable World facts only where the central registry was missing a consequence identity:
- `caretaker_critical_person_saved`
- `caretaker_risk_shared`
- `caretaker_team_solution`
- `coalition_command`
- `forbidden_relic_controlled`

Existing canonical facts are reused for Pathfinder/Vanguard/Arcanist choices. `src/autumn-world-consequences.test.ts` covers all 12 campaign choices and rejects cross-campaign/malformed options.

## Lane E2E coverage
`src/autumn-world-tactical-lane.test.ts` verifies:
1. Caretaker flawless rescue/survival -> `exceptional_victory`, current/inherited prerequisite facts preserved
2. Pathfinder successful traversal without full battle victory -> `costly_victory` + fail-forward evidence
3. Vanguard elite command victory with damage -> `victory`
4. Arcanist defeat -> `defeat`, Great Expedition evidence only, no invented Major Choice
5. World/Tactical stage mismatch is rejected instead of cross-route fallback

Every route commits Tactical terminal through existing once-only handoff and asserts replay returns `null`.

## RED / fix evidence
- CI #1602 / run `32553998523`: expected RED. The new Lane suite alone failed because `./autumn-world-tactical-lane` was intentionally absent.
- Existing composed candidate stayed GREEN: **371/371 prior test files, 1377/1377 tests**; Tactical stability **13/13**, AUTO **10/50/100**, Expedition stress **4/4**.
- Minimal fix added only `src/autumn-world-tactical-lane.ts`; no shared state/save/runtime wiring.

## Final GREEN verification
- CI **#1603** / run `32554054225`: **SUCCESS**
- `src/autumn-world-tactical-lane.test.ts`: **5/5 PASS**
- `src/autumn-campaign-world.test.ts`: **3/3 PASS**
- `src/autumn-world-consequences.test.ts`: **2/2 PASS**
- `src/autumn-tactical-climax.test.ts`: **3/3 PASS**
- full suite: **372/372 test files, 1382/1382 tests PASS**
- Tactical stability: **13/13 PASS**
- AUTO bounded/progressing through **10 / 50 / 100** battle checkpoints: GREEN
- Expedition stress: **4/4 PASS**
- `npm run build` = `tsc -b && vite build`: PASS
- production build: PASS; Vite 8.2.1, **190 modules transformed**

## Guardrails
- no shared `App.tsx` / `Root.tsx` / game/save persistence edits
- no Major Choice state commit/runtime ownership
- no new map/engine
- no Winter/Long Night
- no direct `integration/v3` merge
- main/prod untouched
- freeze Lane B after this GREEN candidate unless final composite exposes a concrete Lane B regression

## Existing repository notes
- npm install still reports the pre-existing `1 high severity vulnerability`
- Vite still reports the existing >500 kB chunk-size warning
- GitHub Actions still reports Node20 deprecation/forced Node24 warning