### PR TITLE
[03] V3 Winter resolution + modular ending runtime

### DIFF
--- a/src/campaign-seasonal-claim-keys.ts
+++ b/src/campaign-seasonal-claim-keys.ts
@@ -23,11 +23,19 @@ const campaignSeasonalObjectiveClaimTriples = new Set([
   'autumn:vanguard:autumn_vanguard_coalition',
   'autumn:arcanist:autumn_arcanist_relic',
   'autumn:arcanist:autumn_arcanist_control',
+  'winter:caretaker:winter_caretaker_protection',
+  'winter:caretaker:winter_caretaker_shared_burden',
+  'winter:pathfinder:winter_pathfinder_route',
+  'winter:pathfinder:winter_pathfinder_route_memory',
+  'winter:vanguard:winter_vanguard_command',
+  'winter:vanguard:winter_vanguard_elite_chain',
+  'winter:arcanist:winter_arcanist_reality',
+  'winter:arcanist:winter_arcanist_control',
 ]);
 
 export function isValidCampaignSeasonalObjectiveClaimKey(value:unknown):value is string {
   if(typeof value!=='string') return false;
-  const match=/^([1-9]\d*)-(spring|summer|autumn):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
+  const match=/^([1-9]\d*)-(spring|summer|autumn|winter):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
   if(!match) return false;
   return campaignSeasonalObjectiveClaimTriples.has(`${match[2]}:${match[3]}:${match[4]}`);
 }

--- a/src/campaign-winter-season.test.ts
+++ b/src/campaign-winter-season.test.ts
@@ -1,5 +1,6 @@
 import {describe,expect,it} from 'vitest';
 import {emptyCampaignRunState} from './campaign-state';
