### PR TITLE
[01] V3 NG+ Raising — replay relationship semantics

### DIFF
--- a/src/ngplus-raising.test.ts
+++ b/src/ngplus-raising.test.ts
@@ -1,4 +1,5 @@
 import {describe,expect,it} from 'vitest';
+import {mainCampaignIds} from './campaign-model';
 import {emptyLegacyState,type LegacyState} from './legacy-state';
 import {pathConvergence,type SpringAffinityEvidence} from './spring-raising';
 import {resolveNgPlusRaisingReplay} from './ngplus-raising';
@@ -83,7 +84,7 @@ describe('V3 NG+ Raising replay semantics',()=>{
     }),evidence);
     expect(result.normalCandidates.length).toBeGreaterThanOrEqual(2);
     expect(result.specialCandidate).toMatchObject({id:'fifth_path_candidate',kind:'special_candidate'});
-    expect(result.normalCandidates.every(candidate=>candidate.campaign!=='true_path')).toBe(true);
+    expect(result.normalCandidates.every(candidate=>mainCampaignIds.includes(candidate.campaign))).toBe(true);
   });
 
   it('does not expose Fifth Path content when only ordinary NG+ replay unlocks exist',()=>{

--- a/src/ngplus-raising.test.ts
+++ b/src/ngplus-raising.test.ts
@@ -1,0 +1,107 @@
+import {describe,expect,it} from 'vitest';
+import {emptyLegacyState,type LegacyState} from './legacy-state';
+import {pathConvergence,type SpringAffinityEvidence} from './spring-raising';
+import {resolveNgPlusRaisingReplay} from './ngplus-raising';
+
+const evidence:SpringAffinityEvidence[]=[
+  {campaign:'caretaker',source:'training',amount:5,reason:'이번 봄에는 보호 훈련을 선택했다.'},
+  {campaign:'pathfinder',source:'exploration',amount:4,reason:'새 경로를 직접 탐색했다.'},
+  {campaign:'vanguard',source:'tactical',amount:2,reason:'정면 승부를 피하지 않았다.'},
+];
+
+const legacy=(patch:Partial<LegacyState>={}):LegacyState=>({
+  ...emptyLegacyState(),
+  completedRuns:1,
+  completedCampaigns:['caretaker'],
+  endingCollection:['winter.caretaker.team_solution.victory.epilogue'],
+  careerCollection:['winter.career.seasoned'],
+  ngPlusUnlocks:['past_life_dialogue','relationship_reunion'],
+  runSummaries:[{
+    runNumber:1,
+    campaign:'caretaker',
+    route:'normal',
+    ending:'winter.caretaker.team_solution.victory.epilogue',
+    career:'winter.career.seasoned',
+    majorWorldOutcomes:[],
+    keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],
+    trueClues:[],
+  }],
+  relationshipEchoes:{mira:['mira_winter_victory']},
+  ...patch,
+});
+
+describe('V3 NG+ Raising replay semantics',()=>{
+  it('surfaces qualitative past-life evidence from the latest completed run without raw optimization values',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    expect(result.pastLife).toMatchObject({campaign:'caretaker',runNumber:1});
+    expect(result.pastLife?.endingKey).toContain('winter.caretaker');
+    expect(result.pastLife?.careerKey).toBe('winter.career.seasoned');
+    expect(JSON.stringify(result.pastLife)).not.toMatch(/score|trust|affinit|threshold|bestScore|sGrades/i);
+  });
+
+  it('creates representative reunion hooks from relationship echoes and shared Noa/Eiden reunion hooks',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    expect(result.relationshipHooks).toEqual(expect.arrayContaining([
+      expect.objectContaining({character:'mira',kind:'reunion'}),
+      expect.objectContaining({character:'noa',kind:'shared_reunion'}),
+      expect.objectContaining({character:'eiden',kind:'shared_reunion'}),
+    ]));
+    expect(result.relationshipHooks.some(hook=>hook.character==='veyr')).toBe(false);
+  });
+
+  it('does not invent past-life or reunion semantics when the corresponding unlocks are absent',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy({ngPlusUnlocks:[]}),evidence);
+    expect(result.pastLife).toBeNull();
+    expect(result.relationshipHooks).toEqual([]);
+  });
+
+  it('keeps Lyra as a repetition/Fifth Path eligibility hint only',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy({ngPlusUnlocks:['past_life_dialogue','relationship_reunion','fifth_path_candidate']}),evidence);
+    expect(result.relationshipHooks).toContainEqual(expect.objectContaining({character:'lyra',kind:'possibility_hint'}));
+    expect(result.relationshipHooks).not.toContainEqual(expect.objectContaining({character:'lyra',kind:'reunion'}));
+  });
+
+  it('preserves ordinary Spring candidate tendencies instead of letting Legacy overpower current-run play',()=>{
+    const baseline=pathConvergence(evidence);
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    expect(result.normalCandidates.map(candidate=>[candidate.campaign,candidate.tendency]))
+      .toEqual(baseline.map(candidate=>[candidate.campaign,candidate.tendency]));
+    expect(result.normalCandidates).toHaveLength(2);
+  });
+
+  it('adds prior-life rationale qualitatively without replacing current-run reasons',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    const caretaker=result.normalCandidates.find(candidate=>candidate.campaign==='caretaker');
+    expect(caretaker?.reasons).toContain('이번 봄에는 보호 훈련을 선택했다.');
+    expect(caretaker?.legacyReasons?.some(reason=>reason.includes('caretaker'))).toBe(true);
+  });
+
+  it('adds fifth_path_candidate only as a special extra candidate and keeps at least two normal campaigns',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy({
+      ngPlusUnlocks:['past_life_dialogue','relationship_reunion','fifth_path_candidate'],
+      trueClues:['caretaker_life_anomaly','pathfinder_world_route'],
+    }),evidence);
+    expect(result.normalCandidates.length).toBeGreaterThanOrEqual(2);
+    expect(result.specialCandidate).toMatchObject({id:'fifth_path_candidate',kind:'special_candidate'});
+    expect(result.normalCandidates.every(candidate=>candidate.campaign!=='true_path')).toBe(true);
+  });
+
+  it('does not expose Fifth Path content when only ordinary NG+ replay unlocks exist',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    expect(result.specialCandidate).toBeNull();
+    expect(JSON.stringify(result)).not.toContain('true_path');
+  });
+
+  it('degrades malformed/stale legacy input to clean ordinary Spring replay',()=>{
+    const result=resolveNgPlusRaisingReplay({
+      completedRuns:999,
+      ngPlusUnlocks:['stale_unlock'],
+      relationshipEchoes:{mira:['mira_winter_stale']},
+      runSummaries:[{runNumber:'NaN',campaign:'stale'}],
+    } as never,evidence);
+    expect(result.pastLife).toBeNull();
+    expect(result.relationshipHooks).toEqual([]);
+    expect(result.specialCandidate).toBeNull();
+    expect(result.normalCandidates.map(candidate=>candidate.campaign)).toEqual(pathConvergence(evidence).map(candidate=>candidate.campaign));
+  });
+});

