### PR TITLE
[Macro B] V3 NG+ Replay Systems verification

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -12,6 +12,8 @@ import {
 } from './tactical-encounters';
 import type { BattleResult } from './tactical-battle';
 import { grantBattleBond, type CompanionBondState, type CompanionId } from './tactical-companions';
+import { prepareNewPossibilityV3State } from './ngplus-replay';
+import { resetTacticalForNgPlus } from './tactical-ngplus-reset';
 import { hydrateTacticalPersistentState } from './tactical-state';
 import {
   emptyV3PersistentState,
@@ -156,7 +158,22 @@ export function hydrateGameState(raw:unknown):GameState {
 
 export function reducer(state:GameState,action:Action):GameState {
   if (action.type === 'RESET') return initialState;
-  if (action.type === 'NEW_RUN' || action.type === 'EVENT_CHOICE') return state;
+  if (action.type === 'NEW_RUN') {
+    const transition = prepareNewPossibilityV3State(pickV3PersistentState(state));
+    if (!transition.started) return state;
+    const tactical = resetTacticalForNgPlus(state);
+    return {
+      ...initialState,
+      ...transition.state,
+      tacticalBattleRecords:{...tactical.tacticalBattleRecords},
+      claimedTacticalFirstClears:[...tactical.claimedTacticalFirstClears],
+      selectedTacticalCompanions:[...tactical.selectedTacticalCompanions],
+      tacticalCompanionBonds:{...tactical.tacticalCompanionBonds},
+      tacticalAutoBattle:tactical.tacticalAutoBattle,
+      tacticalBattleSpeed:tactical.tacticalBattleSpeed,
+    } as GameState;
+  }
+  if (action.type === 'EVENT_CHOICE') return state;
 
   if (action.type === 'SET_TACTICAL_PARTY') {
     const companions = validParty(action.companions);

--- a/src/ngplus-replay-stale-unlock.test.ts
+++ b/src/ngplus-replay-stale-unlock.test.ts
@@ -1,0 +1,47 @@
+import {describe,expect,it} from 'vitest';
+import {commitLongNightOutcome,commitWinterEnding,resolveLongNightOutcome,resolveModularEnding} from './campaign-winter-season';
+import {prepareNewPossibilityV3State} from './ngplus-replay';
+import {emptyV3PersistentState} from './v3-persistent-state';
+
+describe('V3 NG+ semantic unlock sanitation',()=>{
+  it('drops a persisted fifth_path_candidate when four-campaign clue eligibility is not satisfied',()=>{
+    const initial=emptyV3PersistentState();
+    const outcome=resolveLongNightOutcome({campaign:'caretaker',outcome:'victory'});
+    expect(outcome.accepted).toBe(true);
+    if(!outcome.accepted)return;
+    const longNight=commitLongNightOutcome({
+      ...initial.campaignRun,
+      phase:'winter',
+      activeCampaign:'caretaker',
+      seasonMilestones:['autumn_resolved'],
+    },outcome);
+    expect(longNight.committed).toBe(true);
+    if(!longNight.committed)return;
+
+    const ending=resolveModularEnding({
+      campaignResolution:'shared_guardianship',
+      bondResolution:'mira_shared_future',
+      worldResolution:'survived_together',
+      careerResolution:'guardian_mentor',
+    });
+    expect(ending.accepted).toBe(true);
+    if(!ending.accepted)return;
+
+    const committed=commitWinterEnding({...initial,campaignRun:longNight.state},ending.ending,{
+      majorWorldOutcomes:['festival_saved'],
+      keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],
+      trueClues:['caretaker_life_anomaly'],
+    });
+    expect(committed.committed).toBe(true);
+    if(!committed.committed)return;
+
+    const stale={
+      ...committed.state,
+      legacy:{...committed.state.legacy,ngPlusUnlocks:['fifth_path_candidate' as const]},
+    };
+    const started=prepareNewPossibilityV3State(stale);
+    expect(started.started).toBe(true);
+    if(!started.started)return;
+    expect(started.state.legacy.ngPlusUnlocks).toEqual(['past_life_dialogue','relationship_reunion','world_echo']);
+  });
+});

--- a/src/ngplus-replay.test.ts
+++ b/src/ngplus-replay.test.ts
@@ -1,0 +1,192 @@
+import {describe,expect,it} from 'vitest';
+import {emptyCharacterBondsState} from './character-bonds';
+import {emptyV3PersistentState,hydrateV3PersistentState,type V3PersistentState} from './v3-persistent-state';
+import {
+  commitLongNightOutcome,
+  commitWinterEnding,
+  resolveLongNightOutcome,
+  resolveModularEnding,
+} from './campaign-winter-season';
+import {
+  prepareNewPossibilityV3State,
+  selectNgPlusUnlocks,
+} from './ngplus-replay';
+import type {CharacterId,MainCampaignId} from './campaign-model';
+import type {TrueClueId} from './legacy-state';
+import type {WorldFactId} from './world-history';
+
+const campaignEndingDimension:Record<MainCampaignId,string>={
+  caretaker:'shared_guardianship',
+  pathfinder:'open_horizon',
+  vanguard:'coalition_command',
+  arcanist:'restrained_resonance',
+};
+const campaignCharacter:Record<MainCampaignId,CharacterId>={
+  caretaker:'mira',pathfinder:'kael',vanguard:'rex',arcanist:'selene',
+};
+const campaignMemory:Record<MainCampaignId,string>={
+  caretaker:'mira_winter_victory',
+  pathfinder:'kael_winter_victory',
+  vanguard:'rex_winter_victory',
+  arcanist:'selene_winter_victory',
+};
+const campaignWorldFact:Record<MainCampaignId,WorldFactId>={
+  caretaker:'festival_saved',
+  pathfinder:'ancient_route_opened',
+  vanguard:'regional_alliance',
+  arcanist:'rift_stabilized',
+};
+const campaignTrueClue:Record<MainCampaignId,TrueClueId>={
+  caretaker:'caretaker_life_anomaly',
+  pathfinder:'pathfinder_world_route',
+  vanguard:'vanguard_hidden_conflict_record',
+  arcanist:'arcanist_rift_cycle',
+};
+
+function completeRun(start:V3PersistentState,campaign:MainCampaignId):V3PersistentState{
+  const outcome=resolveLongNightOutcome({campaign,outcome:'victory'});
+  expect(outcome.accepted).toBe(true);
+  if(!outcome.accepted)throw new Error('expected Long Night outcome');
+  const longNight=commitLongNightOutcome({
+    ...start.campaignRun,
+    phase:'winter',
+    activeCampaign:campaign,
+    seasonMilestones:['autumn_resolved'],
+  },outcome);
+  expect(longNight.committed).toBe(true);
+  if(!longNight.committed)throw new Error('expected Long Night commit');
+
+  const ending=resolveModularEnding({
+    campaignResolution:campaignEndingDimension[campaign],
+    bondResolution:`${campaignCharacter[campaign]}_shared_future`,
+    worldResolution:'survived_together',
+    careerResolution:'guardian_mentor',
+  });
+  expect(ending.accepted).toBe(true);
+  if(!ending.accepted)throw new Error('expected modular ending');
+
+  const committed=commitWinterEnding({...start,campaignRun:longNight.state},ending.ending,{
+    majorWorldOutcomes:[campaignWorldFact[campaign]],
+    keyBondMemories:[{characterId:campaignCharacter[campaign],memoryId:campaignMemory[campaign]}],
+    trueClues:[campaignTrueClue[campaign]],
+  });
+  expect(committed.committed).toBe(true);
+  if(!committed.committed)throw new Error('expected Winter ending commit');
+  return committed.state;
+}
+
+describe('V3 NG+ replay systems',()=>{
+  it('starts a new possibility only from a committed completed Winter run',()=>{
+    const empty=emptyV3PersistentState();
+    expect(prepareNewPossibilityV3State(empty)).toEqual({started:false,state:empty,reason:'not_ready'});
+
+    const completed=completeRun(empty,'caretaker');
+    const started=prepareNewPossibilityV3State(completed);
+    expect(started.started).toBe(true);
+    if(!started.started)return;
+    expect(started.sourceRunNumber).toBe(1);
+    expect(started.nextRunNumber).toBe(2);
+  });
+
+  it('resets current-run Campaign, Bond and World state while promoting compact Legacy echoes',()=>{
+    const completed=completeRun(emptyV3PersistentState(),'caretaker');
+    const started=prepareNewPossibilityV3State(completed);
+    expect(started.started).toBe(true);
+    if(!started.started)return;
+
+    expect(started.state.campaignRun).toMatchObject({
+      runNumber:2,
+      phase:'spring_exploration',
+      activeCampaign:null,
+      activeRoute:'normal',
+      campaignAffinities:{caretaker:0,pathfinder:0,vanguard:0,arcanist:0},
+      dangerState:{score:0,behaviors:[]},
+      seasonMilestones:[],
+      majorChoices:{},
+      majorOutcomes:{},
+      failForwardOutcomes:[],
+      claimedCampaignRewards:[],
+      claimedSeasonalObjectives:[],
+    });
+    expect(started.state.characterBonds).toEqual(emptyCharacterBondsState());
+    expect(started.state.worldHistory.currentFacts).toEqual([]);
+    expect(started.state.worldHistory.inheritedFacts).toEqual(['festival_saved']);
+
+    expect(started.state.legacy.completedRuns).toBe(1);
+    expect(started.state.legacy.runSummaries).toHaveLength(1);
+    expect(started.state.legacy.legacyWorldFacts).toEqual(['festival_saved']);
+    expect(started.state.legacy.relationshipEchoes).toEqual({mira:['mira_winter_victory']});
+    expect(started.state.legacy.trueClues).toEqual(['caretaker_life_anomaly']);
+    expect(started.state.legacy.ngPlusUnlocks).toEqual(['past_life_dialogue','relationship_reunion','world_echo']);
+  });
+
+  it('does not duplicate the completed run archive or increment twice on re-entry/reload',()=>{
+    const completed=completeRun(emptyV3PersistentState(),'caretaker');
+    const first=prepareNewPossibilityV3State(completed);
+    expect(first.started).toBe(true);
+    if(!first.started)return;
+
+    const loaded=hydrateV3PersistentState(JSON.parse(JSON.stringify(first.state)));
+    expect(loaded).toEqual(first.state);
+    expect(loaded.legacy.runSummaries).toHaveLength(1);
+    expect(loaded.campaignRun.runNumber).toBe(2);
+
+    expect(prepareNewPossibilityV3State(loaded)).toEqual({started:false,state:loaded,reason:'not_ready'});
+    expect(loaded.legacy.runSummaries).toHaveLength(1);
+    expect(loaded.legacy.completedRuns).toBe(1);
+  });
+
+  it('keeps unlock selection semantic and withholds fifth_path_candidate until all four campaign clues exist',()=>{
+    expect(selectNgPlusUnlocks({
+      ...emptyV3PersistentState().legacy,
+      completedRuns:4,
+      completedCampaigns:['caretaker','pathfinder','vanguard','arcanist'],
+      trueClues:['caretaker_life_anomaly','pathfinder_world_route','vanguard_hidden_conflict_record'],
+      legacyWorldFacts:['regional_alliance'],
+      relationshipEchoes:{rex:['rex_winter_victory']},
+      runSummaries:[{
+        runNumber:1,campaign:'caretaker',route:'normal',ending:'v3:a:b:c:d',career:'guardian_mentor',
+        majorWorldOutcomes:['festival_saved'],keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],trueClues:['caretaker_life_anomaly'],
+      }],
+    })).toEqual(['past_life_dialogue','relationship_reunion','world_echo']);
+
+    expect(selectNgPlusUnlocks({
+      ...emptyV3PersistentState().legacy,
+      completedRuns:4,
+      completedCampaigns:['caretaker','pathfinder','vanguard','arcanist'],
+      trueClues:['caretaker_life_anomaly','pathfinder_world_route','vanguard_hidden_conflict_record','arcanist_rift_cycle'],
+      legacyWorldFacts:['regional_alliance'],
+      relationshipEchoes:{rex:['rex_winter_victory']},
+      runSummaries:[{
+        runNumber:1,campaign:'caretaker',route:'normal',ending:'v3:a:b:c:d',career:'guardian_mentor',
+        majorWorldOutcomes:['festival_saved'],keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],trueClues:['caretaker_life_anomaly'],
+      }],
+    })).toEqual(['past_life_dialogue','relationship_reunion','world_echo','fifth_path_candidate']);
+  });
+
+  it('remains compact and stable through four completed-run/new-possibility cycles',()=>{
+    const campaigns:MainCampaignId[]=['caretaker','pathfinder','vanguard','arcanist'];
+    let state=emptyV3PersistentState();
+
+    for(let index=0;index<campaigns.length;index+=1){
+      const completed=completeRun(state,campaigns[index]);
+      const started=prepareNewPossibilityV3State(completed);
+      expect(started.started).toBe(true);
+      if(!started.started)throw new Error('expected NG+ start');
+      state=hydrateV3PersistentState(JSON.parse(JSON.stringify(started.state)));
+      expect(state.campaignRun.runNumber).toBe(index+2);
+      expect(state.legacy.completedRuns).toBe(index+1);
+      expect(state.legacy.runSummaries.map(item=>item.runNumber)).toEqual(Array.from({length:index+1},(_,i)=>i+1));
+      expect(state.campaignRun.claimedSeasonalObjectives).toEqual([]);
+      expect(state.campaignRun.majorOutcomes).toEqual({});
+      expect(state.worldHistory.currentFacts).toEqual([]);
+      expect(state.characterBonds).toEqual(emptyCharacterBondsState());
+    }
+
+    expect(state.legacy.completedCampaigns).toEqual(['caretaker','pathfinder','vanguard','arcanist']);
+    expect(state.legacy.legacyWorldFacts).toEqual(['festival_saved','ancient_route_opened','regional_alliance','rift_stabilized']);
+    expect(state.legacy.trueClues).toEqual(['caretaker_life_anomaly','pathfinder_world_route','vanguard_hidden_conflict_record','arcanist_rift_cycle']);
+    expect(state.legacy.ngPlusUnlocks).toEqual(['past_life_dialogue','relationship_reunion','world_echo','fifth_path_candidate']);
+    expect(state.campaignRun.runNumber).toBe(5);
+  });
+});

--- a/src/ngplus-replay.ts
+++ b/src/ngplus-replay.ts
@@ -52,8 +52,10 @@ function promoteLegacyEchoes(legacy:LegacyState):LegacyState{
     relationshipEchoes,
     trueClues,
   });
