### PR TITLE
[Lane B] V3 Winter World + Tactical verification

### DIFF
--- a/docs/superpowers/plans/2026-08-22-v3-winter-long-night-world.md
+++ b/docs/superpowers/plans/2026-08-22-v3-winter-long-night-world.md
@@ -1,0 +1,24 @@
+# V3 Winter Long Night World Slice
+
+Baseline: `integration/v3@ce2228cdced098da900e60e6eaafcf2242095b86`
+Lane: Winter B (#126)
+Room: 02 World
+Branch: `work/v3-winter-world`
+
+## Approved bounded design
+
+02 exposes only the World-owned input/consequence contract for The Long Night.
+
+- consume committed Autumn Major Choice and matching current-run typed World Fact
+- inherited facts never substitute for current-run Autumn commitment evidence
+- reuse existing Expedition stages/regions
+- produce four campaign-specific World pressures and Tactical adjustment keys
+- all `exceptional_victory | victory | costly_victory | defeat` outcomes resolve to a typed fail-forward Winter World consequence
+- no persistence, shared game/save, App/Root, Tactical engine, Ending UI, or NG+ changes
+
+## TDD
+
+1. RED: `winter-long-night-world.test.ts` imports missing production module and defines the contract.
+2. GREEN: add the smallest pure World adapter satisfying the tests.
+3. Verify targeted, full suite, `tsc -b`, production build.
+4. Keep Draft/unmerged and hand exact GREEN candidate to Lane B lead 04.

--- a/docs/superpowers/specs/2026-08-22-v3-winter-long-night-world-design.md
+++ b/docs/superpowers/specs/2026-08-22-v3-winter-long-night-world-design.md
@@ -1,0 +1,24 @@
+# V3 Winter Long Night World Design
+
+## Scope
+
+World-owned Long Night input and consequence contracts for Winter Lane B.
+
+## Inputs
+
+The adapter consumes an `AutumnChoiceCommitment` and `WorldHistoryState`. The commitment and matching typed current-run World Fact must agree. Inherited facts are kept separate and cannot satisfy current-run evidence.
+
+## Campaign mapping
+
+- Caretaker → existing `forest_guardian`, preservation crisis, responsibility-sharing adjustment.
+- Pathfinder → existing `city_core`, unstable-route crisis, route-history adjustment.
+- Vanguard → existing `city_core`, command siege, authority/coalition adjustment.
+- Arcanist → existing `lake_tempest`, Reality/Rift/Memory crisis, forbidden-relic adjustment.
+
+## Outcomes
+
+Registered `long_night` outcomes map to typed fail-forward World consequence categories. Defeat is valid and resolves the run rather than creating a retry-only dead end.
+
+## Boundaries
+
+No Tactical engine changes, persistence changes, shared game/save state changes, Ending UI, or NG+ work. 04 consumes this contract and owns Lane B composition.

--- a/src/winter-long-night-tactical.test.ts
+++ b/src/winter-long-night-tactical.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  winterLongNightTacticalScenario,
+  type WinterLongNightTacticalAdjustment,
+} from './winter-long-night-tactical';
+import { createTacticalScenarioBattle } from './tactical-scenario';
+
+const progression = { maxHp: 120, agility: 15, power: 24, magic: 20 };
+const companions = ['bear', 'owl'] as const;
+
+const cases = [
+  ['caretaker', 'forest_guardian', 'preservation_harder', 'survive'],
+  ['caretaker', 'forest_guardian', 'preservation_supported', 'survive'],
+  ['caretaker', 'forest_guardian', 'preservation_coordinated', 'survive'],
+  ['pathfinder', 'city_core', 'route_shortcut_unstable', 'escape'],
+  ['pathfinder', 'city_core', 'route_detour', 'escape'],
+  ['pathfinder', 'city_core', 'route_phase_weakened', 'escape'],
+  ['vanguard', 'city_core', 'elite_chain_centralized', 'target-elimination'],
+  ['vanguard', 'city_core', 'elite_chain_distributed', 'target-elimination'],
+  ['vanguard', 'city_core', 'elite_chain_coalition', 'target-elimination'],
+  ['arcanist', 'lake_tempest', 'rule_shift_empowered_costly', 'standard'],
+  ['arcanist', 'lake_tempest', 'rule_shift_without_relic', 'standard'],
+  ['arcanist', 'lake_tempest', 'rule_shift_controlled', 'standard'],
+] as const;
+
+describe('V3 Winter Long Night Tactical scenarios', () => {
+  it.each(cases)('maps %s %s history adjustment into the existing Tactical vocabulary', (campaign, stageId, tacticalAdjustment, objectiveType) => {
+    const scenario = winterLongNightTacticalScenario({
+      eventId: 'long_night',
+      campaign,
+      stageId,
+      tacticalAdjustment: tacticalAdjustment as WinterLongNightTacticalAdjustment,
+      failForward: true,
+    });
+    expect(scenario.campaign).toBe(campaign);
+    expect(scenario.stageId).toBe(stageId);
+    expect(scenario.objective.type).toBe(objectiveType);
+    expect(scenario.failForward).toBe(true);
+    expect(scenario.modifiers.every(modifier => modifier.campaign === campaign)).toBe(true);
+  });
+
+  it('materially changes encounter pressure across each campaign Autumn-history variant', () => {
+    const caretaker = cases.slice(0, 3).map(([, stageId, tacticalAdjustment]) => winterLongNightTacticalScenario({ eventId: 'long_night', campaign: 'caretaker', stageId, tacticalAdjustment, failForward: true }));
+    expect(caretaker.map(item => item.objective)).toEqual([
+      { type: 'survive', rounds: 6 },
+      { type: 'survive', rounds: 5 },
+      { type: 'survive', rounds: 4 },
+    ]);
+
+    const pathfinder = cases.slice(3, 6).map(([, stageId, tacticalAdjustment]) => winterLongNightTacticalScenario({ eventId: 'long_night', campaign: 'pathfinder', stageId, tacticalAdjustment, failForward: true }));
+    expect(pathfinder.map(item => item.objective)).toEqual([
+      { type: 'escape', afterRounds: 2 },
+      { type: 'escape', afterRounds: 4 },
+      { type: 'escape', afterRounds: 1 },
+    ]);
+
+    const vanguard = cases.slice(6, 9).map(([, stageId, tacticalAdjustment]) => winterLongNightTacticalScenario({ eventId: 'long_night', campaign: 'vanguard', stageId, tacticalAdjustment, failForward: true }));
+    expect(vanguard.map(item => item.modifiers[0])).toEqual([
+      { campaign: 'vanguard', kind: 'elite', levelBonus: 5 },
+      { campaign: 'vanguard', kind: 'elite', levelBonus: 4 },
+      { campaign: 'vanguard', kind: 'elite', levelBonus: 3 },
+    ]);
+
+    const arcanist = cases.slice(9, 12).map(([, stageId, tacticalAdjustment]) => winterLongNightTacticalScenario({ eventId: 'long_night', campaign: 'arcanist', stageId, tacticalAdjustment, failForward: true }));
+    expect(arcanist.map(item => item.modifiers.map(modifier => modifier.kind))).toEqual([
+      ['relic-resonance', 'status-amplify', 'rule-shift'],
+      ['status-amplify', 'rule-shift'],
+      ['relic-resonance', 'status-amplify', 'rule-shift'],
+    ]);
+  });
+
+  it('creates normal 3v3 sessions for all 12 Long Night variants', () => {
+    for (const [index, [campaign, stageId, tacticalAdjustment]] of cases.entries()) {
+      const scenario = winterLongNightTacticalScenario({ eventId: 'long_night', campaign, stageId, tacticalAdjustment, failForward: true });
+      const battle = createTacticalScenarioBattle(scenario, companions, progression, 401 + index);
+      expect(battle.units.filter(unit => unit.side === 'ally')).toHaveLength(3);
+      expect(battle.units.filter(unit => unit.side === 'enemy')).toHaveLength(3);
+    }
+  });
+
+  it('rejects cross-campaign adjustment, wrong stage, and disabled fail-forward instead of inventing a fallback', () => {
+    expect(() => winterLongNightTacticalScenario({ eventId: 'long_night', campaign: 'caretaker', stageId: 'forest_guardian', tacticalAdjustment: 'route_detour', failForward: true })).toThrow();
+    expect(() => winterLongNightTacticalScenario({ eventId: 'long_night', campaign: 'vanguard', stageId: 'lake_tempest', tacticalAdjustment: 'elite_chain_coalition', failForward: true })).toThrow();
+    expect(() => winterLongNightTacticalScenario({ eventId: 'long_night', campaign: 'arcanist', stageId: 'lake_tempest', tacticalAdjustment: 'rule_shift_controlled', failForward: false })).toThrow();
+  });
+});

