### PR TITLE
[03] V3 NG+ replay systems runtime

### DIFF
--- a/src/ngplus-replay-stale-unlock.test.ts
+++ b/src/ngplus-replay-stale-unlock.test.ts
@@ -1,0 +1,47 @@
+import {describe,expect,it} from 'vitest';
+import {commitLongNightOutcome,commitWinterEnding,resolveLongNightOutcome,resolveModularEnding} from './campaign-winter-season';
+import {prepareNewPossibilityV3State} from './ngplus-replay';
+import {emptyV3PersistentState} from './v3-persistent-state';
+
+describe('V3 NG+ semantic unlock sanitation',()=>{
+  it('drops a persisted fifth_path_candidate when four-campaign clue eligibility is not satisfied',()=>{
+    const initial=emptyV3PersistentState();
+    const outcome=resolveLongNightOutcome({campaign:'caretaker',outcome:'victory'});
+    expect(outcome.accepted).toBe(true);
+    if(!outcome.accepted)return;
+    const longNight=commitLongNightOutcome({
+      ...initial.campaignRun,
+      phase:'winter',
+      activeCampaign:'caretaker',
+      seasonMilestones:['autumn_resolved'],
+    },outcome);
+    expect(longNight.committed).toBe(true);
+    if(!longNight.committed)return;
+
+    const ending=resolveModularEnding({
+      campaignResolution:'shared_guardianship',
+      bondResolution:'mira_shared_future',
+      worldResolution:'survived_together',
+      careerResolution:'guardian_mentor',
+    });
+    expect(ending.accepted).toBe(true);
+    if(!ending.accepted)return;
+
+    const committed=commitWinterEnding({...initial,campaignRun:longNight.state},ending.ending,{
+      majorWorldOutcomes:['festival_saved'],
+      keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],
+      trueClues:['caretaker_life_anomaly'],
+    });
+    expect(committed.committed).toBe(true);
+    if(!committed.committed)return;
+
+    const stale={
+      ...committed.state,
+      legacy:{...committed.state.legacy,ngPlusUnlocks:['fifth_path_candidate' as const]},
+    };
+    const started=prepareNewPossibilityV3State(stale);
+    expect(started.started).toBe(true);
+    if(!started.started)return;
+    expect(started.state.legacy.ngPlusUnlocks).toEqual(['past_life_dialogue','relationship_reunion','world_echo']);
+  });
+});