-  const ngPlusUnlocks=[...promoted.ngPlusUnlocks,...selectNgPlusUnlocks(promoted)];
-  return hydrateLegacyState({...promoted,ngPlusUnlocks});
+  return hydrateLegacyState({
+    ...promoted,
+    ngPlusUnlocks:selectNgPlusUnlocks(promoted),
+  });
 }
 
 export function prepareNewPossibilityV3State(current:V3PersistentState):

--- a/src/ngplus-replay.ts
+++ b/src/ngplus-replay.ts
@@ -1,0 +1,80 @@
+import {emptyCampaignRunState} from './campaign-state';
+import {emptyCharacterBondsState} from './character-bonds';
+import {mainCampaignIds} from './campaign-model';
+import {selectCompletedRunHandoff} from './campaign-winter-season';
+import {
+  hydrateLegacyState,
+  ngPlusUnlockIds,
+  trueClueIds,
+  type LegacyState,
+  type NgPlusUnlockId,
+} from './legacy-state';
+import type {V3PersistentState} from './v3-persistent-state';
+
+export function selectNgPlusUnlocks(legacy:LegacyState):NgPlusUnlockId[]{
+  const selected=new Set<NgPlusUnlockId>();
+
+  if(legacy.runSummaries.length>0)selected.add('past_life_dialogue');
+  if(Object.values(legacy.relationshipEchoes).some(memories=>Array.isArray(memories)&&memories.length>0)){
+    selected.add('relationship_reunion');
+  }
+  if(legacy.legacyWorldFacts.length>0)selected.add('world_echo');
+
+  const completedCampaigns=new Set(legacy.completedCampaigns);
+  const clues=new Set(legacy.trueClues);
+  const allMainCampaigns=mainCampaignIds.every(id=>completedCampaigns.has(id));
+  const allTrueClues=trueClueIds.every(id=>clues.has(id));
+  if(allMainCampaigns&&allTrueClues)selected.add('fifth_path_candidate');
+
+  return ngPlusUnlockIds.filter(id=>selected.has(id));
+}
+
+function promoteLegacyEchoes(legacy:LegacyState):LegacyState{
+  const relationshipEchoes:Record<string,string[]>={};
+  for(const [characterId,memories] of Object.entries(legacy.relationshipEchoes)){
+    relationshipEchoes[characterId]=Array.isArray(memories)?[...memories]:[];
+  }
+
+  const legacyWorldFacts=[...legacy.legacyWorldFacts];
+  const trueClues=[...legacy.trueClues];
+  for(const summary of legacy.runSummaries){
+    legacyWorldFacts.push(...summary.majorWorldOutcomes);
+    trueClues.push(...summary.trueClues);
+    for(const memory of summary.keyBondMemories){
+      const current=relationshipEchoes[memory.characterId]??[];
+      relationshipEchoes[memory.characterId]=[...current,memory.memoryId];
+    }
+  }
+
+  const promoted=hydrateLegacyState({
+    ...legacy,
+    legacyWorldFacts,
+    relationshipEchoes,
+    trueClues,
+  });
+  const ngPlusUnlocks=[...promoted.ngPlusUnlocks,...selectNgPlusUnlocks(promoted)];
+  return hydrateLegacyState({...promoted,ngPlusUnlocks});
+}
+
+export function prepareNewPossibilityV3State(current:V3PersistentState):
+  | {started:false;state:V3PersistentState;reason:'not_ready'}
+  | {started:true;state:V3PersistentState;sourceRunNumber:number;nextRunNumber:number}{
+  const handoff=selectCompletedRunHandoff(current);
+  if(!handoff)return {started:false,state:current,reason:'not_ready'};
+
+  const legacy=promoteLegacyEchoes(current.legacy);
+  const nextRunNumber=handoff.runNumber+1;
+  const campaignRun={...emptyCampaignRunState(),runNumber:nextRunNumber};
+  const state:V3PersistentState={
+    campaignRun,
+    worldHistory:{currentFacts:[],inheritedFacts:[...legacy.legacyWorldFacts]},
+    characterBonds:emptyCharacterBondsState(),
+    legacy,
+  };
+  return {
+    started:true,
+    state,
+    sourceRunNumber:handoff.runNumber,
+    nextRunNumber,
+  };
+}