--- a/src/winter-long-night-tactical.ts
+++ b/src/winter-long-night-tactical.ts
@@ -1,0 +1,175 @@
+import type { MainCampaignId } from './campaign-model';
+import {
+  campaignEncounterToTacticalScenario,
+  type CampaignEncounterDefinition,
+  type TacticalScenario,
+} from './tactical-scenario';
+
+export type WinterLongNightTacticalAdjustment =
+  | 'preservation_harder'
+  | 'preservation_supported'
+  | 'preservation_coordinated'
+  | 'route_shortcut_unstable'
+  | 'route_detour'
+  | 'route_phase_weakened'
+  | 'elite_chain_centralized'
+  | 'elite_chain_distributed'
+  | 'elite_chain_coalition'
+  | 'rule_shift_empowered_costly'
+  | 'rule_shift_without_relic'
+  | 'rule_shift_controlled';
+
+export type WinterLongNightTacticalInput = Readonly<{
+  eventId: 'long_night';
+  campaign: MainCampaignId;
+  stageId: string;
+  tacticalAdjustment: WinterLongNightTacticalAdjustment;
+  failForward: boolean;
+}>;
+
+const expectedStage: Readonly<Record<MainCampaignId, string>> = {
+  caretaker: 'forest_guardian',
+  pathfinder: 'city_core',
+  vanguard: 'city_core',
+  arcanist: 'lake_tempest',
+};
+
+function encounterFor(input: WinterLongNightTacticalInput): CampaignEncounterDefinition {
+  if (input.eventId !== 'long_night' || input.failForward !== true || expectedStage[input.campaign] !== input.stageId) {
+    throw new Error('Invalid Winter Long Night Tactical input');
+  }
+
+  switch (input.tacticalAdjustment) {
+    case 'preservation_harder':
+      if (input.campaign !== 'caretaker') break;
+      return {
+        id: 'winter-long-night:caretaker:preservation-harder', campaign: 'caretaker', stageId: input.stageId,
+        objective: { type: 'survive', rounds: 6 },
+        modifiers: [
+          { campaign: 'caretaker', kind: 'rescue', unitId: 'long-night-critical-person' },
+          { campaign: 'caretaker', kind: 'survive', rounds: 6 },
+        ], failForward: true,
+      };
+    case 'preservation_supported':
+      if (input.campaign !== 'caretaker') break;
+      return {
+        id: 'winter-long-night:caretaker:preservation-supported', campaign: 'caretaker', stageId: input.stageId,
+        objective: { type: 'survive', rounds: 5 },
+        modifiers: [
+          { campaign: 'caretaker', kind: 'rescue', unitId: 'long-night-critical-person' },
+          { campaign: 'caretaker', kind: 'survive', rounds: 5 },
+        ], failForward: true,
+      };
+    case 'preservation_coordinated':
+      if (input.campaign !== 'caretaker') break;
+      return {
+        id: 'winter-long-night:caretaker:preservation-coordinated', campaign: 'caretaker', stageId: input.stageId,
+        objective: { type: 'survive', rounds: 4 },
+        modifiers: [
+          { campaign: 'caretaker', kind: 'rescue', unitId: 'long-night-critical-person' },
+          { campaign: 'caretaker', kind: 'survive', rounds: 4 },
+        ], failForward: true,
+      };
+    case 'route_shortcut_unstable':
+      if (input.campaign !== 'pathfinder') break;
+      return {
+        id: 'winter-long-night:pathfinder:shortcut-unstable', campaign: 'pathfinder', stageId: input.stageId,
+        objective: { type: 'escape', afterRounds: 2 },
+        modifiers: [
+          { campaign: 'pathfinder', kind: 'scout', revealCount: 1 },
+          { campaign: 'pathfinder', kind: 'turn-limit', maxRounds: 4 },
+          { campaign: 'pathfinder', kind: 'escape', afterRounds: 2 },
+        ], failForward: true,
+      };
+    case 'route_detour':
+      if (input.campaign !== 'pathfinder') break;
+      return {
+        id: 'winter-long-night:pathfinder:detour', campaign: 'pathfinder', stageId: input.stageId,
+        objective: { type: 'escape', afterRounds: 4 },
+        modifiers: [
+          { campaign: 'pathfinder', kind: 'scout', revealCount: 1 },
+          { campaign: 'pathfinder', kind: 'turn-limit', maxRounds: 7 },
+          { campaign: 'pathfinder', kind: 'escape', afterRounds: 4 },
+        ], failForward: true,
+      };
+    case 'route_phase_weakened':
+      if (input.campaign !== 'pathfinder') break;
+      return {
+        id: 'winter-long-night:pathfinder:phase-weakened', campaign: 'pathfinder', stageId: input.stageId,
+        objective: { type: 'escape', afterRounds: 1 },
+        modifiers: [
+          { campaign: 'pathfinder', kind: 'scout', revealCount: 2 },
+          { campaign: 'pathfinder', kind: 'turn-limit', maxRounds: 5 },
+          { campaign: 'pathfinder', kind: 'escape', afterRounds: 1 },
+        ], failForward: true,
+      };
+    case 'elite_chain_centralized':
+      if (input.campaign !== 'vanguard') break;
+      return {
+        id: 'winter-long-night:vanguard:centralized', campaign: 'vanguard', stageId: input.stageId,
+        objective: { type: 'target-elimination', targetId: `${input.stageId}-enemy-1` },
+        modifiers: [
+          { campaign: 'vanguard', kind: 'elite', levelBonus: 5 },
+          { campaign: 'vanguard', kind: 'chained-battle', chainId: 'long-night-command-siege', index: 4, total: 4 },
+        ], failForward: true,
+      };
+    case 'elite_chain_distributed':
+      if (input.campaign !== 'vanguard') break;
+      return {
+        id: 'winter-long-night:vanguard:distributed', campaign: 'vanguard', stageId: input.stageId,
+        objective: { type: 'target-elimination', targetId: `${input.stageId}-enemy-1` },
+        modifiers: [
+          { campaign: 'vanguard', kind: 'elite', levelBonus: 4 },
+          { campaign: 'vanguard', kind: 'chained-battle', chainId: 'long-night-command-siege', index: 3, total: 4 },
+        ], failForward: true,
+      };
+    case 'elite_chain_coalition':
+      if (input.campaign !== 'vanguard') break;
+      return {
+        id: 'winter-long-night:vanguard:coalition', campaign: 'vanguard', stageId: input.stageId,
+        objective: { type: 'target-elimination', targetId: `${input.stageId}-enemy-1` },
+        modifiers: [
+          { campaign: 'vanguard', kind: 'elite', levelBonus: 3 },
+          { campaign: 'vanguard', kind: 'chained-battle', chainId: 'long-night-command-siege', index: 2, total: 4 },
+        ], failForward: true,
+      };
+    case 'rule_shift_empowered_costly':
+      if (input.campaign !== 'arcanist') break;
+      return {
+        id: 'winter-long-night:arcanist:empowered-costly', campaign: 'arcanist', stageId: input.stageId,
+        objective: { type: 'standard' },
+        modifiers: [
+          { campaign: 'arcanist', kind: 'relic-resonance', relicId: 'forbidden-long-night-relic' },
+          { campaign: 'arcanist', kind: 'status-amplify', statusId: 'break', multiplier: 2 },
+          { campaign: 'arcanist', kind: 'rule-shift', ruleId: 'long-night-empowered-costly' },
+        ], failForward: true,
+      };
+    case 'rule_shift_without_relic':
+      if (input.campaign !== 'arcanist') break;
+      return {
+        id: 'winter-long-night:arcanist:without-relic', campaign: 'arcanist', stageId: input.stageId,
+        objective: { type: 'standard' },
+        modifiers: [
+          { campaign: 'arcanist', kind: 'status-amplify', statusId: 'break', multiplier: 1.5 },
+          { campaign: 'arcanist', kind: 'rule-shift', ruleId: 'long-night-without-relic' },
+        ], failForward: true,
+      };
+    case 'rule_shift_controlled':
+      if (input.campaign !== 'arcanist') break;
+      return {
+        id: 'winter-long-night:arcanist:controlled', campaign: 'arcanist', stageId: input.stageId,
+        objective: { type: 'standard' },
+        modifiers: [
+          { campaign: 'arcanist', kind: 'relic-resonance', relicId: 'controlled-long-night-relic' },
+          { campaign: 'arcanist', kind: 'status-amplify', statusId: 'break', multiplier: 1.25 },
+          { campaign: 'arcanist', kind: 'rule-shift', ruleId: 'long-night-controlled' },
+        ], failForward: true,
+      };
+  }
+
+  throw new Error('Winter Long Night Tactical adjustment/campaign mismatch');
+}
+
+export function winterLongNightTacticalScenario(input: WinterLongNightTacticalInput): TacticalScenario {
+  return campaignEncounterToTacticalScenario(encounterFor(input));
+}

