### PR TITLE
[Lane C] V3 Winter Resolution + Ending State verification

### DIFF
--- a/src/campaign-seasonal-claim-keys.ts
+++ b/src/campaign-seasonal-claim-keys.ts
@@ -23,11 +23,19 @@ const campaignSeasonalObjectiveClaimTriples = new Set([
   'autumn:vanguard:autumn_vanguard_coalition',
   'autumn:arcanist:autumn_arcanist_relic',
   'autumn:arcanist:autumn_arcanist_control',
+  'winter:caretaker:winter_caretaker_protection',
+  'winter:caretaker:winter_caretaker_shared_burden',
+  'winter:pathfinder:winter_pathfinder_route',
+  'winter:pathfinder:winter_pathfinder_route_memory',
+  'winter:vanguard:winter_vanguard_command',
+  'winter:vanguard:winter_vanguard_elite_chain',
+  'winter:arcanist:winter_arcanist_reality',
+  'winter:arcanist:winter_arcanist_control',
 ]);
 
 export function isValidCampaignSeasonalObjectiveClaimKey(value:unknown):value is string {
   if(typeof value!=='string') return false;
-  const match=/^([1-9]\d*)-(spring|summer|autumn):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
+  const match=/^([1-9]\d*)-(spring|summer|autumn|winter):(caretaker|pathfinder|vanguard|arcanist):([a-z0-9_]+)$/.exec(value);
   if(!match) return false;
   return campaignSeasonalObjectiveClaimTriples.has(`${match[2]}:${match[3]}:${match[4]}`);
 }

--- a/src/campaign-winter-season.test.ts
+++ b/src/campaign-winter-season.test.ts
@@ -1,5 +1,6 @@
 import {describe,expect,it} from 'vitest';
 import {emptyCampaignRunState} from './campaign-state';