--- a/src/tactical-ngplus-reset.test.ts
+++ b/src/tactical-ngplus-reset.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { createTacticalExpeditionBattle } from './tactical-expedition';
+import { handoffTacticalTerminalResult } from './tactical-scenario';
+import {
+  createTacticalNgPlusRuntimeState,
+  resetTacticalForNgPlus,
+  type TacticalNgPlusResetState,
+} from './tactical-ngplus-reset';
+
+const dirtyState = (): TacticalNgPlusResetState => ({
+  tacticalBattleRecords: {
+    training_ground: { grade: 'S', bestRounds: 2, clearCount: 9 },
+  },
+  claimedTacticalFirstClears: ['training_ground'],
+  selectedTacticalCompanions: ['wolf', 'cat'],
+  tacticalCompanionBonds: {
+    bear: { xp: 120, level: 3 },
+    owl: { xp: 80, level: 2 },
+    wolf: { xp: 300, level: 4 },
+    cat: { xp: 220, level: 4 },
+  },
+  tacticalAutoBattle: true,
+  tacticalBattleSpeed: 2,
+});
+
+const progression = { maxHp: 140, agility: 18, power: 28, magic: 24 };
+
+describe('V3 NG+ Tactical reset/re-entry integrity', () => {
+  it('resets run-owned Tactical progression while preserving non-power battle preferences', () => {
+    const next = resetTacticalForNgPlus(dirtyState());
+
+    expect(next.tacticalBattleRecords).toEqual({});
+    expect(next.claimedTacticalFirstClears).toEqual([]);
+    expect(next.selectedTacticalCompanions).toEqual([]);
+    expect(next.tacticalCompanionBonds).toEqual({
+      bear: { xp: 0, level: 1 },
+      owl: { xp: 0, level: 1 },
+      wolf: { xp: 0, level: 1 },
+      cat: { xp: 0, level: 1 },
+    });
+    expect(next.tacticalAutoBattle).toBe(true);
+    expect(next.tacticalBattleSpeed).toBe(2);
+  });
+
+  it('is idempotent across at least three NG+ cycles and never accumulates Tactical power', () => {
+    const first = resetTacticalForNgPlus(dirtyState());
+    const second = resetTacticalForNgPlus(first);
+    const third = resetTacticalForNgPlus(second);
+
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+    expect(Object.values(third.tacticalCompanionBonds).every(bond => bond.xp === 0 && bond.level === 1)).toBe(true);
+  });
+
+  it('creates an empty once-only terminal handoff scope for every new run', () => {
+    const oldRuntime = createTacticalNgPlusRuntimeState();
+    const terminal = {
+      scenarioId: 'ngplus-reset-check',
+      campaign: 'caretaker' as const,
+      attemptKey: 'run-1',
+      terminalKey: 'ngplus-reset-check:run-1',
+      objectiveResult: 'success' as const,
+      battleResult: 'victory' as const,
+      failForward: true,
+      rounds: 3,
+      survivingAllies: 2,
+      damageTaken: 40,
+    };
+    const consumed = handoffTacticalTerminalResult(oldRuntime.terminalHandoff, terminal);
+    expect(consumed.result).not.toBeNull();
+    expect(consumed.state.handedOffKeys).toHaveLength(1);
+
+    const newRuntime = createTacticalNgPlusRuntimeState();
+    expect(newRuntime.terminalHandoff.handedOffKeys).toEqual([]);
+    expect(newRuntime).not.toBe(oldRuntime);
+  });
+
+  it('creates a fresh 3v3 BattleSession after a prior run is heavily mutated', () => {
+    const prior = createTacticalExpeditionBattle('forest_path', ['bear', 'owl'], progression, 501);
+    for (const unit of prior.units) {
+      unit.hp = 0;
+      unit.ap = 0;
+      unit.mp = 10;
+      unit.shield = 9999;
+      unit.statuses = [{ id: 'break', turns: 99 }];
+    }
+    prior.round = 999;
+    prior.timeline = [];
+    prior.acted = prior.units.map(unit => unit.id);
+
+    const fresh = createTacticalExpeditionBattle('forest_path', ['bear', 'owl'], progression, 502);
+    expect(fresh).not.toBe(prior);
+    expect(fresh.round).toBe(1);
+    expect(fresh.acted).toEqual([]);
+    expect(fresh.units.filter(unit => unit.side === 'ally')).toHaveLength(3);
+    expect(fresh.units.filter(unit => unit.side === 'enemy')).toHaveLength(3);
+    expect(fresh.units.every(unit => unit.hp > 0 && unit.hp <= unit.maxHp)).toBe(true);
+    expect(fresh.units.every(unit => unit.ap >= 0 && unit.ap <= unit.maxAp)).toBe(true);
+    expect(fresh.units.every(unit => unit.mp >= 0 && unit.mp <= unit.maxMp)).toBe(true);
+    expect(fresh.units.every(unit => unit.shield < 9999)).toBe(true);
+    expect(fresh.units.every(unit => !unit.statuses?.some(status => status.turns === 99))).toBe(true);
+  });
+});