--- a/src/winter-long-night-world.test.ts
+++ b/src/winter-long-night-world.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { AutumnChoiceCommitment } from './autumn-major-choice';
+import type { WorldHistoryState } from './world-history';
+import {
+  getWinterLongNightWorldCrisis,
+  resolveWinterLongNightWorldConsequence,
+} from './winter-long-night-world';
+
+const history = (currentFacts: WorldHistoryState['currentFacts'], inheritedFacts: WorldHistoryState['inheritedFacts'] = []): WorldHistoryState => ({
+  currentFacts,
+  inheritedFacts,
+});
+
+const commitment = (
+  campaign: AutumnChoiceCommitment['campaign'],
+  optionId: AutumnChoiceCommitment['optionId'],
+): AutumnChoiceCommitment => ({
+  campaign,
+  choiceId: `${campaign}_autumn` as AutumnChoiceCommitment['choiceId'],
+  optionId,
+});
+
+describe('V3 Winter Long Night World contracts', () => {
+  it('builds four distinct fail-forward Long Night crises from committed current-run Autumn history', () => {
+    const caretaker = getWinterLongNightWorldCrisis(
+      commitment('caretaker', 'team_solution'),
+      history(['caretaker_team_solution']),
+    );
+    const pathfinder = getWinterLongNightWorldCrisis(
+      commitment('pathfinder', 'limited_access'),
+      history(['ancient_route_limited']),
+    );
+    const vanguard = getWinterLongNightWorldCrisis(
+      commitment('vanguard', 'coalition_command'),
+      history(['coalition_command']),
+    );
+    const arcanist = getWinterLongNightWorldCrisis(
+      commitment('arcanist', 'controlled_use'),
+      history(['forbidden_relic_controlled']),
+    );
+
+    expect(caretaker).toMatchObject({
+      eventId: 'long_night', campaign: 'caretaker', stageId: 'forest_guardian',
+      pressure: 'preservation_crisis', historyEffect: 'team_coordinated',
+      tacticalAdjustment: 'preservation_coordinated', failForward: true,
+    });
+    expect(pathfinder).toMatchObject({
+      eventId: 'long_night', campaign: 'pathfinder', stageId: 'city_core',
+      pressure: 'unstable_route', historyEffect: 'route_limited',
+      tacticalAdjustment: 'route_phase_weakened', failForward: true,
+    });
+    expect(vanguard).toMatchObject({
+      eventId: 'long_night', campaign: 'vanguard', stageId: 'city_core',
+      pressure: 'command_siege', historyEffect: 'coalition_command',
+      tacticalAdjustment: 'elite_chain_coalition', failForward: true,
+    });
+    expect(arcanist).toMatchObject({
+      eventId: 'long_night', campaign: 'arcanist', stageId: 'lake_tempest',
+      pressure: 'reality_rift_memory', historyEffect: 'forbidden_power_controlled',
+      tacticalAdjustment: 'rule_shift_controlled', failForward: true,
+    });
+  });
+
+  it('maps every registered Autumn choice to a materially distinct Winter adjustment', () => {
+    const cases = [
+      ['caretaker', 'save_one', 'caretaker_critical_person_saved', 'preservation_harder'],
+      ['caretaker', 'spread_risk', 'caretaker_risk_shared', 'preservation_supported'],
+      ['caretaker', 'team_solution', 'caretaker_team_solution', 'preservation_coordinated'],
+      ['pathfinder', 'open_route', 'ancient_route_opened', 'route_shortcut_unstable'],
+      ['pathfinder', 'seal_route', 'ancient_route_sealed', 'route_detour'],
+      ['pathfinder', 'limited_access', 'ancient_route_limited', 'route_phase_weakened'],
+      ['vanguard', 'centralize', 'eiden_central_command', 'elite_chain_centralized'],
+      ['vanguard', 'preserve_independence', 'regional_alliance', 'elite_chain_distributed'],
+      ['vanguard', 'coalition_command', 'coalition_command', 'elite_chain_coalition'],
+      ['arcanist', 'use_relic', 'forbidden_relic_used', 'rule_shift_empowered_costly'],
+      ['arcanist', 'destroy_relic', 'forbidden_relic_destroyed', 'rule_shift_without_relic'],
+      ['arcanist', 'controlled_use', 'forbidden_relic_controlled', 'rule_shift_controlled'],
+    ] as const;
+
+    for (const [campaign, optionId, fact, adjustment] of cases) {
+      const crisis = getWinterLongNightWorldCrisis(
+        commitment(campaign, optionId),
+        history([fact]),
+      );
+      expect(crisis?.tacticalAdjustment).toBe(adjustment);
+    }
+  });
+
+  it('does not let inherited or contradictory history substitute for the committed current-run Autumn fact', () => {
+    expect(getWinterLongNightWorldCrisis(
+      commitment('pathfinder', 'limited_access'),
+      history([], ['ancient_route_limited']),
+    )).toBeNull();
+
+    expect(getWinterLongNightWorldCrisis(
+      commitment('arcanist', 'controlled_use'),
+      history(['forbidden_relic_used']),
+    )).toBeNull();
+  });
+
+  it('resolves all Long Night outcomes into typed fail-forward World consequences, including defeat', () => {
+    expect(resolveWinterLongNightWorldConsequence('caretaker', 'exceptional_victory')).toEqual({
+      eventId: 'long_night', campaign: 'caretaker', outcome: 'exceptional_victory',
+      consequence: 'night_broken', failForward: true,
+    });
+    expect(resolveWinterLongNightWorldConsequence('pathfinder', 'victory')?.consequence).toBe('night_endured');
+    expect(resolveWinterLongNightWorldConsequence('vanguard', 'costly_victory')?.consequence).toBe('night_survived_at_cost');
+    expect(resolveWinterLongNightWorldConsequence('arcanist', 'defeat')).toEqual({
+      eventId: 'long_night', campaign: 'arcanist', outcome: 'defeat',
+      consequence: 'night_scars_remain', failForward: true,
+    });
+  });
+
+  it('rejects malformed commitments, history, campaigns, and outcomes without inventing fallback history', () => {
+    expect(getWinterLongNightWorldCrisis(null, history([]))).toBeNull();
+    expect(getWinterLongNightWorldCrisis(
+      { campaign: 'caretaker', choiceId: 'pathfinder_autumn', optionId: 'team_solution' } as AutumnChoiceCommitment,
+      history(['caretaker_team_solution']),
+    )).toBeNull();
+    expect(getWinterLongNightWorldCrisis(
+      commitment('caretaker', 'team_solution'),
+      { currentFacts: ['unknown_fact'], inheritedFacts: [] } as unknown as WorldHistoryState,
+    )).toBeNull();
+    expect(resolveWinterLongNightWorldConsequence('unknown', 'victory')).toBeNull();
+    expect(resolveWinterLongNightWorldConsequence('caretaker', 'unknown')).toBeNull();
+  });
+});

