### PR TITLE
feat(v3): add NG+ Tactical reset contract

### DIFF
--- a/src/tactical-ngplus-reset.test.ts
+++ b/src/tactical-ngplus-reset.test.ts
@@ -4,14 +4,15 @@ import { handoffTacticalTerminalResult } from './tactical-scenario';
 import {
   createTacticalNgPlusRuntimeState,
   resetTacticalForNgPlus,
+  type TacticalNgPlusResetState,
 } from './tactical-ngplus-reset';
 
-const dirtyState = () => ({
+const dirtyState = (): TacticalNgPlusResetState => ({
   tacticalBattleRecords: {
-    training_ground: { grade: 'S' as const, bestRounds: 2, clearCount: 9 },
+    training_ground: { grade: 'S', bestRounds: 2, clearCount: 9 },
   },
-  claimedTacticalFirstClears: ['training_ground' as const],
-  selectedTacticalCompanions: ['wolf', 'cat'] as const,
+  claimedTacticalFirstClears: ['training_ground'],
+  selectedTacticalCompanions: ['wolf', 'cat'],
   tacticalCompanionBonds: {
     bear: { xp: 120, level: 3 },
     owl: { xp: 80, level: 2 },
@@ -19,7 +20,7 @@ const dirtyState = () => ({
     cat: { xp: 220, level: 4 },
   },
   tacticalAutoBattle: true,
-  tacticalBattleSpeed: 2 as const,
+  tacticalBattleSpeed: 2,
 });
 
 const progression = { maxHp: 140, agility: 18, power: 28, magic: 24 };

--- a/src/tactical-ngplus-reset.test.ts
+++ b/src/tactical-ngplus-reset.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { createTacticalExpeditionBattle } from './tactical-expedition';
+import { handoffTacticalTerminalResult } from './tactical-scenario';
+import {
+  createTacticalNgPlusRuntimeState,
+  resetTacticalForNgPlus,
+} from './tactical-ngplus-reset';
+
+const dirtyState = () => ({
+  tacticalBattleRecords: {
+    training_ground: { grade: 'S' as const, bestRounds: 2, clearCount: 9 },
+  },
+  claimedTacticalFirstClears: ['training_ground' as const],
+  selectedTacticalCompanions: ['wolf', 'cat'] as const,
+  tacticalCompanionBonds: {
+    bear: { xp: 120, level: 3 },
+    owl: { xp: 80, level: 2 },
+    wolf: { xp: 300, level: 4 },
+    cat: { xp: 220, level: 4 },
+  },
+  tacticalAutoBattle: true,
+  tacticalBattleSpeed: 2 as const,
+});
+
+const progression = { maxHp: 140, agility: 18, power: 28, magic: 24 };
+
+describe('V3 NG+ Tactical reset/re-entry integrity', () => {
+  it('resets run-owned Tactical progression while preserving non-power battle preferences', () => {
+    const next = resetTacticalForNgPlus(dirtyState());
+
+    expect(next.tacticalBattleRecords).toEqual({});
+    expect(next.claimedTacticalFirstClears).toEqual([]);
+    expect(next.selectedTacticalCompanions).toEqual([]);
+    expect(next.tacticalCompanionBonds).toEqual({
+      bear: { xp: 0, level: 1 },
+      owl: { xp: 0, level: 1 },
+      wolf: { xp: 0, level: 1 },
+      cat: { xp: 0, level: 1 },
+    });
+    expect(next.tacticalAutoBattle).toBe(true);
+    expect(next.tacticalBattleSpeed).toBe(2);
+  });
+
+  it('is idempotent across at least three NG+ cycles and never accumulates Tactical power', () => {
+    const first = resetTacticalForNgPlus(dirtyState());
+    const second = resetTacticalForNgPlus(first);
+    const third = resetTacticalForNgPlus(second);
+
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+    expect(Object.values(third.tacticalCompanionBonds).every(bond => bond.xp === 0 && bond.level === 1)).toBe(true);
+  });
+
+  it('creates an empty once-only terminal handoff scope for every new run', () => {
+    const oldRuntime = createTacticalNgPlusRuntimeState();
+    const terminal = {
+      scenarioId: 'ngplus-reset-check',
+      campaign: 'caretaker' as const,
+      attemptKey: 'run-1',
+      terminalKey: 'ngplus-reset-check:run-1',
+      objectiveResult: 'success' as const,
+      battleResult: 'victory' as const,
+      failForward: true,
+      rounds: 3,
+      survivingAllies: 2,
+      damageTaken: 40,
+    };
+    const consumed = handoffTacticalTerminalResult(oldRuntime.terminalHandoff, terminal);
+    expect(consumed.result).not.toBeNull();
+    expect(consumed.state.handedOffKeys).toHaveLength(1);
+
+    const newRuntime = createTacticalNgPlusRuntimeState();
+    expect(newRuntime.terminalHandoff.handedOffKeys).toEqual([]);
+    expect(newRuntime).not.toBe(oldRuntime);
+  });
+
+  it('creates a fresh 3v3 BattleSession after a prior run is heavily mutated', () => {
+    const prior = createTacticalExpeditionBattle('forest_path', ['bear', 'owl'], progression, 501);
+    for (const unit of prior.units) {
+      unit.hp = 0;
+      unit.ap = 0;
+      unit.mp = 10;
+      unit.shield = 9999;
+      unit.statuses = [{ id: 'break', turns: 99 }];
+    }
+    prior.round = 999;
+    prior.timeline = [];
+    prior.acted = prior.units.map(unit => unit.id);
+
+    const fresh = createTacticalExpeditionBattle('forest_path', ['bear', 'owl'], progression, 502);
+    expect(fresh).not.toBe(prior);
+    expect(fresh.round).toBe(1);
+    expect(fresh.acted).toEqual([]);
+    expect(fresh.units.filter(unit => unit.side === 'ally')).toHaveLength(3);
+    expect(fresh.units.filter(unit => unit.side === 'enemy')).toHaveLength(3);
+    expect(fresh.units.every(unit => unit.hp > 0 && unit.hp <= unit.maxHp)).toBe(true);
+    expect(fresh.units.every(unit => unit.ap >= 0 && unit.ap <= unit.maxAp)).toBe(true);
+    expect(fresh.units.every(unit => unit.mp >= 0 && unit.mp <= unit.maxMp)).toBe(true);
+    expect(fresh.units.every(unit => unit.shield < 9999)).toBe(true);
+    expect(fresh.units.every(unit => !unit.statuses?.some(status => status.turns === 99))).toBe(true);
+  });
+});

--- a/src/tactical-ngplus-reset.ts
+++ b/src/tactical-ngplus-reset.ts
@@ -1,0 +1,33 @@
+import type { CompanionBondState, CompanionId } from './tactical-companions';
+import type { TacticalBattleRecord, TacticalEncounterId } from './tactical-encounters';
+import { createTacticalTerminalHandoffState, type TacticalTerminalHandoffState } from './tactical-scenario';
+import { emptyTacticalPersistentState } from './tactical-state';
+
+export type TacticalNgPlusResetState = Readonly<{
+  tacticalBattleRecords: Partial<Record<TacticalEncounterId, TacticalBattleRecord>>;
+  claimedTacticalFirstClears: readonly TacticalEncounterId[];
+  selectedTacticalCompanions: readonly CompanionId[];
+  tacticalCompanionBonds: Readonly<Record<CompanionId, CompanionBondState>>;
+  tacticalAutoBattle: boolean;
+  tacticalBattleSpeed: 1 | 2;
+}>;
+
+export type TacticalNgPlusRuntimeState = Readonly<{
+  terminalHandoff: TacticalTerminalHandoffState;
+}>;
+
+export function resetTacticalForNgPlus(state: TacticalNgPlusResetState): TacticalNgPlusResetState {
+  const defaults = emptyTacticalPersistentState();
+  return {
+    tacticalBattleRecords: {},
+    claimedTacticalFirstClears: [],
+    selectedTacticalCompanions: [],
+    tacticalCompanionBonds: defaults.companionBonds,
+    tacticalAutoBattle: state.tacticalAutoBattle === true,
+    tacticalBattleSpeed: state.tacticalBattleSpeed === 2 ? 2 : 1,
+  };
+}
+
+export function createTacticalNgPlusRuntimeState(): TacticalNgPlusRuntimeState {
+  return { terminalHandoff: createTacticalTerminalHandoffState() };
+}


### PR DESCRIPTION
Parent: #143

## Status
**04 Tactical NG+ independent candidate GREEN**

- authoritative baseline: `integration/v3@ff6a8fe55b1b2df5d8cf1434bb9b607af4bda264`
- branch: `work/v3-ngplus-tactical`
- head: `0268fd3897c3532580f2c771b4aa4a6958c81d78`
- verified merge-ref: `c3976b62db10732bf197dc279a13c39288807928`
- Draft / independent candidate / **DO NOT MERGE DIRECTLY**

## Tactical NG+ reset contract
Run-owned Tactical state resets on New Game+:
- `tacticalBattleRecords` -> `{}`
- `claimedTacticalFirstClears` -> `[]`
- `selectedTacticalCompanions` -> `[]`
- `tacticalCompanionBonds` -> fresh level 1 / xp 0 defaults

Non-power player preferences survive:
- `tacticalAutoBattle`
- `tacticalBattleSpeed`

Session-only state is recreated rather than inherited:
- fresh `TacticalTerminalHandoffState`
- new `BattleSession` has fresh round/acted/HP/AP/MP/shield/status state
- no prior terminal handoff key leakage

Repeated reset is idempotent across 3 NG+ cycles and does not accumulate Tactical companion power.

## TDD evidence
Intentional RED — CI #1662 / run `32561068186`
- new NG+ suite failed only because `./tactical-ngplus-reset` did not exist
- existing baseline: **389/389 prior test files, 1523/1523 prior tests GREEN**
- Tactical stability **13/13 GREEN**
- AUTO **10/50/100 GREEN**

Minimal implementation — CI #1663 / run `32561128400`
- behavior already GREEN: `src/tactical-ngplus-reset.test.ts` **4/4**
- full **390/390 files, 1527/1527 tests GREEN**
- build stopped only on two test-fixture literal type-widening errors; production implementation was unchanged

Final GREEN — CI #1665 / run `32561227376`: **SUCCESS**
- `src/tactical-ngplus-reset.test.ts`: **4/4 GREEN**
- full: **390/390 test files, 1527/1527 tests GREEN**
- Tactical stability: **13/13 GREEN**
- AUTO bounded/progressing through **10 / 50 / 100 battle checkpoints GREEN**
- Expedition stress: **4/4 GREEN**
- `npm run build` = `tsc -b && vite build`: **PASS**
- production build PASS; **190 modules transformed**

## Diff / ownership audit
Exactly 2 changed files:
- `src/tactical-ngplus-reset.ts`
- `src/tactical-ngplus-reset.test.ts`

No `App.tsx`, `Root.tsx`, shared `game.ts`, save schema/resilience, `main.tsx`, or `vercel.json` edits. 06/runtime can consume this pure reset contract when composing the NG+ transition.

Existing non-blocking repository warnings remain unchanged: npm audit high-severity dependency warning, Vite >500kB chunk warning, GitHub Actions Node20 deprecation warning.

**Status: independent GREEN; ready for NG+ runtime/composite consumption. Keep Draft/unmerged unless control tower assigns a concrete synthesis branch.**