### PR TITLE
02 V3 NG+: inherited world echo contracts

### DIFF
--- a/src/ngplus-world-echo.test.ts
+++ b/src/ngplus-world-echo.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { NgPlusUnlockId } from './legacy-state';
+import { worldFactIds, type WorldHistoryState } from './world-history';
+import {
+  buildNgPlusWorldEchoPresentation,
+  ngPlusWorldEchoDefinitions,
+} from './ngplus-world-echo';
+
+const unlocked: readonly NgPlusUnlockId[] = ['world_echo'];
+
+const history = (
+  currentFacts: WorldHistoryState['currentFacts'],
+  inheritedFacts: WorldHistoryState['inheritedFacts'],
+): WorldHistoryState => ({ currentFacts, inheritedFacts });
+
+describe('NG+ world echoes', () => {
+  it('presents inherited facts as typed echoes without mixing current-run evidence', () => {
+    const result = buildNgPlusWorldEchoPresentation(
+      history(
+        ['festival_saved'],
+        ['caretaker_team_solution', 'ancient_route_limited', 'coalition_command', 'forbidden_relic_controlled'],
+      ),
+      unlocked,
+    );
+
+    expect(result.currentFacts).toEqual(['festival_saved']);
+    expect(result.inheritedEchoes).toEqual([
+      expect.objectContaining({ factId: 'caretaker_team_solution', source: 'inherited', effect: 'reward', campaign: 'caretaker' }),
+      expect.objectContaining({ factId: 'ancient_route_limited', source: 'inherited', effect: 'candidate_rationale', campaign: 'pathfinder' }),
+      expect.objectContaining({ factId: 'coalition_command', source: 'inherited', effect: 'candidate_rationale', campaign: 'vanguard' }),
+      expect.objectContaining({ factId: 'forbidden_relic_controlled', source: 'inherited', effect: 'hidden_quest', campaign: 'arcanist' }),
+    ]);
+    expect(result.normalCampaignAccessAffected).toBe(false);
+  });
+
+  it('does not expose inherited echoes before the world_echo NG+ unlock is active', () => {
+    const result = buildNgPlusWorldEchoPresentation(
+      history(['festival_saved'], ['ancient_route_opened']),
+      [],
+    );
+
+    expect(result.currentFacts).toEqual(['festival_saved']);
+    expect(result.inheritedEchoes).toEqual([]);
+    expect(result.normalCampaignAccessAffected).toBe(false);
+  });
+
+  it('keeps the same canonical fact distinct when it exists in both current and inherited history', () => {
+    const result = buildNgPlusWorldEchoPresentation(
+      history(['regional_alliance'], ['regional_alliance']),
+      unlocked,
+    );
+
+    expect(result.currentFacts).toEqual(['regional_alliance']);
+    expect(result.inheritedEchoes).toHaveLength(1);
+    expect(result.inheritedEchoes[0]).toMatchObject({
+      factId: 'regional_alliance',
+      source: 'inherited',
+      effect: 'candidate_rationale',
+      campaign: 'vanguard',
+    });
+  });
+
+  it('has exactly one deterministic presentation definition for every canonical World Fact', () => {
+    expect(Object.keys(ngPlusWorldEchoDefinitions).sort()).toEqual([...worldFactIds].sort());
+
+    for (const factId of worldFactIds) {
+      const definition = ngPlusWorldEchoDefinitions[factId];
+      expect(definition.presentationKey).toBe(`ngplus.world_echo.${factId}`);
+      expect(['flavor', 'starting_event', 'hidden_quest', 'candidate_rationale', 'reward']).toContain(definition.effect);
+      expect(definition.affectsNormalCampaignAccess).toBe(false);
+    }
+  });
+});