--- a/src/winter-long-night-world.ts
+++ b/src/winter-long-night-world.ts
@@ -1,0 +1,154 @@
+import {
+  mainCampaignIds,
+  majorOutcomeResults,
+  type MainCampaignId,
+  type MajorOutcomeResult,
+} from './campaign-model';
+import type { AutumnChoiceCommitment } from './autumn-major-choice';
+import { getAutumnMajorChoiceWorldFacts } from './autumn-world-consequences';
+import type { ExpeditionStageId } from './expedition-regions';
+import type { WorldHistoryState } from './world-history';
+
+export type WinterLongNightWorldPressure =
+  | 'preservation_crisis'
+  | 'unstable_route'
+  | 'command_siege'
+  | 'reality_rift_memory';
+
+export type WinterLongNightHistoryEffect =
+  | 'single_burden'
+  | 'responsibility_shared'
+  | 'team_coordinated'
+  | 'route_opened'
+  | 'route_sealed'
+  | 'route_limited'
+  | 'centralized_command'
+  | 'regional_alliance'
+  | 'coalition_command'
+  | 'forbidden_power_used'
+  | 'forbidden_power_destroyed'
+  | 'forbidden_power_controlled';
+
+export type WinterLongNightTacticalAdjustment =
+  | 'preservation_harder'
+  | 'preservation_supported'
+  | 'preservation_coordinated'
+  | 'route_shortcut_unstable'
+  | 'route_detour'
+  | 'route_phase_weakened'
+  | 'elite_chain_centralized'
+  | 'elite_chain_distributed'
+  | 'elite_chain_coalition'
+  | 'rule_shift_empowered_costly'
+  | 'rule_shift_without_relic'
+  | 'rule_shift_controlled';
+
+export type WinterLongNightWorldConsequenceId =
+  | 'night_broken'
+  | 'night_endured'
+  | 'night_survived_at_cost'
+  | 'night_scars_remain';
+
+export type WinterLongNightWorldCrisis = Readonly<{
+  eventId: 'long_night';
+  campaign: MainCampaignId;
+  stageId: ExpeditionStageId;
+  pressure: WinterLongNightWorldPressure;
+  historyEffect: WinterLongNightHistoryEffect;
+  tacticalAdjustment: WinterLongNightTacticalAdjustment;
+  failForward: true;
+}>;
+
+export type WinterLongNightWorldConsequence = Readonly<{
+  eventId: 'long_night';
+  campaign: MainCampaignId;
+  outcome: MajorOutcomeResult;
+  consequence: WinterLongNightWorldConsequenceId;
+  failForward: true;
+}>;
+
+type CampaignBase = Readonly<{
+  stageId: ExpeditionStageId;
+  pressure: WinterLongNightWorldPressure;
+}>;
+
+type ChoiceEffect = Readonly<{
+  historyEffect: WinterLongNightHistoryEffect;
+  tacticalAdjustment: WinterLongNightTacticalAdjustment;
+}>;
+
+const campaignBase: Readonly<Record<MainCampaignId, CampaignBase>> = {
+  caretaker: { stageId: 'forest_guardian', pressure: 'preservation_crisis' },
+  pathfinder: { stageId: 'city_core', pressure: 'unstable_route' },
+  vanguard: { stageId: 'city_core', pressure: 'command_siege' },
+  arcanist: { stageId: 'lake_tempest', pressure: 'reality_rift_memory' },
+};
+
+const choiceEffects: Readonly<Record<string, ChoiceEffect>> = {
+  save_one: { historyEffect: 'single_burden', tacticalAdjustment: 'preservation_harder' },
+  spread_risk: { historyEffect: 'responsibility_shared', tacticalAdjustment: 'preservation_supported' },
+  team_solution: { historyEffect: 'team_coordinated', tacticalAdjustment: 'preservation_coordinated' },
+  open_route: { historyEffect: 'route_opened', tacticalAdjustment: 'route_shortcut_unstable' },
+  seal_route: { historyEffect: 'route_sealed', tacticalAdjustment: 'route_detour' },
+  limited_access: { historyEffect: 'route_limited', tacticalAdjustment: 'route_phase_weakened' },
+  centralize: { historyEffect: 'centralized_command', tacticalAdjustment: 'elite_chain_centralized' },
+  preserve_independence: { historyEffect: 'regional_alliance', tacticalAdjustment: 'elite_chain_distributed' },
+  coalition_command: { historyEffect: 'coalition_command', tacticalAdjustment: 'elite_chain_coalition' },
+  use_relic: { historyEffect: 'forbidden_power_used', tacticalAdjustment: 'rule_shift_empowered_costly' },
+  destroy_relic: { historyEffect: 'forbidden_power_destroyed', tacticalAdjustment: 'rule_shift_without_relic' },
+  controlled_use: { historyEffect: 'forbidden_power_controlled', tacticalAdjustment: 'rule_shift_controlled' },
+};
+
+const consequenceByOutcome: Readonly<Record<MajorOutcomeResult, WinterLongNightWorldConsequenceId>> = {
+  exceptional_victory: 'night_broken',
+  victory: 'night_endured',
+  costly_victory: 'night_survived_at_cost',
+  defeat: 'night_scars_remain',
+};
+
+const isCampaign = (value: unknown): value is MainCampaignId =>
+  typeof value === 'string' && (mainCampaignIds as readonly string[]).includes(value);
+
+const isOutcome = (value: unknown): value is MajorOutcomeResult =>
+  typeof value === 'string' && (majorOutcomeResults as readonly string[]).includes(value);
+
+export function getWinterLongNightWorldCrisis(
+  commitment: AutumnChoiceCommitment | null | undefined,
+  worldHistory: WorldHistoryState | null | undefined,
+): WinterLongNightWorldCrisis | null {
+  if (!commitment || !isCampaign(commitment.campaign) || !worldHistory) return null;
+  if (commitment.choiceId !== `${commitment.campaign}_autumn`) return null;
+  if (!Array.isArray(worldHistory.currentFacts) || !Array.isArray(worldHistory.inheritedFacts)) return null;
+
+  const expectedFacts = getAutumnMajorChoiceWorldFacts(commitment.campaign, commitment.optionId);
+  if (!expectedFacts || expectedFacts.length === 0) return null;
+  if (!expectedFacts.every(fact => worldHistory.currentFacts.includes(fact))) return null;
+
+  const effect = choiceEffects[commitment.optionId];
+  if (!effect) return null;
+  const base = campaignBase[commitment.campaign];
+
+  return {
+    eventId: 'long_night',
+    campaign: commitment.campaign,
+    stageId: base.stageId,
+    pressure: base.pressure,
+    historyEffect: effect.historyEffect,
+    tacticalAdjustment: effect.tacticalAdjustment,
+    failForward: true,
+  };
+}
+
+export function resolveWinterLongNightWorldConsequence(
+  campaign: unknown,
+  outcome: unknown,
+): WinterLongNightWorldConsequence | null {
+  if (!isCampaign(campaign) || !isOutcome(outcome)) return null;
+  return {
+    eventId: 'long_night',
+    campaign,
+    outcome,
+    consequence: consequenceByOutcome[outcome],
+    failForward: true,
+  };
+}