--- a/src/ngplus-raising.ts
+++ b/src/ngplus-raising.ts
@@ -1,0 +1,116 @@
+import {mainCampaignIds,type CampaignId,type CharacterId,type MainCampaignId} from './campaign-model';
+import {hydrateLegacyState,type LegacyState,type RunSummary} from './legacy-state';
+import {pathConvergence,type SpringAffinityEvidence,type SpringPathCandidate} from './spring-raising';
+
+export type NgPlusRelationshipHookKind='reunion'|'shared_reunion'|'possibility_hint';
+export type NgPlusRelationshipHook={
+  character:CharacterId;
+  kind:NgPlusRelationshipHookKind;
+  memoryKeys:string[];
+  summaryKey:string;
+};
+
+export type NgPlusPastLife={
+  runNumber:number;
+  campaign:CampaignId;
+  endingKey:string|null;
+  careerKey:string|null;
+  memoryKeys:string[];
+};
+
+export type NgPlusNormalCandidate=SpringPathCandidate&{legacyReasons:string[]};
+export type NgPlusSpecialCandidate={
+  id:'fifth_path_candidate';
+  kind:'special_candidate';
+  reasons:string[];
+};
+
+export type NgPlusRaisingReplay={
+  pastLife:NgPlusPastLife|null;
+  relationshipHooks:NgPlusRelationshipHook[];
+  normalCandidates:NgPlusNormalCandidate[];
+  specialCandidate:NgPlusSpecialCandidate|null;
+};
+
+const representativeByCampaign:Record<MainCampaignId,CharacterId>={
+  caretaker:'mira',
+  pathfinder:'kael',
+  vanguard:'rex',
+  arcanist:'selene',
+};
+
+const latestRun=(legacy:LegacyState):RunSummary|null=>legacy.runSummaries.at(-1)??null;
+const hasUnlock=(legacy:LegacyState,id:'past_life_dialogue'|'relationship_reunion'|'fifth_path_candidate')=>legacy.ngPlusUnlocks.includes(id);
+const isMainCampaign=(campaign:CampaignId):campaign is MainCampaignId=>(mainCampaignIds as readonly CampaignId[]).includes(campaign);
+
+function pastLifeFor(legacy:LegacyState):NgPlusPastLife|null{
+  if(!hasUnlock(legacy,'past_life_dialogue'))return null;
+  const run=latestRun(legacy);
+  if(!run)return null;
+  return {
+    runNumber:run.runNumber,
+    campaign:run.campaign,
+    endingKey:run.ending,
+    careerKey:run.career,
+    memoryKeys:run.keyBondMemories.map(item=>item.memoryId),
+  };
+}
+
+function reunionHooksFor(legacy:LegacyState):NgPlusRelationshipHook[]{
+  if(!hasUnlock(legacy,'relationship_reunion'))return [];
+  const latest=latestRun(legacy);
+  const hooks:NgPlusRelationshipHook[]=[];
+
+  for(const campaign of mainCampaignIds){
+    const character=representativeByCampaign[campaign];
+    const persisted=legacy.relationshipEchoes[character]??[];
+    const summaryMemories=(latest?.keyBondMemories??[])
+      .filter(item=>item.characterId===character)
+      .map(item=>item.memoryId);
+    const memoryKeys=[...new Set([...persisted,...summaryMemories])];
+    if(memoryKeys.length){
+      hooks.push({character,kind:'reunion',memoryKeys,summaryKey:`ngplus.reunion.${character}`});
+    }
+  }
+
+  hooks.push({character:'noa',kind:'shared_reunion',memoryKeys:[],summaryKey:'ngplus.reunion.noa.shared'});
+  hooks.push({character:'eiden',kind:'shared_reunion',memoryKeys:[],summaryKey:'ngplus.reunion.eiden.shared'});
+
+  if(hasUnlock(legacy,'fifth_path_candidate')){
+    hooks.push({character:'lyra',kind:'possibility_hint',memoryKeys:[],summaryKey:'ngplus.hint.lyra.repetition'});
+  }
+  return hooks;
+}
+
+function legacyReasonsFor(candidate:SpringPathCandidate,legacy:LegacyState):string[]{
+  const run=latestRun(legacy);
+  if(!run||!hasUnlock(legacy,'past_life_dialogue')||!isMainCampaign(run.campaign)||run.campaign!==candidate.campaign)return [];
+  const reasons=[`A past ${run.campaign} life leaves a familiar echo.`];
+  if(run.career)reasons.push('A former guardian career still feels faintly familiar.');
+  if(run.keyBondMemories.length)reasons.push('A remembered bond makes this path feel known.');
+  return reasons.slice(0,2);
+}
+
+function specialCandidateFor(legacy:LegacyState):NgPlusSpecialCandidate|null{
+  if(!hasUnlock(legacy,'fifth_path_candidate'))return null;
+  const reasons=legacy.trueClues.slice(0,2).map(clue=>`Legacy clue remembered: ${clue}.`);
+  if(reasons.length===0)reasons.push('Several past possibilities overlap in a way that did not exist before.');
+  return {id:'fifth_path_candidate',kind:'special_candidate',reasons};
+}
+
+export function resolveNgPlusRaisingReplay(
+  rawLegacy:unknown,
+  evidence:readonly SpringAffinityEvidence[],
+):NgPlusRaisingReplay{
+  const legacy=hydrateLegacyState(rawLegacy);
+  const normalCandidates=pathConvergence(evidence).map(candidate=>({
+    ...candidate,
+    legacyReasons:legacyReasonsFor(candidate,legacy),
+  }));
+  return {
+    pastLife:pastLifeFor(legacy),
+    relationshipHooks:reunionHooksFor(legacy),
+    normalCandidates,
+    specialCandidate:specialCandidateFor(legacy),
+  };
+}