--- a/src/ngplus-world-echo.ts
+++ b/src/ngplus-world-echo.ts
@@ -1,0 +1,81 @@
+import type { MainCampaignId } from './campaign-model';
+import type { NgPlusUnlockId } from './legacy-state';
+import type { WorldFactId, WorldHistoryState } from './world-history';
+
+export type NgPlusWorldEchoEffect =
+  | 'flavor'
+  | 'starting_event'
+  | 'hidden_quest'
+  | 'candidate_rationale'
+  | 'reward';
+
+export type NgPlusWorldEchoDefinition = Readonly<{
+  effect: NgPlusWorldEchoEffect;
+  campaign: MainCampaignId | null;
+  presentationKey: string;
+  affectsNormalCampaignAccess: false;
+}>;
+
+export type NgPlusWorldEchoPresentationEntry = NgPlusWorldEchoDefinition & Readonly<{
+  factId: WorldFactId;
+  source: 'inherited';
+}>;
+
+export type NgPlusWorldEchoPresentation = Readonly<{
+  currentFacts: WorldFactId[];
+  inheritedEchoes: NgPlusWorldEchoPresentationEntry[];
+  normalCampaignAccessAffected: false;
+}>;
+
+const echo = (
+  factId: WorldFactId,
+  effect: NgPlusWorldEchoEffect,
+  campaign: MainCampaignId | null,
+): NgPlusWorldEchoDefinition => ({
+  effect,
+  campaign,
+  presentationKey: `ngplus.world_echo.${factId}`,
+  affectsNormalCampaignAccess: false,
+});
+
+export const ngPlusWorldEchoDefinitions: Readonly<Record<WorldFactId, NgPlusWorldEchoDefinition>> = {
+  festival_saved: echo('festival_saved', 'starting_event', null),
+  festival_heavy_losses: echo('festival_heavy_losses', 'flavor', null),
+
+  ancient_route_opened: echo('ancient_route_opened', 'candidate_rationale', 'pathfinder'),
+  ancient_route_sealed: echo('ancient_route_sealed', 'candidate_rationale', 'pathfinder'),
+  ancient_route_limited: echo('ancient_route_limited', 'candidate_rationale', 'pathfinder'),
+
+  eiden_central_command: echo('eiden_central_command', 'candidate_rationale', 'vanguard'),
+  regional_alliance: echo('regional_alliance', 'candidate_rationale', 'vanguard'),
+  coalition_command: echo('coalition_command', 'candidate_rationale', 'vanguard'),
+
+  forbidden_relic_used: echo('forbidden_relic_used', 'hidden_quest', 'arcanist'),
+  forbidden_relic_destroyed: echo('forbidden_relic_destroyed', 'hidden_quest', 'arcanist'),
+  forbidden_relic_controlled: echo('forbidden_relic_controlled', 'hidden_quest', 'arcanist'),
+  rift_stabilized: echo('rift_stabilized', 'hidden_quest', 'arcanist'),
+  rift_unstable: echo('rift_unstable', 'hidden_quest', 'arcanist'),
+
+  caretaker_critical_person_saved: echo('caretaker_critical_person_saved', 'reward', 'caretaker'),
+  caretaker_risk_shared: echo('caretaker_risk_shared', 'reward', 'caretaker'),
+  caretaker_team_solution: echo('caretaker_team_solution', 'reward', 'caretaker'),
+};
+
+export function buildNgPlusWorldEchoPresentation(
+  worldHistory: WorldHistoryState,
+  unlocks: readonly NgPlusUnlockId[],
+): NgPlusWorldEchoPresentation {
+  const inheritedEchoes = unlocks.includes('world_echo')
+    ? worldHistory.inheritedFacts.map(factId => ({
+        factId,
+        source: 'inherited' as const,
+        ...ngPlusWorldEchoDefinitions[factId],
+      }))
+    : [];
+
+  return {
+    currentFacts: [...worldHistory.currentFacts],
+    inheritedEchoes,
+    normalCampaignAccessAffected: false,
+  };
+}


### PR DESCRIPTION
## Status
- **02 NG+ World independent GREEN candidate**
- Macro A: #142
- base: `integration/v3@ff6a8fe55b1b2df5d8cf1434bb9b607af4bda264`
- head: `work/v3-ngplus-world@88d30ce9b7a6c4c3c81209b95dab818cf93f3898`
- merge-ref verified: `69ccf4e6fe5c6433389366d774922a49a15a7000`
- Draft / unmerged

## Scope
02-owned pure NG+ World echo semantics only:
- inherited World Facts render as explicit past-life echoes
- current-run World Facts remain a separate evidence channel
- `world_echo` unlock gates inherited echo presentation
- every canonical World Fact receives one deterministic presentation contract
- echo effects: `flavor | starting_event | hidden_quest | candidate_rationale | reward`
- inherited echoes never alter or remove normal four-campaign access
- same canonical fact may exist in both current and inherited channels without collapsing them
- no shared NG+ reset/persistence, App/Root, Tactical, Season, Hub implementation, Fifth Path content, or Hollow

## Exported contract
05/06 may consume:
- `buildNgPlusWorldEchoPresentation`
- `ngPlusWorldEchoDefinitions`
- `NgPlusWorldEchoEffect`
- `NgPlusWorldEchoDefinition`
- `NgPlusWorldEchoPresentationEntry`
- `NgPlusWorldEchoPresentation`

Presentation invariants:
- `currentFacts` = current-run evidence only
- inherited entries always carry `source: 'inherited'`
- inherited presentation requires `world_echo`
- every definition has `affectsNormalCampaignAccess: false`
- aggregate result has `normalCampaignAccessAffected: false`

## TDD evidence
### RED
- commit: `baa2daa2371fced2bebc1624a749baf94d876bc1`
- CI #1652 / run `32560560511`: expected FAILURE
- exact failure: `Cannot find module './ngplus-world-echo'`
- all pre-existing coverage remained GREEN: **389/389 existing test files, 1523/1523 existing tests**

### GREEN
- candidate: `88d30ce9b7a6c4c3c81209b95dab818cf93f3898`
- CI #1654 / run `32560612006`: **SUCCESS**
- `src/ngplus-world-echo.test.ts`: **4/4 PASS**
- full suite: **390/390 test files, 1527/1527 tests PASS**
- Tactical stability: **13/13 PASS**
- AUTO 10/50/100 stress checkpoints: GREEN
- `npm run build` = `tsc -b && vite build`: PASS
- production build: PASS
- 190 modules transformed

## Guardrails
- normal four campaigns remain available
- Fifth Path remains candidate/hint only in Macro A; no playable Fifth Path content here
- no shared reset/persistence implementation
- no direct `integration/v3` merge
- main/prod untouched

## Known non-blocking repository notes
- `npm install` still reports the pre-existing 1 high severity vulnerability
- Actions still emits Node20 deprecation / forced Node24 warning
- Vite still reports the existing >500 kB chunk warning