--- a/src/winter-world-tactical-lane.test.ts
+++ b/src/winter-world-tactical-lane.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import type { AutumnChoiceCommitment } from './autumn-major-choice';
+import { getAutumnMajorChoiceWorldFacts } from './autumn-world-consequences';
+import {
+  getWinterLongNightWorldCrisis,
+  resolveWinterLongNightWorldConsequence,
+  type WinterLongNightWorldCrisis,
+} from './winter-long-night-world';
+import {
+  createTacticalScenarioBattle,
+  createTacticalTerminalHandoffState,
+  handoffTacticalTerminalResult,
+  resolveTacticalScenarioResult,
+  type TacticalScenario,
+} from './tactical-scenario';
+import {
+  mapWinterTacticalResultToMajorOutcome,
+  winterLongNightWorldCrisisToTacticalScenario,
+} from './winter-world-tactical-lane';
+
+const progression = { maxHp: 120, agility: 15, power: 24, magic: 20 };
+const companions = ['bear', 'owl'] as const;
+
+const choices = {
+  caretaker: { campaign: 'caretaker', choiceId: 'caretaker_autumn', optionId: 'team_solution' },
+  pathfinder: { campaign: 'pathfinder', choiceId: 'pathfinder_autumn', optionId: 'limited_access' },
+  vanguard: { campaign: 'vanguard', choiceId: 'vanguard_autumn', optionId: 'centralize' },
+  arcanist: { campaign: 'arcanist', choiceId: 'arcanist_autumn', optionId: 'controlled_use' },
+} as const satisfies Record<string, AutumnChoiceCommitment>;
+
+function crisisFor(commitment: AutumnChoiceCommitment) {
+  const facts = getAutumnMajorChoiceWorldFacts(commitment.campaign, commitment.optionId)!;
+  const crisis = getWinterLongNightWorldCrisis(commitment, {
+    currentFacts: [...facts],
+    inheritedFacts: ['rift_stabilized'],
+  });
+  expect(crisis).not.toBeNull();
+  return crisis!;
+}
+
+function battleFor(commitment: AutumnChoiceCommitment, seed: number) {
+  const crisis = crisisFor(commitment);
+  const scenario = winterLongNightWorldCrisisToTacticalScenario(crisis);
+  expect(scenario.campaign).toBe(commitment.campaign);
+  expect(scenario.stageId).toBe(crisis.stageId);
+  expect(scenario.failForward).toBe(true);
+  const battle = createTacticalScenarioBattle(scenario, companions, progression, seed);
+  expect(battle.units.filter(unit => unit.side === 'ally')).toHaveLength(3);
+  expect(battle.units.filter(unit => unit.side === 'enemy')).toHaveLength(3);
+  return { crisis, scenario, battle };
+}
+
+function handoffWorld(
+  crisis: WinterLongNightWorldCrisis,
+  scenario: TacticalScenario,
+  session: ReturnType<typeof createTacticalScenarioBattle>,
+  attemptKey: string,
+) {
+  const terminal = resolveTacticalScenarioResult(scenario, session, attemptKey);
+  expect(terminal).not.toBeNull();
+  const handed = handoffTacticalTerminalResult(createTacticalTerminalHandoffState(), terminal);
+  expect(handed.result).not.toBeNull();
+  const outcome = mapWinterTacticalResultToMajorOutcome(handed.result!);
+  const world = resolveWinterLongNightWorldConsequence(crisis.campaign, outcome);
+  expect(world).not.toBeNull();
+  expect(world!.failForward).toBe(true);
+  const replay = handoffTacticalTerminalResult(handed.state, terminal);
+  expect(replay.result).toBeNull();
+  return { terminal: handed.result!, outcome, world: world! };
+}
+
+describe('V3 Winter Lane B Long Night World + Tactical E2E', () => {
+  it('Caretaker team solution creates coordinated preservation pressure and a flawless night_broken consequence', () => {
+    const { crisis, scenario, battle } = battleFor(choices.caretaker, 501);
+    expect(crisis.tacticalAdjustment).toBe('preservation_coordinated');
+    expect(scenario.objective).toEqual({ type: 'survive', rounds: 4 });
+    const flawless = {
+      ...battle,
+      round: 5,
+      units: battle.units.map(unit => unit.side === 'enemy' ? { ...unit, hp: 0 } : { ...unit, hp: unit.maxHp }),
+    };
+    const { terminal, outcome, world } = handoffWorld(crisis, scenario, flawless, 'winter-caretaker-1');
+    expect(terminal.objectiveResult).toBe('success');
+    expect(terminal.battleResult).toBe('victory');
+    expect(outcome).toBe('exceptional_victory');
+    expect(world.consequence).toBe('night_broken');
+  });
+
+  it('Pathfinder limited access creates phase-weakened escape pressure and costly fail-forward consequence', () => {
+    const { crisis, scenario, battle } = battleFor(choices.pathfinder, 502);
+    expect(crisis.tacticalAdjustment).toBe('route_phase_weakened');
+    expect(scenario.objective).toEqual({ type: 'escape', afterRounds: 1 });
+    const escaped = { ...battle, round: 2 };
+    const { terminal, outcome, world } = handoffWorld(crisis, scenario, escaped, 'winter-pathfinder-1');
+    expect(terminal.objectiveResult).toBe('success');
+    expect(terminal.battleResult).toBeNull();
+    expect(outcome).toBe('costly_victory');
+    expect(world.consequence).toBe('night_survived_at_cost');
+  });
+
+  it('Vanguard centralization creates hardest elite chain and a damaged victory night_endured consequence', () => {
+    const { crisis, scenario, battle } = battleFor(choices.vanguard, 503);
+    expect(crisis.tacticalAdjustment).toBe('elite_chain_centralized');
+    expect(scenario.modifiers[0]).toEqual({ campaign: 'vanguard', kind: 'elite', levelBonus: 5 });
+    const wonWithDamage = {
+      ...battle,
+      round: 2,
+      units: battle.units.map(unit => {
+        if (unit.side === 'enemy') return { ...unit, hp: 0 };
+        if (unit.id === 'runa') return { ...unit, hp: Math.max(1, unit.maxHp - 1) };
+        return unit;
+      }),
+    };
+    const { terminal, outcome, world } = handoffWorld(crisis, scenario, wonWithDamage, 'winter-vanguard-1');
+    expect(terminal.battleResult).toBe('victory');
+    expect(terminal.damageTaken).toBeGreaterThan(0);
+    expect(outcome).toBe('victory');
+    expect(world.consequence).toBe('night_endured');
+  });
+
+  it('Arcanist controlled Relic creates controlled rule shift and defeat still resolves to night_scars_remain', () => {
+    const { crisis, scenario, battle } = battleFor(choices.arcanist, 504);
+    expect(crisis.tacticalAdjustment).toBe('rule_shift_controlled');
+    const defeated = {
+      ...battle,
+      round: 2,
+      units: battle.units.map(unit => unit.side === 'ally' ? { ...unit, hp: 0 } : unit),
+    };
+    const { terminal, outcome, world } = handoffWorld(crisis, scenario, defeated, 'winter-arcanist-1');
+    expect(terminal.objectiveResult).toBe('failure');
+    expect(terminal.battleResult).toBe('defeat');
+    expect(outcome).toBe('defeat');
+    expect(world.consequence).toBe('night_scars_remain');
+  });
+
+  it('rejects a World crisis whose stage or campaign no longer matches the canonical Tactical route', () => {
+    const crisis = crisisFor(choices.caretaker);
+    expect(() => winterLongNightWorldCrisisToTacticalScenario({ ...crisis, stageId: 'city_core' })).toThrow();
+    expect(() => winterLongNightWorldCrisisToTacticalScenario({ ...crisis, campaign: 'pathfinder' })).toThrow();
+  });
+});