--- a/src/tactical-ngplus-reset.ts
+++ b/src/tactical-ngplus-reset.ts
@@ -1,0 +1,33 @@
+import type { CompanionBondState, CompanionId } from './tactical-companions';
+import type { TacticalBattleRecord, TacticalEncounterId } from './tactical-encounters';
+import { createTacticalTerminalHandoffState, type TacticalTerminalHandoffState } from './tactical-scenario';
+import { emptyTacticalPersistentState } from './tactical-state';
+
+export type TacticalNgPlusResetState = Readonly<{
+  tacticalBattleRecords: Partial<Record<TacticalEncounterId, TacticalBattleRecord>>;
+  claimedTacticalFirstClears: readonly TacticalEncounterId[];
+  selectedTacticalCompanions: readonly CompanionId[];
+  tacticalCompanionBonds: Readonly<Record<CompanionId, CompanionBondState>>;
+  tacticalAutoBattle: boolean;
+  tacticalBattleSpeed: 1 | 2;
+}>;
+
+export type TacticalNgPlusRuntimeState = Readonly<{
+  terminalHandoff: TacticalTerminalHandoffState;
+}>;
+
+export function resetTacticalForNgPlus(state: TacticalNgPlusResetState): TacticalNgPlusResetState {
+  const defaults = emptyTacticalPersistentState();
+  return {
+    tacticalBattleRecords: {},
+    claimedTacticalFirstClears: [],
+    selectedTacticalCompanions: [],
+    tacticalCompanionBonds: defaults.companionBonds,
+    tacticalAutoBattle: state.tacticalAutoBattle === true,
+    tacticalBattleSpeed: state.tacticalBattleSpeed === 2 ? 2 : 1,
+  };
+}
+
+export function createTacticalNgPlusRuntimeState(): TacticalNgPlusRuntimeState {
+  return { terminalHandoff: createTacticalTerminalHandoffState() };
+}