### PR DESCRIPTION
Parent: #142 / tracking #146

## [01 NG+ Raising — frozen GREEN candidate]

Authoritative baseline: `integration/v3@ff6a8fe55b1b2df5d8cf1434bb9b607af4bda264`
Candidate: `work/v3-ngplus-raising@5130d28bab8ace114adc1f67ec39697f37889061`
Status: **Draft / frozen for Macro A consumption / DO NOT MERGE DIRECTLY**

## Scope
- consumes sanitized `LegacyState`; does not own NG+ start/reset/runNumber/archive
- exposes latest completed-run past-life semantics only when `past_life_dialogue` is unlocked
- representative reunion hooks from persisted relationship echoes / prior run Bond memories
  - Caretaker → Mira
  - Pathfinder → Kael
  - Vanguard → Rex
  - Arcanist → Selene
- Noa / Eiden shared reunion hooks
- Lyra is possibility/repetition hint only when `fifth_path_candidate` is eligible; no Fifth Path story/content
- Veyr gets no ordinary NG+ reunion hook in this slice
- prior Campaign/Bond/Career history appears as separate qualitative `legacyReasons`; it never changes current-run Spring tendency/order
- normal Path Convergence still uses existing `pathConvergence(evidence)` and remains at least two normal campaigns
- optional special candidate is additive as `fifth_path_candidate`; it is never converted into `true_path` here
- malformed/stale Legacy data is sanitized through `hydrateLegacyState` and degrades to ordinary Spring behavior