--- a/src/winter-world-tactical-lane.ts
+++ b/src/winter-world-tactical-lane.ts
@@ -1,0 +1,22 @@
+import type { MajorOutcomeResult } from './campaign-model';
+import type { WinterLongNightWorldCrisis } from './winter-long-night-world';
+import { winterLongNightTacticalScenario } from './winter-long-night-tactical';
+import type { TacticalScenario, TacticalScenarioResult } from './tactical-scenario';
+
+export function winterLongNightWorldCrisisToTacticalScenario(
+  crisis: WinterLongNightWorldCrisis,
+): TacticalScenario {
+  return winterLongNightTacticalScenario(crisis);
+}
+
+export function mapWinterTacticalResultToMajorOutcome(
+  result: TacticalScenarioResult,
+): MajorOutcomeResult {
+  if (result.objectiveResult === 'failure' || result.battleResult === 'defeat') return 'defeat';
+  if (result.battleResult === 'victory') {
+    return result.survivingAllies === 3 && result.damageTaken === 0
+      ? 'exceptional_victory'
+      : 'victory';
+  }
+  return 'costly_victory';
+}


### PR DESCRIPTION
Parent: #126

## Status
**Winter Lane B #126 COMPLETE / GREEN candidate**

- authoritative baseline: `integration/v3@ce2228cdced098da900e60e6eaafcf2242095b86`
- 02 World input: `work/v3-winter-world@00399891a9afcb2ed43871b1a28474f6b9877197` / PR #133
- 04 Tactical input: `work/v3-winter-tactical@afe19307f991ebfda36d555f56b60b746f843303` / PR #136
- Lane head: `verify/v3-winter-world-tactical@d3ff11433afa57e9ce0af6f66a0828a26741f25e`
- verified merge-ref: `48d5d1104ef04eafbedb6d91c653702ae13b60a2`
- Draft / verification-only / **DO NOT MERGE DIRECTLY**

