### PR TITLE
02 V3 Winter: Long Night world inputs & consequences

### DIFF
--- a/docs/superpowers/plans/2026-08-22-v3-winter-long-night-world.md
+++ b/docs/superpowers/plans/2026-08-22-v3-winter-long-night-world.md
@@ -1,0 +1,24 @@
+# V3 Winter Long Night World Slice
+
+Baseline: `integration/v3@ce2228cdced098da900e60e6eaafcf2242095b86`
+Lane: Winter B (#126)
+Room: 02 World
+Branch: `work/v3-winter-world`
+
+## Approved bounded design
+
+02 exposes only the World-owned input/consequence contract for The Long Night.
+
+- consume committed Autumn Major Choice and matching current-run typed World Fact
+- inherited facts never substitute for current-run Autumn commitment evidence
+- reuse existing Expedition stages/regions
+- produce four campaign-specific World pressures and Tactical adjustment keys
+- all `exceptional_victory | victory | costly_victory | defeat` outcomes resolve to a typed fail-forward Winter World consequence
+- no persistence, shared game/save, App/Root, Tactical engine, Ending UI, or NG+ changes
+
+## TDD
+
+1. RED: `winter-long-night-world.test.ts` imports missing production module and defines the contract.
+2. GREEN: add the smallest pure World adapter satisfying the tests.
+3. Verify targeted, full suite, `tsc -b`, production build.
+4. Keep Draft/unmerged and hand exact GREEN candidate to Lane B lead 04.

--- a/docs/superpowers/specs/2026-08-22-v3-winter-long-night-world-design.md
+++ b/docs/superpowers/specs/2026-08-22-v3-winter-long-night-world-design.md
@@ -1,0 +1,24 @@
+# V3 Winter Long Night World Design
+
+## Scope
+
+World-owned Long Night input and consequence contracts for Winter Lane B.
+
+## Inputs
+
+The adapter consumes an `AutumnChoiceCommitment` and `WorldHistoryState`. The commitment and matching typed current-run World Fact must agree. Inherited facts are kept separate and cannot satisfy current-run evidence.
+
+## Campaign mapping
+
+- Caretaker → existing `forest_guardian`, preservation crisis, responsibility-sharing adjustment.
+- Pathfinder → existing `city_core`, unstable-route crisis, route-history adjustment.
+- Vanguard → existing `city_core`, command siege, authority/coalition adjustment.
+- Arcanist → existing `lake_tempest`, Reality/Rift/Memory crisis, forbidden-relic adjustment.
+
+## Outcomes
+
+Registered `long_night` outcomes map to typed fail-forward World consequence categories. Defeat is valid and resolves the run rather than creating a retry-only dead end.
+
+## Boundaries
+
+No Tactical engine changes, persistence changes, shared game/save state changes, Ending UI, or NG+ work. 04 consumes this contract and owns Lane B composition.

--- a/src/winter-long-night-world.test.ts
+++ b/src/winter-long-night-world.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { AutumnChoiceCommitment } from './autumn-major-choice';
+import type { WorldHistoryState } from './world-history';
+import {
+  getWinterLongNightWorldCrisis,
+  resolveWinterLongNightWorldConsequence,
+} from './winter-long-night-world';
+
+const history = (currentFacts: WorldHistoryState['currentFacts'], inheritedFacts: WorldHistoryState['inheritedFacts'] = []): WorldHistoryState => ({
+  currentFacts,
+  inheritedFacts,
+});
+
+const commitment = (
+  campaign: AutumnChoiceCommitment['campaign'],
+  optionId: AutumnChoiceCommitment['optionId'],
+): AutumnChoiceCommitment => ({
+  campaign,
+  choiceId: `${campaign}_autumn` as AutumnChoiceCommitment['choiceId'],
+  optionId,
+});
+
+describe('V3 Winter Long Night World contracts', () => {
+  it('builds four distinct fail-forward Long Night crises from committed current-run Autumn history', () => {
+    const caretaker = getWinterLongNightWorldCrisis(
+      commitment('caretaker', 'team_solution'),
+      history(['caretaker_team_solution']),
+    );
+    const pathfinder = getWinterLongNightWorldCrisis(
+      commitment('pathfinder', 'limited_access'),
+      history(['ancient_route_limited']),
+    );
+    const vanguard = getWinterLongNightWorldCrisis(
+      commitment('vanguard', 'coalition_command'),
+      history(['coalition_command']),
+    );
+    const arcanist = getWinterLongNightWorldCrisis(
+      commitment('arcanist', 'controlled_use'),
+      history(['forbidden_relic_controlled']),
+    );
+
+    expect(caretaker).toMatchObject({
+      eventId: 'long_night', campaign: 'caretaker', stageId: 'forest_guardian',
+      pressure: 'preservation_crisis', historyEffect: 'team_coordinated',
+      tacticalAdjustment: 'preservation_coordinated', failForward: true,
+    });
+    expect(pathfinder).toMatchObject({
+      eventId: 'long_night', campaign: 'pathfinder', stageId: 'city_core',
+      pressure: 'unstable_route', historyEffect: 'route_limited',
+      tacticalAdjustment: 'route_phase_weakened', failForward: true,
+    });
+    expect(vanguard).toMatchObject({
+      eventId: 'long_night', campaign: 'vanguard', stageId: 'city_core',
+      pressure: 'command_siege', historyEffect: 'coalition_command',
+      tacticalAdjustment: 'elite_chain_coalition', failForward: true,
+    });
+    expect(arcanist).toMatchObject({
+      eventId: 'long_night', campaign: 'arcanist', stageId: 'lake_tempest',
+      pressure: 'reality_rift_memory', historyEffect: 'forbidden_power_controlled',
+      tacticalAdjustment: 'rule_shift_controlled', failForward: true,
+    });
+  });
+
+  it('maps every registered Autumn choice to a materially distinct Winter adjustment', () => {
+    const cases = [
+      ['caretaker', 'save_one', 'caretaker_critical_person_saved', 'preservation_harder'],
+      ['caretaker', 'spread_risk', 'caretaker_risk_shared', 'preservation_supported'],
+      ['caretaker', 'team_solution', 'caretaker_team_solution', 'preservation_coordinated'],
+      ['pathfinder', 'open_route', 'ancient_route_opened', 'route_shortcut_unstable'],
+      ['pathfinder', 'seal_route', 'ancient_route_sealed', 'route_detour'],
+      ['pathfinder', 'limited_access', 'ancient_route_limited', 'route_phase_weakened'],
+      ['vanguard', 'centralize', 'eiden_central_command', 'elite_chain_centralized'],
+      ['vanguard', 'preserve_independence', 'regional_alliance', 'elite_chain_distributed'],
+      ['vanguard', 'coalition_command', 'coalition_command', 'elite_chain_coalition'],
+      ['arcanist', 'use_relic', 'forbidden_relic_used', 'rule_shift_empowered_costly'],
+      ['arcanist', 'destroy_relic', 'forbidden_relic_destroyed', 'rule_shift_without_relic'],
+      ['arcanist', 'controlled_use', 'forbidden_relic_controlled', 'rule_shift_controlled'],
+    ] as const;
+
+    for (const [campaign, optionId, fact, adjustment] of cases) {
+      const crisis = getWinterLongNightWorldCrisis(
+        commitment(campaign, optionId),
+        history([fact]),
+      );
+      expect(crisis?.tacticalAdjustment).toBe(adjustment);
+    }
+  });
+
+  it('does not let inherited or contradictory history substitute for the committed current-run Autumn fact', () => {
+    expect(getWinterLongNightWorldCrisis(
+      commitment('pathfinder', 'limited_access'),
+      history([], ['ancient_route_limited']),
+    )).toBeNull();
+
+    expect(getWinterLongNightWorldCrisis(
+      commitment('arcanist', 'controlled_use'),
+      history(['forbidden_relic_used']),
+    )).toBeNull();
+  });
+
+  it('resolves all Long Night outcomes into typed fail-forward World consequences, including defeat', () => {
+    expect(resolveWinterLongNightWorldConsequence('caretaker', 'exceptional_victory')).toEqual({
+      eventId: 'long_night', campaign: 'caretaker', outcome: 'exceptional_victory',
+      consequence: 'night_broken', failForward: true,
+    });
+    expect(resolveWinterLongNightWorldConsequence('pathfinder', 'victory')?.consequence).toBe('night_endured');
+    expect(resolveWinterLongNightWorldConsequence('vanguard', 'costly_victory')?.consequence).toBe('night_survived_at_cost');
+    expect(resolveWinterLongNightWorldConsequence('arcanist', 'defeat')).toEqual({
+      eventId: 'long_night', campaign: 'arcanist', outcome: 'defeat',
+      consequence: 'night_scars_remain', failForward: true,
+    });
+  });
+
+  it('rejects malformed commitments, history, campaigns, and outcomes without inventing fallback history', () => {
+    expect(getWinterLongNightWorldCrisis(null, history([]))).toBeNull();
+    expect(getWinterLongNightWorldCrisis(
+      { campaign: 'caretaker', choiceId: 'pathfinder_autumn', optionId: 'team_solution' } as AutumnChoiceCommitment,
+      history(['caretaker_team_solution']),
+    )).toBeNull();
+    expect(getWinterLongNightWorldCrisis(
+      commitment('caretaker', 'team_solution'),
+      { currentFacts: ['unknown_fact'], inheritedFacts: [] } as unknown as WorldHistoryState,
+    )).toBeNull();
+    expect(resolveWinterLongNightWorldConsequence('unknown', 'victory')).toBeNull();
+    expect(resolveWinterLongNightWorldConsequence('caretaker', 'unknown')).toBeNull();
+  });
+});

--- a/src/winter-long-night-world.ts
+++ b/src/winter-long-night-world.ts
@@ -1,0 +1,154 @@
+import {
+  mainCampaignIds,
+  majorOutcomeResults,
+  type MainCampaignId,
+  type MajorOutcomeResult,
+} from './campaign-model';
+import type { AutumnChoiceCommitment } from './autumn-major-choice';
+import { getAutumnMajorChoiceWorldFacts } from './autumn-world-consequences';
+import type { ExpeditionStageId } from './expedition-regions';
+import type { WorldHistoryState } from './world-history';
+
+export type WinterLongNightWorldPressure =
+  | 'preservation_crisis'
+  | 'unstable_route'
+  | 'command_siege'
+  | 'reality_rift_memory';
+
+export type WinterLongNightHistoryEffect =
+  | 'single_burden'
+  | 'responsibility_shared'
+  | 'team_coordinated'
+  | 'route_opened'
+  | 'route_sealed'
+  | 'route_limited'
+  | 'centralized_command'
+  | 'regional_alliance'
+  | 'coalition_command'
+  | 'forbidden_power_used'
+  | 'forbidden_power_destroyed'
+  | 'forbidden_power_controlled';
+
+export type WinterLongNightTacticalAdjustment =
+  | 'preservation_harder'
+  | 'preservation_supported'
+  | 'preservation_coordinated'
+  | 'route_shortcut_unstable'
+  | 'route_detour'
+  | 'route_phase_weakened'
+  | 'elite_chain_centralized'
+  | 'elite_chain_distributed'
+  | 'elite_chain_coalition'
+  | 'rule_shift_empowered_costly'
+  | 'rule_shift_without_relic'
+  | 'rule_shift_controlled';
+
+export type WinterLongNightWorldConsequenceId =
+  | 'night_broken'
+  | 'night_endured'
+  | 'night_survived_at_cost'
+  | 'night_scars_remain';
+
+export type WinterLongNightWorldCrisis = Readonly<{
+  eventId: 'long_night';
+  campaign: MainCampaignId;
+  stageId: ExpeditionStageId;
+  pressure: WinterLongNightWorldPressure;
+  historyEffect: WinterLongNightHistoryEffect;
+  tacticalAdjustment: WinterLongNightTacticalAdjustment;
+  failForward: true;
+}>;
+
+export type WinterLongNightWorldConsequence = Readonly<{
+  eventId: 'long_night';
+  campaign: MainCampaignId;
+  outcome: MajorOutcomeResult;
+  consequence: WinterLongNightWorldConsequenceId;
+  failForward: true;
+}>;
+
+type CampaignBase = Readonly<{
+  stageId: ExpeditionStageId;
+  pressure: WinterLongNightWorldPressure;
+}>;
+
+type ChoiceEffect = Readonly<{
+  historyEffect: WinterLongNightHistoryEffect;
+  tacticalAdjustment: WinterLongNightTacticalAdjustment;
+}>;
+
+const campaignBase: Readonly<Record<MainCampaignId, CampaignBase>> = {
+  caretaker: { stageId: 'forest_guardian', pressure: 'preservation_crisis' },
+  pathfinder: { stageId: 'city_core', pressure: 'unstable_route' },
+  vanguard: { stageId: 'city_core', pressure: 'command_siege' },
+  arcanist: { stageId: 'lake_tempest', pressure: 'reality_rift_memory' },
+};
+
+const choiceEffects: Readonly<Record<string, ChoiceEffect>> = {
+  save_one: { historyEffect: 'single_burden', tacticalAdjustment: 'preservation_harder' },
+  spread_risk: { historyEffect: 'responsibility_shared', tacticalAdjustment: 'preservation_supported' },
+  team_solution: { historyEffect: 'team_coordinated', tacticalAdjustment: 'preservation_coordinated' },
+  open_route: { historyEffect: 'route_opened', tacticalAdjustment: 'route_shortcut_unstable' },
+  seal_route: { historyEffect: 'route_sealed', tacticalAdjustment: 'route_detour' },
+  limited_access: { historyEffect: 'route_limited', tacticalAdjustment: 'route_phase_weakened' },
+  centralize: { historyEffect: 'centralized_command', tacticalAdjustment: 'elite_chain_centralized' },
+  preserve_independence: { historyEffect: 'regional_alliance', tacticalAdjustment: 'elite_chain_distributed' },
+  coalition_command: { historyEffect: 'coalition_command', tacticalAdjustment: 'elite_chain_coalition' },
+  use_relic: { historyEffect: 'forbidden_power_used', tacticalAdjustment: 'rule_shift_empowered_costly' },
+  destroy_relic: { historyEffect: 'forbidden_power_destroyed', tacticalAdjustment: 'rule_shift_without_relic' },
+  controlled_use: { historyEffect: 'forbidden_power_controlled', tacticalAdjustment: 'rule_shift_controlled' },
+};
+
+const consequenceByOutcome: Readonly<Record<MajorOutcomeResult, WinterLongNightWorldConsequenceId>> = {
+  exceptional_victory: 'night_broken',
+  victory: 'night_endured',
+  costly_victory: 'night_survived_at_cost',
+  defeat: 'night_scars_remain',
+};
+
+const isCampaign = (value: unknown): value is MainCampaignId =>
+  typeof value === 'string' && (mainCampaignIds as readonly string[]).includes(value);
+
+const isOutcome = (value: unknown): value is MajorOutcomeResult =>
+  typeof value === 'string' && (majorOutcomeResults as readonly string[]).includes(value);
+
+export function getWinterLongNightWorldCrisis(
+  commitment: AutumnChoiceCommitment | null | undefined,
+  worldHistory: WorldHistoryState | null | undefined,
+): WinterLongNightWorldCrisis | null {
+  if (!commitment || !isCampaign(commitment.campaign) || !worldHistory) return null;
+  if (commitment.choiceId !== `${commitment.campaign}_autumn`) return null;
+  if (!Array.isArray(worldHistory.currentFacts) || !Array.isArray(worldHistory.inheritedFacts)) return null;
+
+  const expectedFacts = getAutumnMajorChoiceWorldFacts(commitment.campaign, commitment.optionId);
+  if (!expectedFacts || expectedFacts.length === 0) return null;
+  if (!expectedFacts.every(fact => worldHistory.currentFacts.includes(fact))) return null;
+
+  const effect = choiceEffects[commitment.optionId];
+  if (!effect) return null;
+  const base = campaignBase[commitment.campaign];
+
+  return {
+    eventId: 'long_night',
+    campaign: commitment.campaign,
+    stageId: base.stageId,
+    pressure: base.pressure,
+    historyEffect: effect.historyEffect,
+    tacticalAdjustment: effect.tacticalAdjustment,
+    failForward: true,
+  };
+}
+
+export function resolveWinterLongNightWorldConsequence(
+  campaign: unknown,
+  outcome: unknown,
+): WinterLongNightWorldConsequence | null {
+  if (!isCampaign(campaign) || !isOutcome(outcome)) return null;
+  return {
+    eventId: 'long_night',
+    campaign,
+    outcome,
+    consequence: consequenceByOutcome[outcome],
+    failForward: true,
+  };
+}


### PR DESCRIPTION
## Status
- **02 Winter World independent GREEN candidate**
- Parent: #54
- Lane B: #126
- base: `integration/v3@ce2228cdced098da900e60e6eaafcf2242095b86`
- head: `work/v3-winter-world@00399891a9afcb2ed43871b1a28474f6b9877197`
- merge-ref verified: `e287e9e20c2a5dae3a6764b64498ef89eb06dbc9`
- Draft / unmerged

## Scope
World-owned Long Night input/consequence contracts only:
- consumes committed Autumn Major Choice + matching current-run typed World Fact
- inherited World Facts never substitute for current-run Autumn commitment evidence
- reuses existing Expedition stages/regions
- Caretaker → `forest_guardian` / `preservation_crisis`
- Pathfinder → `city_core` / `unstable_route`
- Vanguard → `city_core` / `command_siege`
- Arcanist → `lake_tempest` / `reality_rift_memory`
- all Long Night outcome consequences are fail-forward
- malformed/contradictory inputs return null; no invented fallback history

### 12 Autumn-history Tactical adjustments
Caretaker:
- `save_one` → `preservation_harder`
- `spread_risk` → `preservation_supported`
- `team_solution` → `preservation_coordinated`

Pathfinder:
- `open_route` → `route_shortcut_unstable`
- `seal_route` → `route_detour`
- `limited_access` → `route_phase_weakened`

Vanguard:
- `centralize` → `elite_chain_centralized`
- `preserve_independence` → `elite_chain_distributed`
- `coalition_command` → `elite_chain_coalition`

Arcanist:
- `use_relic` → `rule_shift_empowered_costly`
- `destroy_relic` → `rule_shift_without_relic`
- `controlled_use` → `rule_shift_controlled`

### Typed World consequence mapping
- `exceptional_victory` → `night_broken`
- `victory` → `night_endured`
- `costly_victory` → `night_survived_at_cost`
- `defeat` → `night_scars_remain`

No Tactical engine, shared game/save, App/Root, Ending UI, or NG+ changes.

## TDD evidence
### RED
- test commit: `1bee902c1fd2734ea8d6ef840e15514ffdc16482`
- RED PR head: `599be8cde61a5715c7131da480ed6d51d832bce3`
- CI #1637 / run `32556545387`: expected failure
- only new suite failed with `Cannot find module './winter-long-night-world'`
- pre-existing suite remained GREEN: **379/379 existing files, 1437/1437 tests**

### GREEN
- candidate: `00399891a9afcb2ed43871b1a28474f6b9877197`
- CI #1639 / run `32556610517`: **SUCCESS**
- `src/winter-long-night-world.test.ts`: **5/5 PASS**
- full suite: **380/380 test files, 1442/1442 tests PASS**
- `src/tactical-stability.test.ts`: **13/13 PASS**
- repeated manual/AUTO battle stability: GREEN
- AUTO stress 10 / 50 / 100 checkpoints: GREEN
- `npm run build` = `tsc -b && vite build`: PASS
- Vite production build: PASS
- 190 modules transformed

## Lane B handoff contract
04 is the Lane B lead and should consume only these exported World contracts:
- `getWinterLongNightWorldCrisis`
- `resolveWinterLongNightWorldConsequence`
- `WinterLongNightWorldCrisis`
- `WinterLongNightTacticalAdjustment`
- `WinterLongNightWorldConsequence`

02 freezes new World feature expansion here. Further changes only for concrete World-owned compatibility gaps exposed by `verify/v3-winter-world-tactical` composition.

## Guardrails
- no shared `App.tsx` / `Root.tsx` / game / save edits
- no direct `integration/v3` merge
- main/prod untouched
- NG+ remains closed

## Known non-blocking repository notes
- `npm install` still reports the pre-existing **1 high severity vulnerability**
- GitHub Actions still emits Node20 deprecation / forced Node24 warning
- Vite still reports the existing >500 kB chunk-size warning