## Key API
`resolveNgPlusRaisingReplay(rawLegacy, evidence)` returns:
- `pastLife`
- `relationshipHooks`
- `normalCandidates` with current-run `reasons` + separate `legacyReasons`
- optional `specialCandidate: { id: 'fifth_path_candidate', kind: 'special_candidate', reasons }`

No raw score/trust/affinity/threshold output is introduced.

## TDD evidence
Initial RED — CI #1653 / run `32560590042`
- new NG+ suite failed only with `ERR_MODULE_NOT_FOUND` for `./ngplus-raising`
- existing baseline remained **389/389 test files, 1523/1523 existing tests GREEN**

First implementation — CI #1655 / run `32560652837`
- `src/ngplus-raising.test.ts`: **9/9 GREEN**
- full tests: **390/390 files, 1532/1532 tests GREEN**
- build caught one test-only TS2367 impossible comparison; production semantics were GREEN

Final GREEN — CI #1657 / run `32560727478`
- NG+ Raising: **9/9 GREEN**
- full suite: **390/390 test files, 1532/1532 tests GREEN**
- `npm run build` = `tsc -b && vite build`: **GREEN**
- Vite 8.2.1: **190 modules transformed**
- existing >500 kB chunk warning only

## Exact diff isolation
Compared with authoritative baseline:
- ahead: **3 commits**
- behind: **0**
- changed files: **2**
  - `src/ngplus-raising.ts`
  - `src/ngplus-raising.test.ts`

No shared `game.ts`, save/schema, `App.tsx`, or `Root.tsx` changes.

## [05 Handoff — Macro A #142]
Consume exact candidate SHA `5130d28bab8ace114adc1f67ec39697f37889061`.

Presentation rules:
1. treat `pastLife`, `relationshipHooks`, and `legacyReasons` as qualitative memory context only
2. normal candidate tendency/order is current-run Spring authority
3. render `specialCandidate` separately/additively; do not replace or hide the >=2 normal Campaign candidates
4. `fifth_path_candidate` is eligibility language only; do not expose Fifth Path campaign content yet

## [06 Integration Request]
Macro B / final NG+ composite should provide the authoritative hydrated `LegacyState` after exactly-once archive + runNumber/reset handling. 01 requires no new shared save field. Final E2E should prove that repeated NG+ cycles preserve prior-run qualitative echoes without allowing them to overwrite current-run Spring affinity/candidates.

Keep this PR Draft. Room 01 does not merge `integration/v3`, `main`, or prod.