## Connected Winter vertical slice
`committed Autumn Major Choice + current World history`
→ 02 `getWinterLongNightWorldCrisis()`
→ history-specific `tacticalAdjustment`
→ 04 `winterLongNightTacticalScenario()`
→ existing `CampaignEncounterDefinition -> TacticalScenario`
→ existing 3v3 battle engine
→ objective terminal result
→ existing once-only `handoffTacticalTerminalResult()`
→ bounded `MajorOutcomeResult`
→ 02 `resolveWinterLongNightWorldConsequence()`
→ typed authoritative Long Night consequence / fail-forward

World remains authority for the Long Night consequence. Tactical does not mutate World state.

## Autumn-history-dependent Tactical pressure
Caretaker:
- `save_one` → `preservation_harder` → survive 6 + rescue pressure
- `spread_risk` → `preservation_supported` → survive 5
- `team_solution` → `preservation_coordinated` → survive 4

Pathfinder:
- `open_route` → `route_shortcut_unstable` → escape after 2
- `seal_route` → `route_detour` → escape after 4
- `limited_access` → `route_phase_weakened` → escape after 1

Vanguard:
- `centralize` → `elite_chain_centralized` → elite +5 / hardest chain
- `preserve_independence` → `elite_chain_distributed` → elite +4
- `coalition_command` → `elite_chain_coalition` → elite +3