--- a/src/ngplus-replay.test.ts
+++ b/src/ngplus-replay.test.ts
@@ -1,0 +1,192 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCharacterBondsState} from './character-bonds';
+import {emptyV3PersistentState,hydrateV3PersistentState,type V3PersistentState} from './v3-persistent-state';
+import {
+  commitLongNightOutcome,
+  commitWinterEnding,
+  resolveLongNightOutcome,
+  resolveModularEnding,
+} from './campaign-winter-season';
+import {
+  prepareNewPossibilityV3State,
+  selectNgPlusUnlocks,
+} from './ngplus-replay';
+import type {CharacterId,MainCampaignId} from './campaign-model';
+import type {TrueClueId} from './legacy-state';
+import type {WorldFactId} from './world-history';
+
+const campaignEndingDimension:Record<MainCampaignId,string>={
+  caretaker:'shared_guardianship',
+  pathfinder:'open_horizon',
+  vanguard:'coalition_command',
+  arcanist:'restrained_resonance',
+};
+const campaignCharacter:Record<MainCampaignId,CharacterId>={
+  caretaker:'mira',pathfinder:'kael',vanguard:'rex',arcanist:'selene',
+};
+const campaignMemory:Record<MainCampaignId,string>={
+  caretaker:'mira_winter_victory',
+  pathfinder:'kael_winter_victory',
+  vanguard:'rex_winter_victory',
+  arcanist:'selene_winter_victory',
+};
+const campaignWorldFact:Record<MainCampaignId,WorldFactId>={
+  caretaker:'festival_saved',
+  pathfinder:'ancient_route_opened',
+  vanguard:'regional_alliance',
+  arcanist:'rift_stabilized',
+};
+const campaignTrueClue:Record<MainCampaignId,TrueClueId>={
+  caretaker:'caretaker_life_anomaly',
+  pathfinder:'pathfinder_world_route',
+  vanguard:'vanguard_hidden_conflict_record',
+  arcanist:'arcanist_rift_cycle',
+};
+
+function completeRun(start:V3PersistentState,campaign:MainCampaignId):V3PersistentState{
+  const outcome=resolveLongNightOutcome({campaign,outcome:'victory'});
+  expect(outcome.accepted).toBe(true);
+  if(!outcome.accepted)throw new Error('expected Long Night outcome');
+  const longNight=commitLongNightOutcome({
+    ...start.campaignRun,
+    phase:'winter',
+    activeCampaign:campaign,
+    seasonMilestones:['autumn_resolved'],
+  },outcome);
+  expect(longNight.committed).toBe(true);
+  if(!longNight.committed)throw new Error('expected Long Night commit');
+
+  const ending=resolveModularEnding({
+    campaignResolution:campaignEndingDimension[campaign],
+    bondResolution:`${campaignCharacter[campaign]}_shared_future`,
+    worldResolution:'survived_together',
+    careerResolution:'guardian_mentor',
+  });
+  expect(ending.accepted).toBe(true);
+  if(!ending.accepted)throw new Error('expected modular ending');
+
+  const committed=commitWinterEnding({...start,campaignRun:longNight.state},ending.ending,{
+    majorWorldOutcomes:[campaignWorldFact[campaign]],
+    keyBondMemories:[{characterId:campaignCharacter[campaign],memoryId:campaignMemory[campaign]}],
+    trueClues:[campaignTrueClue[campaign]],
+  });
+  expect(committed.committed).toBe(true);
+  if(!committed.committed)throw new Error('expected Winter ending commit');
+  return committed.state;
+}
+
+describe('V3 NG+ replay systems',()=>{
+  it('starts a new possibility only from a committed completed Winter run',()=>{
+    const empty=emptyV3PersistentState();
+    expect(prepareNewPossibilityV3State(empty)).toEqual({started:false,state:empty,reason:'not_ready'});
+
+    const completed=completeRun(empty,'caretaker');
+    const started=prepareNewPossibilityV3State(completed);
+    expect(started.started).toBe(true);
+    if(!started.started)return;
+    expect(started.sourceRunNumber).toBe(1);
+    expect(started.nextRunNumber).toBe(2);
+  });
+
+  it('resets current-run Campaign, Bond and World state while promoting compact Legacy echoes',()=>{
+    const completed=completeRun(emptyV3PersistentState(),'caretaker');
+    const started=prepareNewPossibilityV3State(completed);
+    expect(started.started).toBe(true);
+    if(!started.started)return;
+
+    expect(started.state.campaignRun).toMatchObject({
+      runNumber:2,
+      phase:'spring_exploration',
+      activeCampaign:null,
+      activeRoute:'normal',
+      campaignAffinities:{caretaker:0,pathfinder:0,vanguard:0,arcanist:0},
+      dangerState:{score:0,behaviors:[]},
+      seasonMilestones:[],
+      majorChoices:{},
+      majorOutcomes:{},
+      failForwardOutcomes:[],
+      claimedCampaignRewards:[],
+      claimedSeasonalObjectives:[],
+    });
+    expect(started.state.characterBonds).toEqual(emptyCharacterBondsState());
+    expect(started.state.worldHistory.currentFacts).toEqual([]);
+    expect(started.state.worldHistory.inheritedFacts).toEqual(['festival_saved']);
+
+    expect(started.state.legacy.completedRuns).toBe(1);
+    expect(started.state.legacy.runSummaries).toHaveLength(1);
+    expect(started.state.legacy.legacyWorldFacts).toEqual(['festival_saved']);
+    expect(started.state.legacy.relationshipEchoes).toEqual({mira:['mira_winter_victory']});
+    expect(started.state.legacy.trueClues).toEqual(['caretaker_life_anomaly']);
+    expect(started.state.legacy.ngPlusUnlocks).toEqual(['past_life_dialogue','relationship_reunion','world_echo']);
+  });
+
+  it('does not duplicate the completed run archive or increment twice on re-entry/reload',()=>{
+    const completed=completeRun(emptyV3PersistentState(),'caretaker');
+    const first=prepareNewPossibilityV3State(completed);
+    expect(first.started).toBe(true);
+    if(!first.started)return;
+
+    const loaded=hydrateV3PersistentState(JSON.parse(JSON.stringify(first.state)));
+    expect(loaded).toEqual(first.state);
+    expect(loaded.legacy.runSummaries).toHaveLength(1);
+    expect(loaded.campaignRun.runNumber).toBe(2);
+
+    expect(prepareNewPossibilityV3State(loaded)).toEqual({started:false,state:loaded,reason:'not_ready'});
+    expect(loaded.legacy.runSummaries).toHaveLength(1);
+    expect(loaded.legacy.completedRuns).toBe(1);
+  });
+
+  it('keeps unlock selection semantic and withholds fifth_path_candidate until all four campaign clues exist',()=>{
+    expect(selectNgPlusUnlocks({
+      ...emptyV3PersistentState().legacy,
+      completedRuns:4,
+      completedCampaigns:['caretaker','pathfinder','vanguard','arcanist'],
+      trueClues:['caretaker_life_anomaly','pathfinder_world_route','vanguard_hidden_conflict_record'],
+      legacyWorldFacts:['regional_alliance'],
+      relationshipEchoes:{rex:['rex_winter_victory']},
+      runSummaries:[{
+        runNumber:1,campaign:'caretaker',route:'normal',ending:'v3:a:b:c:d',career:'guardian_mentor',
+        majorWorldOutcomes:['festival_saved'],keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],trueClues:['caretaker_life_anomaly'],
+      }],
+    })).toEqual(['past_life_dialogue','relationship_reunion','world_echo']);
+
+    expect(selectNgPlusUnlocks({
+      ...emptyV3PersistentState().legacy,
+      completedRuns:4,
+      completedCampaigns:['caretaker','pathfinder','vanguard','arcanist'],
+      trueClues:['caretaker_life_anomaly','pathfinder_world_route','vanguard_hidden_conflict_record','arcanist_rift_cycle'],
+      legacyWorldFacts:['regional_alliance'],
+      relationshipEchoes:{rex:['rex_winter_victory']},
+      runSummaries:[{
+        runNumber:1,campaign:'caretaker',route:'normal',ending:'v3:a:b:c:d',career:'guardian_mentor',
+        majorWorldOutcomes:['festival_saved'],keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],trueClues:['caretaker_life_anomaly'],
+      }],
+    })).toEqual(['past_life_dialogue','relationship_reunion','world_echo','fifth_path_candidate']);
+  });
+
+  it('remains compact and stable through four completed-run/new-possibility cycles',()=>{
+    const campaigns:MainCampaignId[]=['caretaker','pathfinder','vanguard','arcanist'];
+    let state=emptyV3PersistentState();
+
+    for(let index=0;index<campaigns.length;index+=1){
+      const completed=completeRun(state,campaigns[index]);
+      const started=prepareNewPossibilityV3State(completed);
+      expect(started.started).toBe(true);
+      if(!started.started)throw new Error('expected NG+ start');
+      state=hydrateV3PersistentState(JSON.parse(JSON.stringify(started.state)));
+      expect(state.campaignRun.runNumber).toBe(index+2);
+      expect(state.legacy.completedRuns).toBe(index+1);
+      expect(state.legacy.runSummaries.map(item=>item.runNumber)).toEqual(Array.from({length:index+1},(_,i)=>i+1));
+      expect(state.campaignRun.claimedSeasonalObjectives).toEqual([]);
+      expect(state.campaignRun.majorOutcomes).toEqual({});
+      expect(state.worldHistory.currentFacts).toEqual([]);
+      expect(state.characterBonds).toEqual(emptyCharacterBondsState());
+    }
+
+    expect(state.legacy.completedCampaigns).toEqual(['caretaker','pathfinder','vanguard','arcanist']);
+    expect(state.legacy.legacyWorldFacts).toEqual(['festival_saved','ancient_route_opened','regional_alliance','rift_stabilized']);
+    expect(state.legacy.trueClues).toEqual(['caretaker_life_anomaly','pathfinder_world_route','vanguard_hidden_conflict_record','arcanist_rift_cycle']);
+    expect(state.legacy.ngPlusUnlocks).toEqual(['past_life_dialogue','relationship_reunion','world_echo','fifth_path_candidate']);
+    expect(state.campaignRun.runNumber).toBe(5);
+  });
+});