--- a/src/v3-ngplus-replay-multicycle.test.ts
+++ b/src/v3-ngplus-replay-multicycle.test.ts
@@ -1,0 +1,78 @@
+import {describe,expect,it} from 'vitest';
+import {commitLongNightOutcome,commitWinterEnding,resolveLongNightOutcome,resolveModularEnding} from './campaign-winter-season';
+import {hydrateGameState,initialState,reducer,type GameState} from './game';
+
+function completeCaretakerWinter(state:GameState):GameState{
+  const longNight=resolveLongNightOutcome({campaign:'caretaker',outcome:'victory'});
+  expect(longNight.accepted).toBe(true);
+  if(!longNight.accepted)throw new Error('expected Long Night outcome');
+  const outcome=commitLongNightOutcome({
+    ...state.campaignRun,
+    phase:'winter',
+    activeCampaign:'caretaker',
+    seasonMilestones:['autumn_resolved'],
+  },longNight);
+  expect(outcome.committed).toBe(true);
+  if(!outcome.committed)throw new Error('expected Long Night commit');
+
+  const ending=resolveModularEnding({
+    campaignResolution:'shared_guardianship',
+    bondResolution:'mira_shared_future',
+    worldResolution:'survived_together',
+    careerResolution:'guardian_mentor',
+  });
+  expect(ending.accepted).toBe(true);
+  if(!ending.accepted)throw new Error('expected modular ending');
+
+  const committed=commitWinterEnding({...state,campaignRun:outcome.state},ending.ending,{
+    majorWorldOutcomes:['festival_saved'],
+    keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],
+    trueClues:['caretaker_life_anomaly'],
+  });
+  expect(committed.committed).toBe(true);
+  if(!committed.committed)throw new Error('expected Winter ending commit');
+  return committed.state as GameState;
+}
+
+describe('V3 NG+ Macro B repeated replay stability',()=>{
+  it('survives three complete ending -> NEW_RUN -> save/load cycles without archive duplication or raw-power inflation',()=>{
+    let state:GameState=initialState;
+
+    for(let cycle=1;cycle<=3;cycle+=1){
+      const completed=completeCaretakerWinter(state);
+      expect(completed.legacy.completedRuns).toBe(cycle);
+      expect(completed.legacy.runSummaries.map(item=>item.runNumber)).toEqual(
+        Array.from({length:cycle},(_,index)=>index+1),
+      );
+
+      const next=reducer(completed,{type:'NEW_RUN'});
+      expect(next.campaignRun.runNumber).toBe(cycle+1);
+      expect(next.campaignRun.phase).toBe('spring_exploration');
+      expect(next.campaignRun.activeCampaign).toBeNull();
+      expect(next.campaignRun.claimedSeasonalObjectives).toEqual([]);
+      expect(next.campaignRun.majorOutcomes).toEqual({});
+      expect(next.worldHistory.currentFacts).toEqual([]);
+      expect(next.gold).toBe(initialState.gold);
+      expect(next.gems).toBe(initialState.gems);
+      expect(next.stats).toEqual(initialState.stats);
+      expect(next.mastery).toEqual(initialState.mastery);
+      expect(next.tacticalBattleRecords).toEqual({});
+      expect(next.claimedTacticalFirstClears).toEqual([]);
+      expect(next.selectedTacticalCompanions).toEqual([]);
+      expect(next.tacticalCompanionBonds).toEqual(initialState.tacticalCompanionBonds);
+      expect(next.legacy.completedRuns).toBe(cycle);
+      expect(next.legacy.runSummaries).toHaveLength(cycle);
+
+      state=hydrateGameState(JSON.parse(JSON.stringify(next)));
+      expect(state).toEqual(next);
+      expect(reducer(state,{type:'NEW_RUN'})).toEqual(state);
+    }
+
+    expect(state.campaignRun.runNumber).toBe(4);
+    expect(state.legacy.completedRuns).toBe(3);
+    expect(state.legacy.runSummaries.map(item=>item.runNumber)).toEqual([1,2,3]);
+    expect(state.legacy.legacyWorldFacts).toEqual(['festival_saved']);
+    expect(state.legacy.relationshipEchoes).toEqual({mira:['mira_winter_victory']});
+    expect(state.legacy.trueClues).toEqual(['caretaker_life_anomaly']);
+  });
+});