Arcanist:
- `use_relic` → `rule_shift_empowered_costly`
- `destroy_relic` → `rule_shift_without_relic` (no relic-resonance)
- `controlled_use` → `rule_shift_controlled`

All 12 variants reuse existing Expedition stages and current 3v3 engine. Wrong stage, cross-campaign adjustment, or disabled fail-forward is rejected instead of inventing a fallback.

## 04 independent TDD evidence
RED — CI #1642 / run `32558066105`
- new Winter Tactical suite failed only because `./winter-long-night-tactical` was intentionally absent
- existing baseline: **379/379 files, 1437/1437 tests GREEN**
- Tactical stability **13/13**, AUTO **10/50/100**, Expedition stress **4/4** GREEN

GREEN — CI #1643 / run `32558124792`
- `src/winter-long-night-tactical.test.ts`: **15/15 GREEN**
- full: **380/380 test files, 1452/1452 tests GREEN**
- Tactical stability **13/13**
- AUTO **10/50/100 GREEN**
- Expedition stress **4/4**
- `tsc -b && vite build`: **PASS**
- production build PASS; **190 modules transformed**

## Lane B TDD evidence
RED — CI #1645 / run `32558326994`
- new `src/winter-world-tactical-lane.test.ts` failed only because `./winter-world-tactical-lane` was intentionally absent
- composed World + Tactical inputs remained GREEN: **381 prior files / 1457 prior tests**
- World suite **5/5**, Tactical suite **15/15**, Tactical stability **13/13**, AUTO **10/50/100**, Expedition stress **4/4** GREEN

Minimal Lane glue added only:
- World crisis → Tactical scenario delegation
- Tactical terminal telemetry → `exceptional_victory | victory | costly_victory | defeat`

## Final Lane GREEN verification
CI **#1646** / run **`32558386298`**: **SUCCESS**
- `src/winter-world-tactical-lane.test.ts`: **5/5 GREEN**
- `src/winter-long-night-world.test.ts`: **5/5 GREEN**
- `src/winter-long-night-tactical.test.ts`: **15/15 GREEN**
- full: **382/382 test files, 1462/1462 tests GREEN**
- Tactical stability: **13/13 GREEN**
- AUTO bounded/progressing through **10 / 50 / 100 battle checkpoints GREEN**
- Expedition stress: **4/4 GREEN**
- `npm run build` = `tsc -b && vite build`: **PASS**
- Vite production build: **PASS**, **190 modules transformed**

Representative Lane E2E paths:
1. Caretaker `team_solution` → coordinated survival → flawless terminal → `exceptional_victory` → `night_broken`
2. Pathfinder `limited_access` → phase-weakened escape → non-victory objective success → `costly_victory` → `night_survived_at_cost`
3. Vanguard `centralize` → hardest elite chain → damaged battle victory → `victory` → `night_endured`
4. Arcanist `controlled_use` → controlled rule shift → defeat → `defeat` → `night_scars_remain`
5. terminal replay is blocked by existing once-only handoff; stage/campaign mismatch is rejected

## Ownership / diff audit
Exactly 8 changed files vs Winter baseline:
- 02 World candidate: World module + tests + design/plan docs
- 04 Tactical candidate: Tactical module + tests
- Lane B: lane glue + E2E test

No `App.tsx`, `Root.tsx`, shared game/save, `main.tsx`, or `vercel.json` edits. No new map or battle engine. No NG+ implementation.

## Existing non-blocking repository warnings
- npm reports pre-existing 1 high severity vulnerability
- Vite reports existing >500 kB chunk warning
- Actions reports Node20 deprecation / forced Node24 warning

**Status: Winter Lane B #126 GREEN; exact candidate ready for 06 Winter final composite. Keep Draft/unmerged and freeze unless final composite exposes a concrete Lane B regression.**