--- a/src/ngplus-replay.ts
+++ b/src/ngplus-replay.ts
@@ -52,8 +52,10 @@ function promoteLegacyEchoes(legacy:LegacyState):LegacyState{
     relationshipEchoes,
     trueClues,
   });
-  const ngPlusUnlocks=[...promoted.ngPlusUnlocks,...selectNgPlusUnlocks(promoted)];
-  return hydrateLegacyState({...promoted,ngPlusUnlocks});
+  return hydrateLegacyState({
+    ...promoted,
+    ngPlusUnlocks:selectNgPlusUnlocks(promoted),
+  });
 }
 
 export function prepareNewPossibilityV3State(current:V3PersistentState):

--- a/src/ngplus-replay.ts
+++ b/src/ngplus-replay.ts
@@ -1,0 +1,80 @@
+import {emptyCampaignRunState} from './campaign-state';
+import {emptyCharacterBondsState} from './character-bonds';
+import {mainCampaignIds} from './campaign-model';
+import {selectCompletedRunHandoff} from './campaign-winter-season';
+import {
+  hydrateLegacyState,
+  ngPlusUnlockIds,
+  trueClueIds,
+  type LegacyState,
+  type NgPlusUnlockId,
+} from './legacy-state';
+import type {V3PersistentState} from './v3-persistent-state';
+
+export function selectNgPlusUnlocks(legacy:LegacyState):NgPlusUnlockId[]{
+  const selected=new Set<NgPlusUnlockId>();
+
+  if(legacy.runSummaries.length>0)selected.add('past_life_dialogue');
+  if(Object.values(legacy.relationshipEchoes).some(memories=>Array.isArray(memories)&&memories.length>0)){
+    selected.add('relationship_reunion');
+  }
+  if(legacy.legacyWorldFacts.length>0)selected.add('world_echo');
+
+  const completedCampaigns=new Set(legacy.completedCampaigns);
+  const clues=new Set(legacy.trueClues);
+  const allMainCampaigns=mainCampaignIds.every(id=>completedCampaigns.has(id));
+  const allTrueClues=trueClueIds.every(id=>clues.has(id));
+  if(allMainCampaigns&&allTrueClues)selected.add('fifth_path_candidate');
+
+  return ngPlusUnlockIds.filter(id=>selected.has(id));
+}
+
+function promoteLegacyEchoes(legacy:LegacyState):LegacyState{
+  const relationshipEchoes:Record<string,string[]>={};
+  for(const [characterId,memories] of Object.entries(legacy.relationshipEchoes)){
+    relationshipEchoes[characterId]=Array.isArray(memories)?[...memories]:[];
+  }
+
+  const legacyWorldFacts=[...legacy.legacyWorldFacts];
+  const trueClues=[...legacy.trueClues];
+  for(const summary of legacy.runSummaries){
+    legacyWorldFacts.push(...summary.majorWorldOutcomes);
+    trueClues.push(...summary.trueClues);
+    for(const memory of summary.keyBondMemories){
+      const current=relationshipEchoes[memory.characterId]??[];
+      relationshipEchoes[memory.characterId]=[...current,memory.memoryId];
+    }
+  }
+
+  const promoted=hydrateLegacyState({
+    ...legacy,
+    legacyWorldFacts,
+    relationshipEchoes,
+    trueClues,
+  });
+  const ngPlusUnlocks=[...promoted.ngPlusUnlocks,...selectNgPlusUnlocks(promoted)];
+  return hydrateLegacyState({...promoted,ngPlusUnlocks});
+}
+
+export function prepareNewPossibilityV3State(current:V3PersistentState):
+  | {started:false;state:V3PersistentState;reason:'not_ready'}
+  | {started:true;state:V3PersistentState;sourceRunNumber:number;nextRunNumber:number}{
+  const handoff=selectCompletedRunHandoff(current);
+  if(!handoff)return {started:false,state:current,reason:'not_ready'};
+
+  const legacy=promoteLegacyEchoes(current.legacy);
+  const nextRunNumber=handoff.runNumber+1;
+  const campaignRun={...emptyCampaignRunState(),runNumber:nextRunNumber};
+  const state:V3PersistentState={
+    campaignRun,
+    worldHistory:{currentFacts:[],inheritedFacts:[...legacy.legacyWorldFacts]},
+    characterBonds:emptyCharacterBondsState(),
+    legacy,
+  };
+  return {
+    started:true,
+    state,
+    sourceRunNumber:handoff.runNumber,
+    nextRunNumber,
+  };
+}