--- a/src/v3-ngplus-replay-systems-lane.test.ts
+++ b/src/v3-ngplus-replay-systems-lane.test.ts
@@ -65,7 +65,7 @@ describe('V3 NG+ Macro B authoritative replay transition',()=>{
     expect(replayed.legacy.runSummaries).toHaveLength(1);
   });
 
-  it('resets raw growth, normal currencies and current Season/weekly state for clean Spring replay',()=>{
+  it('resets raw growth, currencies, Season/weekly and Tactical run state for clean Spring replay',()=>{
     const completed=completedWinterGameState();
     const dirty:GameState={
       ...completed,
@@ -79,6 +79,14 @@ describe('V3 NG+ Macro B authoritative replay transition',()=>{
       seasonJourneyScores:{'1-spring':999},
       claimedSeasonJourneyTiers:['1-spring:1'],
       seasonTokenBalances:{'1-spring':999},
+      tacticalBattleRecords:{training_ground:{grade:'S',bestRounds:2,clearCount:9}},
+      claimedTacticalFirstClears:['training_ground'],
+      selectedTacticalCompanions:['wolf','cat'],
+      tacticalCompanionBonds:{
+        bear:{xp:120,level:3},owl:{xp:80,level:2},wolf:{xp:300,level:4},cat:{xp:220,level:4},
+      },
+      tacticalAutoBattle:true,
+      tacticalBattleSpeed:2,
     };
     const next=reducer(dirty,{type:'NEW_RUN'});
 
@@ -92,6 +100,12 @@ describe('V3 NG+ Macro B authoritative replay transition',()=>{
     expect(next.seasonJourneyScores).toEqual({});
     expect(next.claimedSeasonJourneyTiers).toEqual([]);
     expect(next.seasonTokenBalances).toEqual({});
+    expect(next.tacticalBattleRecords).toEqual({});
+    expect(next.claimedTacticalFirstClears).toEqual([]);
+    expect(next.selectedTacticalCompanions).toEqual([]);
+    expect(next.tacticalCompanionBonds).toEqual(initialState.tacticalCompanionBonds);
+    expect(next.tacticalAutoBattle).toBe(true);
+    expect(next.tacticalBattleSpeed).toBe(2);
   });
 
   it('stays save/load/reload idempotent after the authoritative start',()=>{

--- a/src/v3-ngplus-replay-systems-lane.test.ts
+++ b/src/v3-ngplus-replay-systems-lane.test.ts
@@ -1,0 +1,109 @@
+import {describe,expect,it} from 'vitest';
+import {commitLongNightOutcome,commitWinterEnding,resolveLongNightOutcome,resolveModularEnding} from './campaign-winter-season';
+import {hydrateGameState,initialState,reducer,type GameState} from './game';
+
+function completedWinterGameState():GameState{
+  const longNight=resolveLongNightOutcome({campaign:'caretaker',outcome:'victory'});
+  expect(longNight.accepted).toBe(true);
+  if(!longNight.accepted)throw new Error('expected Long Night outcome');
+  const outcome=commitLongNightOutcome({
+    ...initialState.campaignRun,
+    phase:'winter',
+    activeCampaign:'caretaker',
+    seasonMilestones:['autumn_resolved'],
+  },longNight);
+  expect(outcome.committed).toBe(true);
+  if(!outcome.committed)throw new Error('expected Long Night commit');
+
+  const ending=resolveModularEnding({
+    campaignResolution:'shared_guardianship',
+    bondResolution:'mira_shared_future',
+    worldResolution:'survived_together',
+    careerResolution:'guardian_mentor',
+  });
+  expect(ending.accepted).toBe(true);
+  if(!ending.accepted)throw new Error('expected modular ending');
+
+  const committed=commitWinterEnding({...initialState,campaignRun:outcome.state},ending.ending,{
+    majorWorldOutcomes:['festival_saved'],
+    keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],
+    trueClues:['caretaker_life_anomaly'],
+  });
+  expect(committed.committed).toBe(true);
+  if(!committed.committed)throw new Error('expected Winter ending commit');
+  return committed.state as GameState;
+}
+
+describe('V3 NG+ Macro B authoritative replay transition',()=>{
+  it('makes NEW_RUN consume the committed ending exactly once without re-archiving it',()=>{
+    const completed=completedWinterGameState();
+    const next=reducer(completed,{type:'NEW_RUN'});
+
+    expect(next.campaignRun).toMatchObject({
+      runNumber:2,
+      phase:'spring_exploration',
+      activeCampaign:null,
+      activeRoute:'normal',
+      seasonMilestones:[],
+      majorChoices:{},
+      majorOutcomes:{},
+      failForwardOutcomes:[],
+      claimedCampaignRewards:[],
+      claimedSeasonalObjectives:[],
+    });
+    expect(next.legacy.completedRuns).toBe(1);
+    expect(next.legacy.runSummaries).toHaveLength(1);
+    expect(next.worldHistory.currentFacts).toEqual([]);
+    expect(next.worldHistory.inheritedFacts).toEqual(['festival_saved']);
+    expect(next.legacy.relationshipEchoes).toEqual({mira:['mira_winter_victory']});
+    expect(next.legacy.trueClues).toEqual(['caretaker_life_anomaly']);
+
+    const replayed=reducer(next,{type:'NEW_RUN'});
+    expect(replayed).toEqual(next);
+    expect(replayed.campaignRun.runNumber).toBe(2);
+    expect(replayed.legacy.completedRuns).toBe(1);
+    expect(replayed.legacy.runSummaries).toHaveLength(1);
+  });
+
+  it('resets raw growth, normal currencies and current Season/weekly state for clean Spring replay',()=>{
+    const completed=completedWinterGameState();
+    const dirty:GameState={
+      ...completed,
+      gold:999999,
+      gems:99999,
+      stats:{...completed.stats,strength:100,intelligence:100,magic:100},
+      mastery:{hunt:{xp:999},magic:{xp:999},rest:{xp:999},herb:{xp:999}},
+      weeklyDirectiveKey:'1-4-2',
+      weeklyDirectiveProgress:{steady_training:99,field_patrol:99},
+      rewardedWeeklyDirectives:['1-4-2:steady_training'],
+      seasonJourneyScores:{'1-spring':999},
+      claimedSeasonJourneyTiers:['1-spring:1'],
+      seasonTokenBalances:{'1-spring':999},
+    };
+    const next=reducer(dirty,{type:'NEW_RUN'});
+
+    expect(next.gold).toBe(initialState.gold);
+    expect(next.gems).toBe(initialState.gems);
+    expect(next.stats).toEqual(initialState.stats);
+    expect(next.mastery).toEqual(initialState.mastery);
+    expect(next.weeklyDirectiveKey).toBeNull();
+    expect(next.weeklyDirectiveProgress).toEqual({});
+    expect(next.rewardedWeeklyDirectives).toEqual([]);
+    expect(next.seasonJourneyScores).toEqual({});
+    expect(next.claimedSeasonJourneyTiers).toEqual([]);
+    expect(next.seasonTokenBalances).toEqual({});
+  });
+
+  it('stays save/load/reload idempotent after the authoritative start',()=>{
+    const completed=completedWinterGameState();
+    const next=reducer(completed,{type:'NEW_RUN'});
+    const loaded=hydrateGameState(JSON.parse(JSON.stringify(next)));
+    const reloaded=hydrateGameState(JSON.parse(JSON.stringify(loaded)));
+
+    expect(reloaded).toEqual(loaded);
+    expect(reloaded.campaignRun.runNumber).toBe(2);
+    expect(reloaded.legacy.completedRuns).toBe(1);
+    expect(reloaded.legacy.runSummaries).toHaveLength(1);
+    expect(reducer(reloaded,{type:'NEW_RUN'})).toEqual(reloaded);
+  });
+});


### PR DESCRIPTION
Parent: #143

Macro B verification-only branch led by 03.

## Current composition
- 03 NG+ replay runtime candidate already composed
- 04 Tactical exact GREEN candidate PR #150 / `work/v3-ngplus-tactical@0268fd3897c3532580f2c771b4aa4a6958c81d78` now composed
- 06 shared `NEW_RUN` candidate: **not yet available** (`work/v3-ngplus-shared-state` is currently identical to `integration/v3@ff6a8fe55b1b2df5d8cf1434bb9b607af4bda264`)

04 files composed:
- `src/tactical-ngplus-reset.ts`
- `src/tactical-ngplus-reset.test.ts`

Macro B lane test now explicitly requires authoritative `NEW_RUN` to reset Tactical records / first-clear / party / companion battle bonds while preserving AUTO/speed preferences.

## Current integration RED
Verify head: `ecea2d9e9a09f49372e0ec73ad4e959ea50f565b`
CI #1670 / run `32561401208`: expected FAILURE while 06 shared wiring is absent.

Evidence:
- `src/tactical-ngplus-reset.test.ts`: **4/4 GREEN**
- Tactical stability: **13/13 GREEN**
- AUTO **10/50/100 GREEN**
- Expedition stress remains GREEN
- all non-lane coverage: **392 test files / 1533 tests GREEN**
- only `src/v3-ngplus-replay-systems-lane.test.ts` fails: **3/3**, because `NEW_RUN` itself currently no-ops at the shared GameState layer:
  1. runNumber remains 1 / phase remains `ending` / activeCampaign remains `caretaker`
  2. core gold remains dirty (`999999` instead of reset baseline)
  3. save/load path therefore also remains runNumber 1

This is broader than Tactical and confirms the exact 06 blocker. Current `src/game.ts` wrapper preserves Tactical fields across Base reducer results and has no special NG+ transition yet.

## Required 06 synthesis
Compose an authorized 06 shared candidate that:
- wires authoritative `{type:'NEW_RUN'}` through 03 replay transition
- resets normal/core + Season run state
- consumes 04 `resetTacticalForNgPlus()` for Tactical run-owned fields
- preserves Tactical AUTO/speed preferences
- leaves Legacy/current-vs-inherited echoes authoritative from 03 semantics
- preserves exactly-once archive/runNumber and save/load idempotence

Then rerun this same Macro B lane suite without weakening assertions.

Planned final gate remains:
completed committed Winter ending -> authoritative `NEW_RUN` -> exactly-once runNumber -> no duplicate archive -> core/Season/Tactical run state reset -> Legacy/current-vs-inherited echoes preserved -> save/load/reload -> repeated >=3 cycles without raw-power inflation or history duplication.

Fifth Path eligibility hook only; no Fifth Path content. Keep Draft / verification-only. Do not merge integration/v3.