+import {sanitizeCampaignSeasonalObjectiveClaimKeys} from './campaign-seasonal-claim-keys';
 import {emptyV3PersistentState} from './v3-persistent-state';
 import {
   commitLongNightOutcome,
@@ -36,6 +37,16 @@ describe('V3 Winter campaign season + ending runtime',()=>{
       year:4,week:4,campaign:'caretaker',facts:['long_night_protection','responsibility_sharing'],claimedKeys:[first.claimKey],
     });
     expect(duplicate).toEqual(expect.objectContaining({accepted:false,reason:'already_claimed',claimKey:first.claimKey}));
+  });
+
+  it('registers canonical Winter claims and sanitizes stale or malformed variants',()=>{
+    expect(sanitizeCampaignSeasonalObjectiveClaimKeys([
+      '4-winter:caretaker:winter_caretaker_protection',
+      '4-winter:caretaker:winter_caretaker_protection',
+      '04-winter:caretaker:winter_caretaker_protection',
+      '4-winter:caretaker:winter_vanguard_command',
+      '4-winter:caretaker:stale',
+    ])).toEqual(['4-winter:caretaker:winter_caretaker_protection']);
   });
 
   it('rejects malformed Winter objective context and True Campaign input',()=>{

--- a/src/campaign-winter-season.test.ts
+++ b/src/campaign-winter-season.test.ts
@@ -1,0 +1,244 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCampaignRunState} from './campaign-state';
+import {emptyV3PersistentState} from './v3-persistent-state';
+import {
+  commitLongNightOutcome,
+  commitWinterEnding,
+  resolveLongNightOutcome,
+  resolveModularEnding,
+  resolveWinterCampaignAction,
+  selectCompletedRunHandoff,
+} from './campaign-winter-season';
+
+describe('V3 Winter campaign season + ending runtime',()=>{
+  it.each([
+    ['caretaker',['long_night_protection'],'winter_caretaker_protection'],
+    ['pathfinder',['long_night_route'],'winter_pathfinder_route'],
+    ['vanguard',['long_night_command'],'winter_vanguard_command'],
+    ['arcanist',['long_night_reality'],'winter_arcanist_reality'],
+  ] as const)('maps %s Long Night participation into a Winter objective', (campaign,facts,objectiveId)=>{
+    const result=resolveWinterCampaignAction({year:4,week:2,campaign,facts,claimedKeys:[]});
+    expect(result.accepted).toBe(true);
+    if(!result.accepted)return;
+    expect(result.objective.id).toBe(objectiveId);
+    expect(result.claimKey).toBe(`4-winter:${campaign}:${objectiveId}`);
+  });
+
+  it('keeps one Winter action to one objective and blocks duplicate fallthrough across week rollover',()=>{
+    const first=resolveWinterCampaignAction({
+      year:4,week:1,campaign:'caretaker',facts:['long_night_protection','responsibility_sharing'],claimedKeys:[],
+    });
+    expect(first.accepted).toBe(true);
+    if(!first.accepted)return;
+    expect(first.objective.id).toBe('winter_caretaker_protection');
+
+    const duplicate=resolveWinterCampaignAction({
+      year:4,week:4,campaign:'caretaker',facts:['long_night_protection','responsibility_sharing'],claimedKeys:[first.claimKey],
+    });
+    expect(duplicate).toEqual(expect.objectContaining({accepted:false,reason:'already_claimed',claimKey:first.claimKey}));
+  });
+
+  it('rejects malformed Winter objective context and True Campaign input',()=>{
+    expect(resolveWinterCampaignAction({year:4,week:1,campaign:'true_path',facts:['long_night_protection'],claimedKeys:[]})).toEqual({accepted:false,reason:'invalid_context'});
+    expect(resolveWinterCampaignAction({year:0,week:1,campaign:'caretaker',facts:['long_night_protection'],claimedKeys:[]})).toEqual({accepted:false,reason:'invalid_context'});
+    expect(resolveWinterCampaignAction({year:4,week:5,campaign:'caretaker',facts:['long_night_protection'],claimedKeys:[]})).toEqual({accepted:false,reason:'invalid_context'});
+  });
+
+  it('commits defeat as a valid fail-forward Long Night outcome and resolves Winter',()=>{
+    const state={
+      ...emptyCampaignRunState(),
+      phase:'winter' as const,
+      activeCampaign:'caretaker' as const,
+      seasonMilestones:['autumn_resolved' as const],
+    };
+    const outcome=resolveLongNightOutcome({campaign:'caretaker',outcome:'defeat'});
+    expect(outcome.accepted).toBe(true);
+    if(!outcome.accepted)return;
+
+    const committed=commitLongNightOutcome(state,outcome);
+    expect(committed.committed).toBe(true);
+    expect(committed.state.majorOutcomes.long_night).toBe('defeat');
+    expect(committed.state.seasonMilestones).toEqual(['autumn_resolved','winter_resolved']);
+    expect(committed.state.failForwardOutcomes).toContain('long_night');
+    expect(committed.state.phase).toBe('ending');
+  });
+
+  it('blocks conflicting or repeated Long Night outcome commits',()=>{
+    const ready={
+      ...emptyCampaignRunState(),
+      phase:'winter' as const,
+      activeCampaign:'vanguard' as const,
+      seasonMilestones:['autumn_resolved' as const],
+    };
+    const firstOutcome=resolveLongNightOutcome({campaign:'vanguard',outcome:'costly_victory'});
+    expect(firstOutcome.accepted).toBe(true);
+    if(!firstOutcome.accepted)return;
+    const first=commitLongNightOutcome(ready,firstOutcome);
+    expect(first.committed).toBe(true);
+
+    const replayOutcome=resolveLongNightOutcome({campaign:'vanguard',outcome:'victory'});
+    expect(replayOutcome.accepted).toBe(true);
+    if(!replayOutcome.accepted)return;
+    const replay=commitLongNightOutcome(first.state,replayOutcome);
+    expect(replay).toEqual({committed:false,state:first.state,reason:'already_committed'});
+
+    const conflictOutcome=resolveLongNightOutcome({campaign:'caretaker',outcome:'victory'});
+    expect(conflictOutcome.accepted).toBe(true);
+    if(!conflictOutcome.accepted)return;
+    expect(commitLongNightOutcome(ready,conflictOutcome)).toEqual({committed:false,state:ready,reason:'campaign_conflict'});
+  });
+
+  it('requires Autumn resolution and registered Long Night outcome input',()=>{
+    const state={...emptyCampaignRunState(),phase:'winter' as const,activeCampaign:'arcanist' as const};
+    const outcome=resolveLongNightOutcome({campaign:'arcanist',outcome:'victory'});
+    expect(outcome.accepted).toBe(true);
+    if(!outcome.accepted)return;
+    expect(commitLongNightOutcome(state,outcome)).toEqual({committed:false,state,reason:'not_ready'});
+    expect(resolveLongNightOutcome({campaign:'true_path',outcome:'victory'})).toEqual({accepted:false,reason:'invalid_outcome'});
+    expect(resolveLongNightOutcome({campaign:'arcanist',outcome:'perfect'})).toEqual({accepted:false,reason:'invalid_outcome'});
+  });
+
+  it('composes a stable four-axis ending without owning feature-specific interpretation',()=>{
+    const result=resolveModularEnding({
+      campaignResolution:'coalition_guardianship',
+      bondResolution:'rex_mutual_trust',
+      worldResolution:'survived_with_cost',
+      careerResolution:'guardian_captain',
+    });
+    expect(result).toEqual({
+      accepted:true,
+      ending:{
+        id:'v3:coalition_guardianship:rex_mutual_trust:survived_with_cost:guardian_captain',
+        dimensions:{
+          campaign:'coalition_guardianship',
+          bond:'rex_mutual_trust',
+          world:'survived_with_cost',
+          career:'guardian_captain',
+        },
+      },
+    });
+  });
+
+  it('rejects malformed modular ending dimension IDs',()=>{
+    expect(resolveModularEnding({
+      campaignResolution:'Coalition Guardianship',
+      bondResolution:'rex_mutual_trust',
+      worldResolution:'survived_with_cost',
+      careerResolution:'guardian_captain',
+    })).toEqual({accepted:false,reason:'invalid_dimension'});
+    expect(resolveModularEnding({
+      campaignResolution:'coalition_guardianship',
+      bondResolution:'',
+      worldResolution:'survived_with_cost',
+      careerResolution:'guardian_captain',
+    })).toEqual({accepted:false,reason:'invalid_dimension'});
+  });
+
+  it('commits the modular ending exactly once into existing Legacy summary structures',()=>{
+    const persistent=emptyV3PersistentState();
+    const winterReady={
+      ...persistent,
+      campaignRun:{
+        ...persistent.campaignRun,
+        phase:'ending' as const,
+        activeCampaign:'vanguard' as const,
+        majorChoices:{vanguard_autumn:'coalition_command' as const},
+        majorOutcomes:{great_expedition:'victory' as const,long_night:'costly_victory' as const},
+        seasonMilestones:['autumn_resolved' as const,'winter_resolved' as const],
+      },
+      worldHistory:{currentFacts:['coalition_command' as const],inheritedFacts:[]},
+    };
+    const resolved=resolveModularEnding({
+      campaignResolution:'coalition_guardianship',
+      bondResolution:'rex_mutual_trust',
+      worldResolution:'survived_with_cost',
+      careerResolution:'guardian_captain',
+    });
+    expect(resolved.accepted).toBe(true);
+    if(!resolved.accepted)return;
+
+    const committed=commitWinterEnding(winterReady,resolved.ending,{
+      majorWorldOutcomes:['coalition_command','bad'] as any,
+      keyBondMemories:[
+        {characterId:'rex',memoryId:'rex_autumn_coalition_command'},
+        {characterId:'rex',memoryId:'bad'},
+      ] as any,
+      trueClues:['vanguard_hidden_conflict_record','bad'] as any,
+    });
+    expect(committed.committed).toBe(true);
+    expect(committed.state.campaignRun.seasonMilestones).toEqual(['autumn_resolved','winter_resolved','ending_committed']);
+    expect(committed.state.campaignRun.phase).toBe('ending');
+    expect(committed.state.legacy.completedRuns).toBe(1);
+    expect(committed.state.legacy.completedCampaigns).toEqual(['vanguard']);
+    expect(committed.state.legacy.endingCollection).toEqual([resolved.ending.id]);
+    expect(committed.state.legacy.careerCollection).toEqual(['guardian_captain']);
+    expect(committed.state.legacy.runSummaries).toEqual([{
+      runNumber:1,
+      campaign:'vanguard',
+      route:'normal',
+      ending:resolved.ending.id,
+      career:'guardian_captain',
+      majorWorldOutcomes:['coalition_command'],
+      keyBondMemories:[{characterId:'rex',memoryId:'rex_autumn_coalition_command'}],
+      trueClues:['vanguard_hidden_conflict_record'],
+    }]);
+
+    const different=resolveModularEnding({
+      campaignResolution:'central_command',
+      bondResolution:'rex_rivalry',
+      worldResolution:'victory',
+      careerResolution:'commander',
+    });
+    expect(different.accepted).toBe(true);
+    if(!different.accepted)return;
+    expect(commitWinterEnding(committed.state,different.ending)).toEqual({
+      committed:false,
+      state:committed.state,
+      reason:'already_committed',
+    });
+  });
+
+  it('refuses ending commit before authoritative Winter resolution',()=>{
+    const state=emptyV3PersistentState();
+    const resolved=resolveModularEnding({
+      campaignResolution:'shared_guardianship',bondResolution:'mira_trust',worldResolution:'survived',careerResolution:'healer',
+    });
+    expect(resolved.accepted).toBe(true);
+    if(!resolved.accepted)return;
+    expect(commitWinterEnding(state,resolved.ending)).toEqual({committed:false,state,reason:'not_ready'});
+  });
+
+  it('exposes only a compact completed-run handoff after ending commit',()=>{
+    const persistent=emptyV3PersistentState();
+    const winterReady={
+      ...persistent,
+      campaignRun:{
+        ...persistent.campaignRun,
+        phase:'ending' as const,
+        activeCampaign:'caretaker' as const,
+        majorChoices:{caretaker_autumn:'team_solution' as const},
+        majorOutcomes:{great_expedition:'victory' as const,long_night:'defeat' as const},
+        failForwardOutcomes:['long_night' as const],
+        seasonMilestones:['autumn_resolved' as const,'winter_resolved' as const],
+      },
+    };
+    expect(selectCompletedRunHandoff(winterReady)).toBeNull();
+
+    const resolved=resolveModularEnding({
+      campaignResolution:'shared_guardianship',bondResolution:'mira_shared_burden',worldResolution:'survived_at_cost',careerResolution:'healer',
+    });
+    expect(resolved.accepted).toBe(true);
+    if(!resolved.accepted)return;
+    const committed=commitWinterEnding(winterReady,resolved.ending);
+    expect(committed.committed).toBe(true);
+    if(!committed.committed)return;
+    expect(selectCompletedRunHandoff(committed.state)).toEqual({
+      runNumber:1,
+      campaignId:'caretaker',
+      route:'normal',
+      longNightOutcome:'defeat',
+      endingId:resolved.ending.id,
+      dimensions:resolved.ending.dimensions,
+    });
+  });
+});

--- a/src/campaign-winter-season.ts
+++ b/src/campaign-winter-season.ts
@@ -1,0 +1,256 @@
+import {
+  mainCampaignIds,
+  majorOutcomeResults,
+  type MainCampaignId,
+  type MajorOutcomeResult,
+} from './campaign-model';
+import type {CampaignRunState} from './campaign-state';
+import {sanitizeCampaignSeasonalObjectiveClaimKeys} from './campaign-seasonal-claim-keys';
+import {hydrateLegacyState} from './legacy-state';
+import type {V3PersistentState} from './v3-persistent-state';
+
+export type WinterCampaignActionFact=
+  | 'long_night_protection'
+  | 'responsibility_sharing'
+  | 'long_night_route'
+  | 'route_knowledge'
+  | 'long_night_command'
+  | 'elite_chain'
+  | 'long_night_reality'
+  | 'rift_control';
+
+const mainCampaignSet=new Set<string>(mainCampaignIds);
+const winterFactSet=new Set<string>([
+  'long_night_protection','responsibility_sharing','long_night_route','route_knowledge',
+  'long_night_command','elite_chain','long_night_reality','rift_control',
+]);
+
+function campaignId(value:unknown):MainCampaignId|null{
+  return typeof value==='string'&&mainCampaignSet.has(value)?value as MainCampaignId:null;
+}
+
+function canonicalYear(value:unknown):number|null{
+  return typeof value==='number'&&Number.isInteger(value)&&Number.isFinite(value)&&value>=1?value:null;
+}
+
+function validWeek(value:unknown):boolean{
+  return typeof value==='number'&&Number.isInteger(value)&&value>=1&&value<=4;
+}
+
+function uniqueWinterFacts(raw:unknown):WinterCampaignActionFact[]{
+  if(!Array.isArray(raw))return [];
+  return [...new Set(raw.filter((value):value is WinterCampaignActionFact=>typeof value==='string'&&winterFactSet.has(value)))];
+}
+
+const winterObjectives={
+  caretaker:[
+    {id:'winter_caretaker_protection',facts:['long_night_protection']},
+    {id:'winter_caretaker_shared_burden',facts:['responsibility_sharing']},
+  ],
+  pathfinder:[
+    {id:'winter_pathfinder_route',facts:['long_night_route']},
+    {id:'winter_pathfinder_route_memory',facts:['route_knowledge']},
+  ],
+  vanguard:[
+    {id:'winter_vanguard_command',facts:['long_night_command']},
+    {id:'winter_vanguard_elite_chain',facts:['elite_chain']},
+  ],
+  arcanist:[
+    {id:'winter_arcanist_reality',facts:['long_night_reality']},
+    {id:'winter_arcanist_control',facts:['rift_control']},
+  ],
+} as const;
+
+export type WinterCampaignObjectiveId=typeof winterObjectives[MainCampaignId][number]['id'];
+
+export function resolveWinterCampaignAction(input:{
+  year:unknown;
+  week:unknown;
+  campaign:unknown;
+  facts:unknown;
+  claimedKeys:unknown;
+}){
+  const year=canonicalYear(input.year);
+  const campaign=campaignId(input.campaign);
+  if(!year||!campaign||!validWeek(input.week))return {accepted:false as const,reason:'invalid_context' as const};
+  const facts=uniqueWinterFacts(input.facts);
+  const objective=winterObjectives[campaign].find(candidate=>candidate.facts.some(fact=>facts.includes(fact as WinterCampaignActionFact)));
+  if(!objective)return {accepted:false as const,reason:'no_match' as const};
+  const claimKey=`${year}-winter:${campaign}:${objective.id}` as const;
+  const claimed=sanitizeCampaignSeasonalObjectiveClaimKeys(input.claimedKeys);
+  if(claimed.includes(claimKey))return {accepted:false as const,reason:'already_claimed' as const,objective,claimKey};
+  return {
+    accepted:true as const,
+    objective,
+    claimKey,
+    reward:{kind:'campaign_memory' as const,memoryId:`${objective.id}_memory` as const},
+  };
+}
+
+export type AcceptedLongNightOutcome={
+  accepted:true;
+  campaignId:MainCampaignId;
+  outcome:MajorOutcomeResult;
+};
+
+export function resolveLongNightOutcome(input:{campaign:unknown;outcome:unknown}):
+  | AcceptedLongNightOutcome
+  | {accepted:false;reason:'invalid_outcome'}{
+  const campaign=campaignId(input.campaign);
+  if(!campaign||typeof input.outcome!=='string'||!(majorOutcomeResults as readonly string[]).includes(input.outcome)){
+    return {accepted:false,reason:'invalid_outcome'};
+  }
+  return {accepted:true,campaignId:campaign,outcome:input.outcome as MajorOutcomeResult};
+}
+
+export function commitLongNightOutcome(state:CampaignRunState,result:AcceptedLongNightOutcome):
+  | {committed:true;state:CampaignRunState}
+  | {committed:false;state:CampaignRunState;reason:'not_ready'|'campaign_conflict'|'already_committed'}{
+  const activeCampaign=campaignId(state.activeCampaign);
+  if(!activeCampaign||!state.seasonMilestones.includes('autumn_resolved')){
+    return {committed:false,state,reason:'not_ready'};
+  }
+  if(activeCampaign!==result.campaignId){
+    return {committed:false,state,reason:'campaign_conflict'};
+  }
+  if(state.majorOutcomes.long_night!==undefined||state.seasonMilestones.includes('winter_resolved')){
+    return {committed:false,state,reason:'already_committed'};
+  }
+  const failForwardOutcomes=result.outcome==='defeat'&&!state.failForwardOutcomes.includes('long_night')
+    ? [...state.failForwardOutcomes,'long_night' as const]
+    : state.failForwardOutcomes;
+  return {
+    committed:true,
+    state:{
+      ...state,
+      phase:'ending',
+      majorOutcomes:{...state.majorOutcomes,long_night:result.outcome},
+      failForwardOutcomes,
+      seasonMilestones:[...state.seasonMilestones,'winter_resolved'],
+    },
+  };
+}
+
+export type ModularEndingDimensions={
+  campaign:string;
+  bond:string;
+  world:string;
+  career:string;
+};
+
+export type ModularEnding={
+  id:string;
+  dimensions:ModularEndingDimensions;
+};
+
+const semanticDimensionPattern=/^[a-z][a-z0-9_]{0,63}$/;
+
+function semanticDimension(value:unknown):string|null{
+  return typeof value==='string'&&semanticDimensionPattern.test(value)?value:null;
+}
+
+export function resolveModularEnding(input:{
+  campaignResolution:unknown;
+  bondResolution:unknown;
+  worldResolution:unknown;
+  careerResolution:unknown;
+}):
+  | {accepted:true;ending:ModularEnding}
+  | {accepted:false;reason:'invalid_dimension'}{
+  const campaign=semanticDimension(input.campaignResolution);
+  const bond=semanticDimension(input.bondResolution);
+  const world=semanticDimension(input.worldResolution);
+  const career=semanticDimension(input.careerResolution);
+  if(!campaign||!bond||!world||!career)return {accepted:false,reason:'invalid_dimension'};
+  const dimensions={campaign,bond,world,career};
+  return {
+    accepted:true,
+    ending:{id:`v3:${campaign}:${bond}:${world}:${career}`,dimensions},
+  };
+}
+
+function parseModularEndingId(value:unknown):ModularEndingDimensions|null{
+  if(typeof value!=='string')return null;
+  const parts=value.split(':');
+  if(parts.length!==5||parts[0]!=='v3')return null;
+  const campaign=semanticDimension(parts[1]);
+  const bond=semanticDimension(parts[2]);
+  const world=semanticDimension(parts[3]);
+  const career=semanticDimension(parts[4]);
+  return campaign&&bond&&world&&career?{campaign,bond,world,career}:null;
+}
+
+function sameDimensions(a:ModularEndingDimensions,b:ModularEndingDimensions):boolean{
+  return a.campaign===b.campaign&&a.bond===b.bond&&a.world===b.world&&a.career===b.career;
+}
+
+export type WinterEndingSummaryInput={
+  majorWorldOutcomes?:unknown;
+  keyBondMemories?:unknown;
+  trueClues?:unknown;
+};
+
+export function commitWinterEnding(state:V3PersistentState,ending:ModularEnding,summary:WinterEndingSummaryInput={}):
+  | {committed:true;state:V3PersistentState}
+  | {committed:false;state:V3PersistentState;reason:'not_ready'|'already_committed'|'invalid_ending'}{
+  const campaign=campaignId(state.campaignRun.activeCampaign);
+  if(!campaign||!state.campaignRun.seasonMilestones.includes('winter_resolved')||state.campaignRun.majorOutcomes.long_night===undefined){
+    return {committed:false,state,reason:'not_ready'};
+  }
+  if(state.campaignRun.seasonMilestones.includes('ending_committed')||state.legacy.runSummaries.some(item=>item.runNumber===state.campaignRun.runNumber)){
+    return {committed:false,state,reason:'already_committed'};
+  }
+  const parsed=parseModularEndingId(ending.id);
+  if(!parsed||!sameDimensions(parsed,ending.dimensions)){
+    return {committed:false,state,reason:'invalid_ending'};
+  }
+  const runSummary={
+    runNumber:state.campaignRun.runNumber,
+    campaign,
+    route:state.campaignRun.activeRoute,
+    ending:ending.id,
+    career:ending.dimensions.career,
+    majorWorldOutcomes:summary.majorWorldOutcomes??[],
+    keyBondMemories:summary.keyBondMemories??[],
+    trueClues:summary.trueClues??[],
+  };
+  const legacy=hydrateLegacyState({
+    ...state.legacy,
+    completedRuns:state.legacy.completedRuns+1,
+    completedCampaigns:[...state.legacy.completedCampaigns,campaign],
+    endingCollection:[...state.legacy.endingCollection,ending.id],
+    careerCollection:[...state.legacy.careerCollection,ending.dimensions.career],
+    runSummaries:[...state.legacy.runSummaries,runSummary],
+  });
+  return {
+    committed:true,
+    state:{
+      ...state,
+      campaignRun:{
+        ...state.campaignRun,
+        phase:'ending',
+        seasonMilestones:[...state.campaignRun.seasonMilestones,'ending_committed'],
+      },
+      legacy,
+    },
+  };
+}
+
+export function selectCompletedRunHandoff(state:V3PersistentState){
+  if(!state.campaignRun.seasonMilestones.includes('ending_committed'))return null;
+  const campaign=campaignId(state.campaignRun.activeCampaign);
+  const longNightOutcome=state.campaignRun.majorOutcomes.long_night;
+  if(!campaign||!longNightOutcome)return null;
+  const summary=state.legacy.runSummaries.find(item=>item.runNumber===state.campaignRun.runNumber&&item.campaign===campaign);
+  if(!summary?.ending)return null;
+  const dimensions=parseModularEndingId(summary.ending);
+  if(!dimensions||summary.career!==dimensions.career)return null;
+  return {
+    runNumber:state.campaignRun.runNumber,
+    campaignId:campaign,
+    route:state.campaignRun.activeRoute,
+    longNightOutcome,
+    endingId:summary.ending,
+    dimensions,
+  };
+}


### PR DESCRIPTION
Parent: #127

Winter Lane C room candidate.

Implemented:
- campaign-aware Winter Seasonal Objectives over existing Long Night actions; no new chore layer
- deterministic one-action/one-objective + existing dedicated claim reward-once ledger
- canonical Winter claim registration + malformed/stale/duplicate sanitation
- exactly-once authoritative `long_night` outcome with defeat fail-forward
- `winter_resolved` milestone + replay/campaign-conflict blocking
- modular four-axis ending resolver: Campaign / Bond / World / Career semantic dimensions
- canonical ending ID: `v3:<campaign>:<bond>:<world>:<career>`
- ending commit exactly once using existing Legacy collections + run summaries
- compact completed-run handoff for later NG+ only
- no NG+ start, no True Campaign expansion
- no new CampaignRun/save fields

TDD RED evidence:
- RED head `6125e72e8b1a5cf5263dae906da0ba3ca8034888`
- existing baseline: 379/379 test files and 1437/1437 tests GREEN
- only new Winter suite failed because `campaign-winter-season` production module did not exist

Final independent verification on head `d0626186b4a658a059ca63b1fc973869c28dbc93` / CI #1636:
- 380/380 test files GREEN
- 1452/1452 tests GREEN
- `src/campaign-winter-season.test.ts`: 15/15 GREEN
- `npm run build` GREEN (`tsc -b && vite build`)

Lane save/state composition is verified separately by PR #134. Keep Draft; do not merge integration/v3 here.