### PR DESCRIPTION
Parent: #143

NG+ Macro B 03 candidate.

Implemented:
- start `new possibility` only from a committed completed Winter run
- increment CampaignRun `runNumber` exactly once without re-archiving Winter history
- reset current V3 Campaign/Bond/World/Season-run state to clean Spring semantics
- promote compact run-summary World/Bond/True-clue evidence into Legacy echoes idempotently
- keep current World facts empty and inherited facts structurally separate
- semantic NG+ unlock selector: `past_life_dialogue`, `relationship_reunion`, `world_echo`, optional `fifth_path_candidate`
- recompute semantic unlocks from canonical Legacy evidence on each transition, dropping valid-but-ineligible stale unlocks
- fifth-path eligibility hook only; no Fifth Path campaign content
- repeated 4-cycle pure V3 replay remains compact and stable

Initial TDD RED on `db17476268c4f229d24fb5ca3f9cc6c53686a933` / CI #1656:
- existing 389/389 test files remained GREEN
- existing 1523/1523 tests remained GREEN
- only new `src/ngplus-replay.test.ts` failed because `./ngplus-replay` did not exist

Semantic hardening RED on `9d0a2455966449e0fa84c858a4245e1e8a8572c4` / CI #1661:
- existing 390/390 files and 1528/1528 tests remained GREEN
- only new stale-unlock contract failed because persisted `fifth_path_candidate` survived without four-campaign/four-clue eligibility

Final candidate verification on `43ddd6acb54175a4a7d98dd36515673043805e53` / CI #1664:
- 391/391 test files GREEN
- 1529/1529 tests GREEN
- `src/ngplus-replay.test.ts`: 5/5 GREEN
- `src/ngplus-replay-stale-unlock.test.ts`: 1/1 GREEN
- `npm run build` GREEN (`tsc -b && vite build`)

Shared authoritative `NEW_RUN` action, whole GameState/core economy reset, Tactical reset and save/action wiring remain 06/04 responsibilities and will be composed on `verify/v3-ngplus-replay-systems`.

Keep Draft; do not merge integration/v3.