+import {sanitizeCampaignSeasonalObjectiveClaimKeys} from './campaign-seasonal-claim-keys';
 import {emptyV3PersistentState} from './v3-persistent-state';
 import {
   commitLongNightOutcome,
@@ -36,6 +37,16 @@ describe('V3 Winter campaign season + ending runtime',()=>{
       year:4,week:4,campaign:'caretaker',facts:['long_night_protection','responsibility_sharing'],claimedKeys:[first.claimKey],
     });
     expect(duplicate).toEqual(expect.objectContaining({accepted:false,reason:'already_claimed',claimKey:first.claimKey}));
+  });
+
+  it('registers canonical Winter claims and sanitizes stale or malformed variants',()=>{
+    expect(sanitizeCampaignSeasonalObjectiveClaimKeys([
+      '4-winter:caretaker:winter_caretaker_protection',
+      '4-winter:caretaker:winter_caretaker_protection',
+      '04-winter:caretaker:winter_caretaker_protection',
+      '4-winter:caretaker:winter_vanguard_command',
+      '4-winter:caretaker:stale',
+    ])).toEqual(['4-winter:caretaker:winter_caretaker_protection']);
   });
 
   it('rejects malformed Winter objective context and True Campaign input',()=>{

--- a/src/campaign-winter-season.test.ts
+++ b/src/campaign-winter-season.test.ts
@@ -1,0 +1,244 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCampaignRunState} from './campaign-state';
+import {emptyV3PersistentState} from './v3-persistent-state';
+import {
+  commitLongNightOutcome,
+  commitWinterEnding,
+  resolveLongNightOutcome,
+  resolveModularEnding,
+  resolveWinterCampaignAction,
+  selectCompletedRunHandoff,
+} from './campaign-winter-season';
+
+describe('V3 Winter campaign season + ending runtime',()=>{
+  it.each([
+    ['caretaker',['long_night_protection'],'winter_caretaker_protection'],
+    ['pathfinder',['long_night_route'],'winter_pathfinder_route'],
+    ['vanguard',['long_night_command'],'winter_vanguard_command'],
+    ['arcanist',['long_night_reality'],'winter_arcanist_reality'],
+  ] as const)('maps %s Long Night participation into a Winter objective', (campaign,facts,objectiveId)=>{
+    const result=resolveWinterCampaignAction({year:4,week:2,campaign,facts,claimedKeys:[]});
+    expect(result.accepted).toBe(true);
+    if(!result.accepted)return;
+    expect(result.objective.id).toBe(objectiveId);
+    expect(result.claimKey).toBe(`4-winter:${campaign}:${objectiveId}`);
+  });
+
+  it('keeps one Winter action to one objective and blocks duplicate fallthrough across week rollover',()=>{
+    const first=resolveWinterCampaignAction({
+      year:4,week:1,campaign:'caretaker',facts:['long_night_protection','responsibility_sharing'],claimedKeys:[],
+    });
+    expect(first.accepted).toBe(true);
+    if(!first.accepted)return;
+    expect(first.objective.id).toBe('winter_caretaker_protection');
+
+    const duplicate=resolveWinterCampaignAction({
+      year:4,week:4,campaign:'caretaker',facts:['long_night_protection','responsibility_sharing'],claimedKeys:[first.claimKey],
+    });
+    expect(duplicate).toEqual(expect.objectContaining({accepted:false,reason:'already_claimed',claimKey:first.claimKey}));
+  });
+
+  it('rejects malformed Winter objective context and True Campaign input',()=>{
+    expect(resolveWinterCampaignAction({year:4,week:1,campaign:'true_path',facts:['long_night_protection'],claimedKeys:[]})).toEqual({accepted:false,reason:'invalid_context'});
+    expect(resolveWinterCampaignAction({year:0,week:1,campaign:'caretaker',facts:['long_night_protection'],claimedKeys:[]})).toEqual({accepted:false,reason:'invalid_context'});
+    expect(resolveWinterCampaignAction({year:4,week:5,campaign:'caretaker',facts:['long_night_protection'],claimedKeys:[]})).toEqual({accepted:false,reason:'invalid_context'});
+  });
+
+  it('commits defeat as a valid fail-forward Long Night outcome and resolves Winter',()=>{
+    const state={
+      ...emptyCampaignRunState(),
+      phase:'winter' as const,
+      activeCampaign:'caretaker' as const,
+      seasonMilestones:['autumn_resolved' as const],
+    };
+    const outcome=resolveLongNightOutcome({campaign:'caretaker',outcome:'defeat'});
+    expect(outcome.accepted).toBe(true);
+    if(!outcome.accepted)return;
+
+    const committed=commitLongNightOutcome(state,outcome);
+    expect(committed.committed).toBe(true);
+    expect(committed.state.majorOutcomes.long_night).toBe('defeat');
+    expect(committed.state.seasonMilestones).toEqual(['autumn_resolved','winter_resolved']);
+    expect(committed.state.failForwardOutcomes).toContain('long_night');
+    expect(committed.state.phase).toBe('ending');
+  });
+
+  it('blocks conflicting or repeated Long Night outcome commits',()=>{
+    const ready={
+      ...emptyCampaignRunState(),
+      phase:'winter' as const,
+      activeCampaign:'vanguard' as const,
+      seasonMilestones:['autumn_resolved' as const],
+    };
+    const firstOutcome=resolveLongNightOutcome({campaign:'vanguard',outcome:'costly_victory'});
+    expect(firstOutcome.accepted).toBe(true);
+    if(!firstOutcome.accepted)return;
+    const first=commitLongNightOutcome(ready,firstOutcome);
+    expect(first.committed).toBe(true);
+
+    const replayOutcome=resolveLongNightOutcome({campaign:'vanguard',outcome:'victory'});
+    expect(replayOutcome.accepted).toBe(true);
+    if(!replayOutcome.accepted)return;
+    const replay=commitLongNightOutcome(first.state,replayOutcome);
+    expect(replay).toEqual({committed:false,state:first.state,reason:'already_committed'});
+
+    const conflictOutcome=resolveLongNightOutcome({campaign:'caretaker',outcome:'victory'});
+    expect(conflictOutcome.accepted).toBe(true);
+    if(!conflictOutcome.accepted)return;
+    expect(commitLongNightOutcome(ready,conflictOutcome)).toEqual({committed:false,state:ready,reason:'campaign_conflict'});
+  });
+
+  it('requires Autumn resolution and registered Long Night outcome input',()=>{
+    const state={...emptyCampaignRunState(),phase:'winter' as const,activeCampaign:'arcanist' as const};
+    const outcome=resolveLongNightOutcome({campaign:'arcanist',outcome:'victory'});
+    expect(outcome.accepted).toBe(true);
+    if(!outcome.accepted)return;
+    expect(commitLongNightOutcome(state,outcome)).toEqual({committed:false,state,reason:'not_ready'});
+    expect(resolveLongNightOutcome({campaign:'true_path',outcome:'victory'})).toEqual({accepted:false,reason:'invalid_outcome'});
+    expect(resolveLongNightOutcome({campaign:'arcanist',outcome:'perfect'})).toEqual({accepted:false,reason:'invalid_outcome'});
+  });
+
+  it('composes a stable four-axis ending without owning feature-specific interpretation',()=>{
+    const result=resolveModularEnding({
+      campaignResolution:'coalition_guardianship',
+      bondResolution:'rex_mutual_trust',
+      worldResolution:'survived_with_cost',
+      careerResolution:'guardian_captain',
+    });
+    expect(result).toEqual({
+      accepted:true,
+      ending:{
+        id:'v3:coalition_guardianship:rex_mutual_trust:survived_with_cost:guardian_captain',
+        dimensions:{
+          campaign:'coalition_guardianship',
+          bond:'rex_mutual_trust',
+          world:'survived_with_cost',
+          career:'guardian_captain',
+        },
+      },
+    });
+  });
+
+  it('rejects malformed modular ending dimension IDs',()=>{
+    expect(resolveModularEnding({
+      campaignResolution:'Coalition Guardianship',
+      bondResolution:'rex_mutual_trust',
+      worldResolution:'survived_with_cost',
+      careerResolution:'guardian_captain',
+    })).toEqual({accepted:false,reason:'invalid_dimension'});
+    expect(resolveModularEnding({
+      campaignResolution:'coalition_guardianship',
+      bondResolution:'',
+      worldResolution:'survived_with_cost',
+      careerResolution:'guardian_captain',
+    })).toEqual({accepted:false,reason:'invalid_dimension'});
+  });
+
+  it('commits the modular ending exactly once into existing Legacy summary structures',()=>{
+    const persistent=emptyV3PersistentState();
+    const winterReady={
+      ...persistent,
+      campaignRun:{
+        ...persistent.campaignRun,
+        phase:'ending' as const,
+        activeCampaign:'vanguard' as const,
+        majorChoices:{vanguard_autumn:'coalition_command' as const},
+        majorOutcomes:{great_expedition:'victory' as const,long_night:'costly_victory' as const},
+        seasonMilestones:['autumn_resolved' as const,'winter_resolved' as const],
+      },
+      worldHistory:{currentFacts:['coalition_command' as const],inheritedFacts:[]},
+    };
+    const resolved=resolveModularEnding({
+      campaignResolution:'coalition_guardianship',
+      bondResolution:'rex_mutual_trust',
+      worldResolution:'survived_with_cost',
+      careerResolution:'guardian_captain',
+    });
+    expect(resolved.accepted).toBe(true);
+    if(!resolved.accepted)return;
+
+    const committed=commitWinterEnding(winterReady,resolved.ending,{
+      majorWorldOutcomes:['coalition_command','bad'] as any,
+      keyBondMemories:[
+        {characterId:'rex',memoryId:'rex_autumn_coalition_command'},
+        {characterId:'rex',memoryId:'bad'},
+      ] as any,
+      trueClues:['vanguard_hidden_conflict_record','bad'] as any,
+    });
+    expect(committed.committed).toBe(true);
+    expect(committed.state.campaignRun.seasonMilestones).toEqual(['autumn_resolved','winter_resolved','ending_committed']);
+    expect(committed.state.campaignRun.phase).toBe('ending');
+    expect(committed.state.legacy.completedRuns).toBe(1);
+    expect(committed.state.legacy.completedCampaigns).toEqual(['vanguard']);
+    expect(committed.state.legacy.endingCollection).toEqual([resolved.ending.id]);
+    expect(committed.state.legacy.careerCollection).toEqual(['guardian_captain']);
+    expect(committed.state.legacy.runSummaries).toEqual([{
+      runNumber:1,
+      campaign:'vanguard',
+      route:'normal',
+      ending:resolved.ending.id,
+      career:'guardian_captain',
+      majorWorldOutcomes:['coalition_command'],
+      keyBondMemories:[{characterId:'rex',memoryId:'rex_autumn_coalition_command'}],
+      trueClues:['vanguard_hidden_conflict_record'],
+    }]);
+
+    const different=resolveModularEnding({
+      campaignResolution:'central_command',
+      bondResolution:'rex_rivalry',
+      worldResolution:'victory',
+      careerResolution:'commander',
+    });
+    expect(different.accepted).toBe(true);
+    if(!different.accepted)return;
+    expect(commitWinterEnding(committed.state,different.ending)).toEqual({
+      committed:false,
+      state:committed.state,
+      reason:'already_committed',
+    });
+  });
+
+  it('refuses ending commit before authoritative Winter resolution',()=>{
+    const state=emptyV3PersistentState();
+    const resolved=resolveModularEnding({
+      campaignResolution:'shared_guardianship',bondResolution:'mira_trust',worldResolution:'survived',careerResolution:'healer',
+    });
+    expect(resolved.accepted).toBe(true);
+    if(!resolved.accepted)return;
+    expect(commitWinterEnding(state,resolved.ending)).toEqual({committed:false,state,reason:'not_ready'});
+  });
+
+  it('exposes only a compact completed-run handoff after ending commit',()=>{
+    const persistent=emptyV3PersistentState();
+    const winterReady={
+      ...persistent,
+      campaignRun:{
+        ...persistent.campaignRun,
+        phase:'ending' as const,
+        activeCampaign:'caretaker' as const,
+        majorChoices:{caretaker_autumn:'team_solution' as const},
+        majorOutcomes:{great_expedition:'victory' as const,long_night:'defeat' as const},
+        failForwardOutcomes:['long_night' as const],
+        seasonMilestones:['autumn_resolved' as const,'winter_resolved' as const],
+      },
+    };
+    expect(selectCompletedRunHandoff(winterReady)).toBeNull();
+
+    const resolved=resolveModularEnding({
+      campaignResolution:'shared_guardianship',bondResolution:'mira_shared_burden',worldResolution:'survived_at_cost',careerResolution:'healer',
+    });
+    expect(resolved.accepted).toBe(true);
+    if(!resolved.accepted)return;
+    const committed=commitWinterEnding(winterReady,resolved.ending);
+    expect(committed.committed).toBe(true);
+    if(!committed.committed)return;
+    expect(selectCompletedRunHandoff(committed.state)).toEqual({
+      runNumber:1,
+      campaignId:'caretaker',
+      route:'normal',
+      longNightOutcome:'defeat',
+      endingId:resolved.ending.id,
+      dimensions:resolved.ending.dimensions,
+    });
+  });
+});

--- a/src/campaign-winter-season.ts
+++ b/src/campaign-winter-season.ts
@@ -1,0 +1,256 @@
+import {
+  mainCampaignIds,
+  majorOutcomeResults,
+  type MainCampaignId,
+  type MajorOutcomeResult,
+} from './campaign-model';
+import type {CampaignRunState} from './campaign-state';
+import {sanitizeCampaignSeasonalObjectiveClaimKeys} from './campaign-seasonal-claim-keys';
+import {hydrateLegacyState} from './legacy-state';
+import type {V3PersistentState} from './v3-persistent-state';
+
+export type WinterCampaignActionFact=
+  | 'long_night_protection'
+  | 'responsibility_sharing'
+  | 'long_night_route'
+  | 'route_knowledge'
+  | 'long_night_command'
+  | 'elite_chain'
+  | 'long_night_reality'
+  | 'rift_control';
+
+const mainCampaignSet=new Set<string>(mainCampaignIds);
+const winterFactSet=new Set<string>([
+  'long_night_protection','responsibility_sharing','long_night_route','route_knowledge',
+  'long_night_command','elite_chain','long_night_reality','rift_control',
+]);
+
+function campaignId(value:unknown):MainCampaignId|null{
+  return typeof value==='string'&&mainCampaignSet.has(value)?value as MainCampaignId:null;
+}
+
+function canonicalYear(value:unknown):number|null{
+  return typeof value==='number'&&Number.isInteger(value)&&Number.isFinite(value)&&value>=1?value:null;
+}
+
+function validWeek(value:unknown):boolean{
+  return typeof value==='number'&&Number.isInteger(value)&&value>=1&&value<=4;
+}
+
+function uniqueWinterFacts(raw:unknown):WinterCampaignActionFact[]{
+  if(!Array.isArray(raw))return [];
+  return [...new Set(raw.filter((value):value is WinterCampaignActionFact=>typeof value==='string'&&winterFactSet.has(value)))];
+}
+
+const winterObjectives={
+  caretaker:[
+    {id:'winter_caretaker_protection',facts:['long_night_protection']},
+    {id:'winter_caretaker_shared_burden',facts:['responsibility_sharing']},
+  ],
+  pathfinder:[
+    {id:'winter_pathfinder_route',facts:['long_night_route']},
+    {id:'winter_pathfinder_route_memory',facts:['route_knowledge']},
+  ],
+  vanguard:[
+    {id:'winter_vanguard_command',facts:['long_night_command']},
+    {id:'winter_vanguard_elite_chain',facts:['elite_chain']},
+  ],
+  arcanist:[
+    {id:'winter_arcanist_reality',facts:['long_night_reality']},
+    {id:'winter_arcanist_control',facts:['rift_control']},
+  ],
+} as const;
+
+export type WinterCampaignObjectiveId=typeof winterObjectives[MainCampaignId][number]['id'];
+
+export function resolveWinterCampaignAction(input:{
+  year:unknown;
+  week:unknown;
+  campaign:unknown;
+  facts:unknown;
+  claimedKeys:unknown;
+}){
+  const year=canonicalYear(input.year);
+  const campaign=campaignId(input.campaign);
+  if(!year||!campaign||!validWeek(input.week))return {accepted:false as const,reason:'invalid_context' as const};
+  const facts=uniqueWinterFacts(input.facts);
+  const objective=winterObjectives[campaign].find(candidate=>candidate.facts.some(fact=>facts.includes(fact as WinterCampaignActionFact)));
+  if(!objective)return {accepted:false as const,reason:'no_match' as const};
+  const claimKey=`${year}-winter:${campaign}:${objective.id}` as const;
+  const claimed=sanitizeCampaignSeasonalObjectiveClaimKeys(input.claimedKeys);
+  if(claimed.includes(claimKey))return {accepted:false as const,reason:'already_claimed' as const,objective,claimKey};
+  return {
+    accepted:true as const,
+    objective,
+    claimKey,
+    reward:{kind:'campaign_memory' as const,memoryId:`${objective.id}_memory` as const},
+  };
+}
+
+export type AcceptedLongNightOutcome={
+  accepted:true;
+  campaignId:MainCampaignId;
+  outcome:MajorOutcomeResult;
+};
+
+export function resolveLongNightOutcome(input:{campaign:unknown;outcome:unknown}):
+  | AcceptedLongNightOutcome
+  | {accepted:false;reason:'invalid_outcome'}{
+  const campaign=campaignId(input.campaign);
+  if(!campaign||typeof input.outcome!=='string'||!(majorOutcomeResults as readonly string[]).includes(input.outcome)){
+    return {accepted:false,reason:'invalid_outcome'};
+  }
+  return {accepted:true,campaignId:campaign,outcome:input.outcome as MajorOutcomeResult};
+}
+
+export function commitLongNightOutcome(state:CampaignRunState,result:AcceptedLongNightOutcome):
+  | {committed:true;state:CampaignRunState}
+  | {committed:false;state:CampaignRunState;reason:'not_ready'|'campaign_conflict'|'already_committed'}{
+  const activeCampaign=campaignId(state.activeCampaign);
+  if(!activeCampaign||!state.seasonMilestones.includes('autumn_resolved')){
+    return {committed:false,state,reason:'not_ready'};
+  }
+  if(activeCampaign!==result.campaignId){
+    return {committed:false,state,reason:'campaign_conflict'};
+  }
+  if(state.majorOutcomes.long_night!==undefined||state.seasonMilestones.includes('winter_resolved')){
+    return {committed:false,state,reason:'already_committed'};
+  }
+  const failForwardOutcomes=result.outcome==='defeat'&&!state.failForwardOutcomes.includes('long_night')
+    ? [...state.failForwardOutcomes,'long_night' as const]
+    : state.failForwardOutcomes;
+  return {
+    committed:true,
+    state:{
+      ...state,
+      phase:'ending',
+      majorOutcomes:{...state.majorOutcomes,long_night:result.outcome},
+      failForwardOutcomes,
+      seasonMilestones:[...state.seasonMilestones,'winter_resolved'],
+    },
+  };
+}
+
+export type ModularEndingDimensions={
+  campaign:string;
+  bond:string;
+  world:string;
+  career:string;
+};
+
+export type ModularEnding={
+  id:string;
+  dimensions:ModularEndingDimensions;
+};
+
+const semanticDimensionPattern=/^[a-z][a-z0-9_]{0,63}$/;
+
+function semanticDimension(value:unknown):string|null{
+  return typeof value==='string'&&semanticDimensionPattern.test(value)?value:null;
+}
+
+export function resolveModularEnding(input:{
+  campaignResolution:unknown;
+  bondResolution:unknown;
+  worldResolution:unknown;
+  careerResolution:unknown;
+}):
+  | {accepted:true;ending:ModularEnding}
+  | {accepted:false;reason:'invalid_dimension'}{
+  const campaign=semanticDimension(input.campaignResolution);
+  const bond=semanticDimension(input.bondResolution);
+  const world=semanticDimension(input.worldResolution);
+  const career=semanticDimension(input.careerResolution);
+  if(!campaign||!bond||!world||!career)return {accepted:false,reason:'invalid_dimension'};
+  const dimensions={campaign,bond,world,career};
+  return {
+    accepted:true,
+    ending:{id:`v3:${campaign}:${bond}:${world}:${career}`,dimensions},
+  };
+}
+
+function parseModularEndingId(value:unknown):ModularEndingDimensions|null{
+  if(typeof value!=='string')return null;
+  const parts=value.split(':');
+  if(parts.length!==5||parts[0]!=='v3')return null;
+  const campaign=semanticDimension(parts[1]);
+  const bond=semanticDimension(parts[2]);
+  const world=semanticDimension(parts[3]);
+  const career=semanticDimension(parts[4]);
+  return campaign&&bond&&world&&career?{campaign,bond,world,career}:null;
+}
+
+function sameDimensions(a:ModularEndingDimensions,b:ModularEndingDimensions):boolean{
+  return a.campaign===b.campaign&&a.bond===b.bond&&a.world===b.world&&a.career===b.career;
+}
+
+export type WinterEndingSummaryInput={
+  majorWorldOutcomes?:unknown;
+  keyBondMemories?:unknown;
+  trueClues?:unknown;
+};
+
+export function commitWinterEnding(state:V3PersistentState,ending:ModularEnding,summary:WinterEndingSummaryInput={}):
+  | {committed:true;state:V3PersistentState}
+  | {committed:false;state:V3PersistentState;reason:'not_ready'|'already_committed'|'invalid_ending'}{
+  const campaign=campaignId(state.campaignRun.activeCampaign);
+  if(!campaign||!state.campaignRun.seasonMilestones.includes('winter_resolved')||state.campaignRun.majorOutcomes.long_night===undefined){
+    return {committed:false,state,reason:'not_ready'};
+  }
+  if(state.campaignRun.seasonMilestones.includes('ending_committed')||state.legacy.runSummaries.some(item=>item.runNumber===state.campaignRun.runNumber)){
+    return {committed:false,state,reason:'already_committed'};
+  }
+  const parsed=parseModularEndingId(ending.id);
+  if(!parsed||!sameDimensions(parsed,ending.dimensions)){
+    return {committed:false,state,reason:'invalid_ending'};
+  }
+  const runSummary={
+    runNumber:state.campaignRun.runNumber,
+    campaign,
+    route:state.campaignRun.activeRoute,
+    ending:ending.id,
+    career:ending.dimensions.career,
+    majorWorldOutcomes:summary.majorWorldOutcomes??[],
+    keyBondMemories:summary.keyBondMemories??[],
+    trueClues:summary.trueClues??[],
+  };
+  const legacy=hydrateLegacyState({
+    ...state.legacy,
+    completedRuns:state.legacy.completedRuns+1,
+    completedCampaigns:[...state.legacy.completedCampaigns,campaign],
+    endingCollection:[...state.legacy.endingCollection,ending.id],
+    careerCollection:[...state.legacy.careerCollection,ending.dimensions.career],
+    runSummaries:[...state.legacy.runSummaries,runSummary],
+  });
+  return {
+    committed:true,
+    state:{
+      ...state,
+      campaignRun:{
+        ...state.campaignRun,
+        phase:'ending',
+        seasonMilestones:[...state.campaignRun.seasonMilestones,'ending_committed'],
+      },
+      legacy,
+    },
+  };
+}
+
+export function selectCompletedRunHandoff(state:V3PersistentState){
+  if(!state.campaignRun.seasonMilestones.includes('ending_committed'))return null;
+  const campaign=campaignId(state.campaignRun.activeCampaign);
+  const longNightOutcome=state.campaignRun.majorOutcomes.long_night;
+  if(!campaign||!longNightOutcome)return null;
+  const summary=state.legacy.runSummaries.find(item=>item.runNumber===state.campaignRun.runNumber&&item.campaign===campaign);
+  if(!summary?.ending)return null;
+  const dimensions=parseModularEndingId(summary.ending);
+  if(!dimensions||summary.career!==dimensions.career)return null;
+  return {
+    runNumber:state.campaignRun.runNumber,
+    campaignId:campaign,
+    route:state.campaignRun.activeRoute,
+    longNightOutcome,
+    endingId:summary.ending,
+    dimensions,
+  };
+}

--- a/src/v3-winter-season-state-lane.test.ts
+++ b/src/v3-winter-season-state-lane.test.ts
@@ -1,0 +1,239 @@
+import {describe,expect,it} from 'vitest';
+import {initialState,type GameState} from './game';
+import {inspectSavedGame,serializeSavedGame} from './save-schema';
+import {prepareNewRunState} from './v3-persistent-state';
+import {
+  commitLongNightOutcome,
+  commitWinterEnding,
+  resolveLongNightOutcome,
+  resolveModularEnding,
+  resolveWinterCampaignAction,
+  selectCompletedRunHandoff,
+} from './campaign-winter-season';
+
+const winterClaim='4-winter:vanguard:winter_vanguard_command';
+
+function resolvedVanguardEnding(){
+  const result=resolveModularEnding({
+    campaignResolution:'coalition_guardianship',
+    bondResolution:'rex_mutual_trust',
+    worldResolution:'survived_with_cost',
+    careerResolution:'guardian_captain',
+  });
+  expect(result.accepted).toBe(true);
+  if(!result.accepted)throw new Error('expected modular ending');
+  return result.ending;
+}
+
+describe('V3 Winter Lane C season/state vertical slice',()=>{
+  it('persists Winter objective, Long Night result, modular ending, and compact completed-run handoff across reload',()=>{
+    const action=resolveWinterCampaignAction({
+      year:4,week:2,campaign:'vanguard',facts:['long_night_command'],claimedKeys:[],
+    });
+    expect(action.accepted).toBe(true);
+    if(!action.accepted)return;
+    expect(action.claimKey).toBe(winterClaim);
+
+    const outcome=resolveLongNightOutcome({campaign:'vanguard',outcome:'costly_victory'});
+    expect(outcome.accepted).toBe(true);
+    if(!outcome.accepted)return;
+
+    const longNight=commitLongNightOutcome({
+      ...initialState.campaignRun,
+      phase:'winter',
+      activeCampaign:'vanguard',
+      claimedSeasonalObjectives:[action.claimKey],
+      majorChoices:{vanguard_autumn:'coalition_command'},
+      majorOutcomes:{great_expedition:'victory'},
+      seasonMilestones:['autumn_resolved'],
+    },outcome);
+    expect(longNight.committed).toBe(true);
+    if(!longNight.committed)return;
+
+    const ending=resolvedVanguardEnding();
+    const committed=commitWinterEnding({
+      ...initialState,
+      campaignRun:longNight.state,
+      worldHistory:{currentFacts:['coalition_command'],inheritedFacts:[]},
+    },ending,{
+      majorWorldOutcomes:['coalition_command'],
+      keyBondMemories:[{characterId:'rex',memoryId:'rex_autumn_coalition_command'}],
+      trueClues:['vanguard_hidden_conflict_record'],
+    });
+    expect(committed.committed).toBe(true);
+    if(!committed.committed)return;
+
+    const loaded=inspectSavedGame(serializeSavedGame(committed.state as GameState));
+    expect(loaded.status).toBe('valid');
+    expect(loaded.state.campaignRun.claimedSeasonalObjectives).toEqual([winterClaim]);
+    expect(loaded.state.campaignRun.majorOutcomes.long_night).toBe('costly_victory');
+    expect(loaded.state.campaignRun.seasonMilestones).toEqual(['autumn_resolved','winter_resolved','ending_committed']);
+    expect(loaded.state.legacy.completedRuns).toBe(1);
+    expect(loaded.state.legacy.endingCollection).toEqual([ending.id]);
+    expect(loaded.state.legacy.runSummaries).toHaveLength(1);
+    expect(selectCompletedRunHandoff(loaded.state)).toEqual({
+      runNumber:1,
+      campaignId:'vanguard',
+      route:'normal',
+      longNightOutcome:'costly_victory',
+      endingId:ending.id,
+      dimensions:ending.dimensions,
+    });
+
+    const reloaded=inspectSavedGame(serializeSavedGame(loaded.state));
+    expect(reloaded.status).toBe('valid');
+    expect(reloaded.state).toEqual(loaded.state);
+  });
+
+  it('blocks Winter reward, Long Night result, and ending replacement after save/load',()=>{
+    const ending=resolvedVanguardEnding();
+    const state={
+      ...initialState,
+      campaignRun:{
+        ...initialState.campaignRun,
+        phase:'ending' as const,
+        activeCampaign:'vanguard' as const,
+        claimedSeasonalObjectives:[winterClaim],
+        majorChoices:{vanguard_autumn:'coalition_command' as const},
+        majorOutcomes:{great_expedition:'victory' as const,long_night:'costly_victory' as const},
+        seasonMilestones:['autumn_resolved' as const,'winter_resolved' as const,'ending_committed' as const],
+      },
+      legacy:{
+        ...initialState.legacy,
+        completedRuns:1,
+        completedCampaigns:['vanguard' as const],
+        endingCollection:[ending.id],
+        careerCollection:['guardian_captain'],
+        runSummaries:[{
+          runNumber:1,
+          campaign:'vanguard' as const,
+          route:'normal' as const,
+          ending:ending.id,
+          career:'guardian_captain',
+          majorWorldOutcomes:['coalition_command' as const],
+          keyBondMemories:[{characterId:'rex' as const,memoryId:'rex_autumn_coalition_command' as const}],
+          trueClues:['vanguard_hidden_conflict_record' as const],
+        }],
+      },
+    } as GameState;
+    const loaded=inspectSavedGame(serializeSavedGame(state)).state;
+
+    const duplicateAction=resolveWinterCampaignAction({
+      year:4,week:4,campaign:'vanguard',facts:['long_night_command','elite_chain'],
+      claimedKeys:loaded.campaignRun.claimedSeasonalObjectives,
+    });
+    expect(duplicateAction).toEqual(expect.objectContaining({accepted:false,reason:'already_claimed',claimKey:winterClaim}));
+
+    const replayOutcome=resolveLongNightOutcome({campaign:'vanguard',outcome:'victory'});
+    expect(replayOutcome.accepted).toBe(true);
+    if(!replayOutcome.accepted)return;
+    const afterOutcomeReplay=commitLongNightOutcome(loaded.campaignRun,replayOutcome);
+    expect(afterOutcomeReplay).toEqual({committed:false,state:loaded.campaignRun,reason:'already_committed'});
+
+    const different=resolveModularEnding({
+      campaignResolution:'central_command',bondResolution:'rex_rivalry',worldResolution:'victory',careerResolution:'commander',
+    });
+    expect(different.accepted).toBe(true);
+    if(!different.accepted)return;
+    const afterEndingReplay=commitWinterEnding(loaded,different.ending);
+    expect(afterEndingReplay).toEqual({committed:false,state:loaded,reason:'already_committed'});
+  });
+
+  it('persists defeat fail-forward and sanitizes malformed Winter claims and malformed completed-run handoff',()=>{
+    const outcome=resolveLongNightOutcome({campaign:'caretaker',outcome:'defeat'});
+    expect(outcome.accepted).toBe(true);
+    if(!outcome.accepted)return;
+    const defeated=commitLongNightOutcome({
+      ...initialState.campaignRun,
+      phase:'winter',
+      activeCampaign:'caretaker',
+      seasonMilestones:['autumn_resolved'],
+    },outcome);
+    expect(defeated.committed).toBe(true);
+    if(!defeated.committed)return;
+    const defeatLoaded=inspectSavedGame(serializeSavedGame({...initialState,campaignRun:defeated.state} as GameState)).state;
+    expect(defeatLoaded.campaignRun.majorOutcomes.long_night).toBe('defeat');
+    expect(defeatLoaded.campaignRun.failForwardOutcomes).toContain('long_night');
+    expect(defeatLoaded.campaignRun.seasonMilestones).toContain('winter_resolved');
+
+    const raw={
+      ...initialState,
+      campaignRun:{
+        ...initialState.campaignRun,
+        phase:'ending',
+        activeCampaign:'vanguard',
+        claimedSeasonalObjectives:[
+          winterClaim,
+          winterClaim,
+          '04-winter:vanguard:winter_vanguard_command',
+          '4-winter:caretaker:winter_vanguard_command',
+          'bad',
+        ],
+        majorOutcomes:{great_expedition:'victory',long_night:'victory'},
+        seasonMilestones:['autumn_resolved','winter_resolved','ending_committed'],
+      },
+      legacy:{
+        ...initialState.legacy,
+        completedRuns:1,
+        completedCampaigns:['vanguard'],
+        endingCollection:['broken-ending'],
+        careerCollection:['guardian_captain'],
+        runSummaries:[{
+          runNumber:1,
+          campaign:'vanguard',
+          route:'normal',
+          ending:'broken-ending',
+          career:'guardian_captain',
+          majorWorldOutcomes:['coalition_command'],
+          keyBondMemories:[{characterId:'rex',memoryId:'rex_autumn_coalition_command'}],
+          trueClues:['vanguard_hidden_conflict_record'],
+        }],
+      },
+    } as GameState;
+    const hydrated=inspectSavedGame(serializeSavedGame(raw)).state;
+    expect(hydrated.campaignRun.claimedSeasonalObjectives).toEqual([winterClaim]);
+    expect(hydrated.campaignRun.majorOutcomes.long_night).toBe('victory');
+    expect(hydrated.campaignRun.seasonMilestones).toEqual(['autumn_resolved','winter_resolved','ending_committed']);
+    expect(selectCompletedRunHandoff(hydrated)).toBeNull();
+  });
+
+  it('clears Winter run state on new run while preserving the completed Legacy record',()=>{
+    const ending=resolvedVanguardEnding();
+    const current={
+      ...initialState,
+      campaignRun:{
+        ...initialState.campaignRun,
+        phase:'ending' as const,
+        activeCampaign:'vanguard' as const,
+        claimedSeasonalObjectives:[winterClaim],
+        majorOutcomes:{great_expedition:'victory' as const,long_night:'victory' as const},
+        seasonMilestones:['autumn_resolved' as const,'winter_resolved' as const,'ending_committed' as const],
+      },
+      legacy:{
+        ...initialState.legacy,
+        completedRuns:1,
+        completedCampaigns:['vanguard' as const],
+        endingCollection:[ending.id],
+        careerCollection:['guardian_captain'],
+        runSummaries:[{
+          runNumber:1,
+          campaign:'vanguard' as const,
+          route:'normal' as const,
+          ending:ending.id,
+          career:'guardian_captain',
+          majorWorldOutcomes:['coalition_command' as const],
+          keyBondMemories:[{characterId:'rex' as const,memoryId:'rex_autumn_coalition_command' as const}],
+          trueClues:['vanguard_hidden_conflict_record' as const],
+        }],
+      },
+    };
+    const next=prepareNewRunState(current);
+    expect(next.campaignRun.activeCampaign).toBeNull();
+    expect(next.campaignRun.claimedSeasonalObjectives).toEqual([]);
+    expect(next.campaignRun.majorOutcomes.long_night).toBeUndefined();
+    expect(next.campaignRun.failForwardOutcomes).toEqual([]);
+    expect(next.campaignRun.seasonMilestones).toEqual([]);
+    expect(next.legacy).toEqual(current.legacy);
+    expect(selectCompletedRunHandoff(next)).toBeNull();
+  });
+});


### PR DESCRIPTION
Parent: #127

Verification-only Winter Lane C branch.

Composed:
- PR #131 Winter resolution + modular ending runtime
- existing CampaignRun persistence (`claimedSeasonalObjectives`, `majorOutcomes`, `failForwardOutcomes`, `seasonMilestones`, `activeCampaign`)
- existing Legacy collections + run summaries
- Winter save/load/reload/new-run vertical contract

Lane scope verified GREEN:
- Winter Seasonal Objective reward-once persists through save/load/reload
- canonical Winter claim keys sanitize malformed/stale/duplicate variants
- authoritative `long_night` outcome commits exactly once
- defeat persists as valid fail-forward
- `winter_resolved` and `ending_committed` persist
- four-axis modular ending commits exactly once into existing Legacy summary structures
- conflicting/repeated Long Night and ending replacement are blocked after reload
- malformed completed-run ending handoff is rejected
- compact completed-run handoff survives hydration
- new run clears run-local Winter facts while preserving completed Legacy history
- no NG+ start and no True Campaign expansion

Final verification on head `3e517baafd651d3ff38848302afc39e6855a4e92` / PR merge ref `e4340c02e23677847e3eedd071f118b842735676` / CI #1638:
- 381/381 test files GREEN
- 1456/1456 tests GREEN
- `src/campaign-winter-season.test.ts`: 15/15 GREEN
- `src/v3-winter-season-state-lane.test.ts`: 4/4 GREEN
- `npm run build` GREEN (`tsc -b && vite build`)

`work/v3-winter-shared-state` is still identical to authoritative baseline `ce2228cdced098da900e60e6eaafcf2242095b86` (0 commits). Lane E2E proves no additional CampaignRun/game/save field is required for Lane C; reuse existing persistence.

Lane C #127 is GREEN. Keep Draft / verification-only. Do not merge integration/v3 here.