### PR TITLE
[Macro A #142] GREEN NG+ Replay Experience verification

### DIFF
--- a/docs/superpowers/plans/2026-08-22-v3-ngplus-replay-experience.md
+++ b/docs/superpowers/plans/2026-08-22-v3-ngplus-replay-experience.md
@@ -1,0 +1,176 @@
+# V3 NG+ Replay Experience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the complete player-facing NG+ `new possibility` replay experience, then compose exact 01 Raising + 02 World + 05 Hub candidates into Macro A and verify the replay E2E.
+
+**Architecture:** 05 owns a dedicated `NgPlusReplayHub` presentation surface and no authoritative NG+ state transitions. The Macro verify branch owns one thin adapter that combines 01 qualitative replay semantics, 02 inherited World Echo presentation, and the 05 view model while keeping current-run Spring state authoritative.
+
+**Tech Stack:** React, TypeScript, Vitest, React DOM server rendering, CSS, Vite.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-v3-ngplus-replay-experience-design.md`
+
+## Global Constraints
+
+- Baseline is exactly `integration/v3@ff6a8fe55b1b2df5d8cf1434bb9b607af4bda264`.
+- 01 frozen candidate is exactly `5130d28bab8ace114adc1f67ec39697f37889061`.
+- 02 frozen candidate is exactly `88d30ce9b7a6c4c3c81209b95dab818cf93f3898`.
+- 05 never owns archive, runNumber, reset/persist split, shared save wiring, or authoritative new-run transition.
+- No raw affinity, numeric trust, raw career score, hidden requirement total, optimization threshold, or raw Legacy power value may reach presentation.
+- Normal Path Convergence keeps at least two main campaigns; `fifth_path_candidate` is additive only.
+- Fifth Path main campaign content and Hollow remain closed.
+- 360/390/430, safe areas, 44px targets, Korean wrapping, focus/back/ESC, focus return, reduced motion, and empty-image safety remain mandatory.
+- No direct merge to `integration/v3`, `main`, or production.
+
+---
+
+### Task 1: NG+ Replay Hub contract
+
+**Files:**
+- Create: `src/NgPlusReplayHub.test.tsx`
+- Create: `src/ngplus-replay-mobile.test.ts`
+- Create: `src/NgPlusReplayHub.tsx`
+- Create: `src/ngplus-replay.css`
+
+**Interfaces:**
+- Produces `NgPlusReplayViewModel` with `entry`, `home`, `journey`, `normalCandidates`, `specialCandidate`, and `vn` presentation fields.
+- Produces default export `NgPlusReplayHub` with `{open, model, onOpen, onClose}`.
+
+- [ ] **Step 1: Write the failing component contract**
+
+```tsx
+const model: NgPlusReplayViewModel = {
+  entry:{title:'새로운 가능성',previousRun:'지난 삶은 하나의 기억으로 남았어요.',currentRun:'이번 봄은 새로운 선택으로 시작해요.',cta:'새로운 봄 시작'},
+  home:{season:'봄 · 새로운 가능성',runLabel:'현재 회차',echoSummary:'익숙한 기억이 희미하게 따라와요.',primaryCta:'Journey 돌아보기'},
+  journey:{pastLife:['지난 Caretaker의 삶이 희미하게 떠올라요.'],reunions:['미라와 다시 마주쳤어요.'],worldEchoes:['예전 세계의 흔적이 현재와 분리되어 보여요.'],currentRun:['이번 봄의 행동은 새로 기록돼요.']},
+  normalCandidates:[
+    {id:'caretaker',title:'Caretaker',tendency:'떠오르는 가능성',reasons:['이번 회차의 행동이 이 길을 열었어요.']},
+    {id:'pathfinder',title:'Pathfinder',tendency:'희미하게 보이는 길',reasons:['현재 봄의 선택이 이 방향을 가리켜요.']},
+  ],
+  specialCandidate:{id:'fifth_path_candidate',title:'아직 이름 붙지 않은 가능성',reasons:['몇 번의 삶이 겹쳐 보여요.']},
+  vn:{name:'미라',dialogue:'처음 만나는 것 같은데, 이상하게 익숙해.',choices:['다시 시작하자'],log:[],seen:false},
+};
+```
+
+Assert closed Home shows exactly one CTA and current-vs-inherited wording. Assert open Journey renders past-life/reunion/world echo/current-run sections, >=2 normal candidates, optional special candidate, and never matches `/affinity|trust\s*[:=]|rawScore|legacyPower|\d+\s*\/\s*100/i`.
+
+- [ ] **Step 2: Run full CI through Draft PR and verify RED**
+
+Expected: all existing baseline tests GREEN; only new NG+ UI tests fail because `./NgPlusReplayHub` / `./ngplus-replay.css` do not exist.
+
+- [ ] **Step 3: Implement minimal component**
+
+```tsx
+export type NgPlusReplayViewModel={
+  entry:{title:string;previousRun:string;currentRun:string;cta:string};
+  home:{season:string;runLabel:string;echoSummary:string;primaryCta:string};
+  journey:{pastLife:string[];reunions:string[];worldEchoes:string[];currentRun:string[]};
+  normalCandidates:Array<{id:string;title:string;tendency:string;reasons:string[]}>;
+  specialCandidate:{id:'fifth_path_candidate';title:string;reasons:string[]}|null;
+  vn:{portrait?:string;name:string;dialogue:string;choices:string[];log:string[];seen:boolean};
+};
+```
+
+Closed mode renders compressed Replay Home. Open mode renders a `role="dialog" aria-modal="true"` Journey/Path/VN shell, shows inherited/current sections separately, renders normal candidates first, and renders the special candidate only when non-null. Empty portrait omits `<img>` entirely.
+
+- [ ] **Step 4: Add mobile/accessibility CSS contract**
+
+```css
+.ngplus-replay-shell{min-height:100vh;min-height:100dvh;padding-top:env(safe-area-inset-top);padding-bottom:env(safe-area-inset-bottom)}
+.ngplus-replay-shell button{min-height:44px}
+.ngplus-replay-shell{overflow-wrap:anywhere;word-break:keep-all}
+@media (prefers-reduced-motion: reduce){.ngplus-replay-shell *{animation:none!important;transition:none!important}}
+```
+
+Tests must assert explicit `360px`, `390px`, and `430px` media contracts and the accessibility literals above.
+
+- [ ] **Step 5: Run targeted, full, `tsc -b`, production build**
+
+Expected: new Hub tests GREEN, mobile tests GREEN, full suite GREEN, `npm run build` GREEN.
+
+- [ ] **Step 6: Freeze 05 Draft candidate**
+
+Update the 05 Draft PR with exact head SHA, RED/GREEN CI evidence, file list, and hard presentation boundary.
+
+---
+
+### Task 2: Exact room-candidate composition
+
+**Files:**
+- No production file changes yet.
+- Verify branch: `verify/v3-ngplus-replay-experience`.
+
+**Interfaces:**
+- Consumes exact 01 SHA `5130d28...`, exact 02 SHA `88d30ce...`, and exact frozen 05 SHA from Task 1.
+- Produces one composition commit whose parents preserve exact room provenance.
+
+- [ ] **Step 1: Confirm all three candidates are 0-behind baseline descendants and independently GREEN**
+
+Expected: no candidate moved after freeze.
+
+- [ ] **Step 2: Compose exact 01 + 02 + 05 trees on verify branch**
+
+The resulting tree must contain only the union of those candidates over the baseline, with no shared `game/save/App/Root` edits introduced by 05.
+
+- [ ] **Step 3: Open Draft Macro A verification PR against `integration/v3`**
+
+Mark it verification-only and `DO NOT MERGE DIRECTLY`.
+
+---
+
+### Task 3: Macro A composition adapter E2E
+
+**Files:**
+- Create: `src/ngplus-replay-experience.integration.test.tsx`
+- Create: `src/ngplus-replay-ui.ts`
+
+**Interfaces:**
+- Consumes `resolveNgPlusRaisingReplay(rawLegacy,evidence): NgPlusRaisingReplay` from 01.
+- Consumes `buildNgPlusWorldEchoPresentation(worldHistory,unlocks): NgPlusWorldEchoPresentation` from 02.
+- Produces `buildNgPlusReplayViewModel(inputs): NgPlusReplayViewModel`.
+
+- [ ] **Step 1: Write failing Macro E2E**
+
+Build a hydrated Legacy state with `past_life_dialogue`, `relationship_reunion`, `world_echo`, and optionally `fifth_path_candidate`; supply current-run Spring evidence that yields >=2 normal candidates; supply World history with distinct `currentFacts` and `inheritedFacts`. Call 01 and 02 domain selectors, then import missing `buildNgPlusReplayViewModel` and assert the rendered 05 UI distinguishes previous/inherited/current state.
+
+- [ ] **Step 2: Run CI and verify RED**
+
+Expected: exact 01+02+05 composition suite remains GREEN; only Macro E2E fails because `./ngplus-replay-ui` is absent.
+
+- [ ] **Step 3: Implement minimal adapter**
+
+```ts
+export type NgPlusReplayUiInputs={
+  raising:NgPlusRaisingReplay;
+  world:NgPlusWorldEchoPresentation;
+  currentRunEvents:readonly string[];
+};
+
+export function buildNgPlusReplayViewModel(input:NgPlusReplayUiInputs):NgPlusReplayViewModel
+```
+
+Mapping rules:
+- `raising.pastLife` -> one qualitative previous-life sentence; never render `runNumber` as optimization/progression data.
+- relationship hook `summaryKey` -> stable qualitative Korean copy by character/kind; no trust values.
+- `world.inheritedEchoes` -> qualitative inherited-world copy keyed by `presentationKey`; `world.currentFacts` never enter the inherited list.
+- `raising.normalCandidates` -> candidate title + existing qualitative tendency + current-run reasons; `legacyReasons` appended only as secondary qualitative rationale.
+- `raising.specialCandidate` -> optional additive `fifth_path_candidate`; never replace/remove normal candidates and never produce a commit action.
+- if memory/echo inputs are absent, produce ordinary Spring replay presentation rather than blocking entry.
+
+- [ ] **Step 4: Verify invariants in E2E**
+
+Assert:
+- >=2 normal candidates remain visible.
+- special candidate is additive when eligible and absent otherwise.
+- same World Fact may exist current + inherited without collapse.
+- inherited echo cannot alter normal campaign access.
+- raw `campaignAffinities`, trust, score, threshold, raw Legacy power do not appear in serialized view model or rendered HTML.
+- Mira/Kael/Rex/Selene plus Noa/Eiden hooks render qualitatively; Lyra appears only as possibility hint; Veyr does not appear in ordinary NG+ reunion.
+
+- [ ] **Step 5: Run targeted, full, `tsc -b`, production build**
+
+Expected: Macro A E2E GREEN, all room suites GREEN, full suite GREEN, TypeScript GREEN, Vite production build GREEN.
+
+- [ ] **Step 6: Freeze Macro A handoff**
+
+Update #142 and the Draft Macro PR with exact head, composition parent SHAs, CI run, full counts, diff isolation, and 06 handoff. Close #142 only after fresh final verification. Do not advance `integration/v3`.

--- a/docs/superpowers/specs/2026-08-22-v3-ngplus-replay-experience-design.md
+++ b/docs/superpowers/specs/2026-08-22-v3-ngplus-replay-experience-design.md
@@ -1,0 +1,171 @@
+# V3 NG+ Replay Experience — Macro A Design
+
+Baseline: `integration/v3@ff6a8fe55b1b2df5d8cf1434bb9b607af4bda264`
+Tracking: #142
+Lead: 05 Hub/UI
+Work branches: `work/v3-ngplus-raising`, `work/v3-ngplus-world`, `work/v3-ngplus-hub`
+Verify: `verify/v3-ngplus-replay-experience`
+
+## Goal
+
+Deliver one complete player-facing NG+ replay experience after a completed Winter ending:
+
+`new possibility entry`
+→ `past-life / reunion / world echoes`
+→ `fresh Spring replay`
+→ `ordinary affinity and qualitative tendencies`
+→ `Path Convergence with at least two normal campaigns`
+→ `optional additive fifth_path_candidate hint`
+→ `Home / Journey / Path UI on 360 / 390 / 430`
+
+Macro A consumes authoritative NG+ runtime state from Macro B. It does not own archive, run-number increment, reset/persist split, shared save wiring, or authoritative new-run state transitions.
+
+## Existing frozen room contracts
+
+### 01 Raising
+Candidate: `work/v3-ngplus-raising@5130d28bab8ace114adc1f67ec39697f37889061`
+
+05 consumes only qualitative replay presentation semantics from 01:
+- past-life context
+- representative and shared reunion context
+- legacy reasons
+- current-run Spring Path Convergence candidates
+- optional `fifth_path_candidate` eligibility/hint
+
+Current-run `pathConvergence` remains authoritative for normal candidate tendency and ordering. Prior-run context must never overwrite current-run affinity or reduce normal campaign access below two candidates.
+
+### 02 World
+Candidate: `work/v3-ngplus-world@88d30ce9b7a6c4c3c81209b95dab818cf93f3898`
+
+05 consumes `buildNgPlusWorldEchoPresentation` output only.
+
+World echo constraints:
+- inherited entries remain `source: 'inherited'`
+- `currentFacts` remain current-run evidence only
+- same canonical fact may exist in both current and inherited channels without collapsing
+- inherited echoes may change flavor, starting events, hidden quest hints, rationale, or qualitative rewards
+- inherited echoes cannot remove or replace the ordinary four-campaign replay path
+
+## 05 Player-Facing Architecture
+
+05 adds a dedicated NG+ replay presentation surface rather than teaching Spring domain modules about NG+ state.
+
+### 1. New Possibility Entry
+
+A compact transition shell presented after a completed ending when Macro B exposes an active NG+ replay state.
+
+It shows:
+- previous run as a completed memory
+- current state as a new possibility
+- one primary action to enter the fresh Spring replay
+
+It never performs the authoritative reset itself and never renders run archive internals or numeric carry-over values.
+
+### 2. Replay Home
+
+The Spring replay home remains compressed. It distinguishes three concepts explicitly:
+- current run
+- inherited memory/echo
+- ordinary current-run campaign direction
+
+The home may surface at most a small qualitative echo summary. It must not become a history dashboard.
+
+### 3. Replay Journey
+
+Journey is the detailed replay-memory surface. It may display:
+- past-life dialogue
+- representative reunion memory for Mira / Kael / Rex / Selene
+- shared reunion hooks for Noa / Eiden
+- Lyra repetition / possibility hint when provided
+- inherited World Echo entries
+- current-run Spring events separately from inherited material
+
+Inherited and current-run sections use distinct labels and data channels.
+
+### 4. Replay Path Convergence
+
+05 reuses existing qualitative campaign presentation rules:
+- never show raw affinity numbers
+- normal Path Convergence must retain at least two main campaigns
+- prior-run evidence may appear only as qualitative rationale
+- `fifth_path_candidate` may render as an additional special candidate only when upstream semantic eligibility says it is available
+- no Fifth Path campaign commit, route content, battle content, World content, Ending, or Hollow content is implemented in this Wave
+
+The special candidate must visually read as a possibility/hook rather than a replacement for the ordinary candidates.
+
+### 5. Composition Adapter
+
+Macro verify owns a thin adapter that combines:
+- 01 NG+ Raising presentation semantics
+- 02 NG+ World Echo presentation
+- 05 replay UI view model
+
+The adapter must not:
+- calculate affinity
+- calculate Legacy eligibility
+- calculate World echo eligibility
+- merge inherited and current World Facts
+- mutate Character Bond state
+- own NG+ reset/save state
+
+## Presentation Boundary
+
+The UI must never expose:
+- raw affinity values
+- numeric trust
+- raw career score
+- hidden requirement totals
+- optimization thresholds
+- raw Legacy power values
+
+Past-life evidence is intentionally qualitative and must remain weaker than current-run player choice authority.
+
+## Mobile and Accessibility Contract
+
+The replay experience preserves the established 05 guarantees:
+- 360px, 390px, 430px widths
+- `100dvh` with viewport fallback where needed
+- top and bottom safe areas
+- minimum 44px interactive targets
+- Korean long-text wrapping
+- dialog focus containment
+- ESC/back close semantics
+- focus return to opener
+- reduced-motion support
+- no empty image `src` warnings
+
+## Failure and Malformed Input Behavior
+
+If replay presentation input is stale or malformed:
+- current-run normal Spring candidate access stays authoritative
+- unknown inherited echo IDs are ignored by upstream typed contracts rather than rendered as free-form history
+- missing replay-memory presentation produces an ordinary Spring replay UI, not a broken or blocked screen
+- invalid special candidate input cannot create playable Fifth Path content
+
+## TDD and Composition Sequence
+
+1. 05 RED: NG+ replay UI tests import missing production module(s).
+2. 05 GREEN: implement the minimum New Possibility / Replay Home / Journey / Path presentation and mobile/accessibility contracts.
+3. Freeze exact 05 candidate after targeted + full + `tsc -b` + production build.
+4. Compose exact 01, 02, and 05 frozen candidate SHAs on `verify/v3-ngplus-replay-experience`.
+5. Macro RED: add one end-to-end replay experience test that fails only because the composition adapter is absent.
+6. Macro GREEN: add the minimum adapter with no shared-state ownership.
+7. Verify:
+   - completed prior run can be represented as `new possibility`
+   - past-life/reunion/world echoes remain inherited context
+   - fresh Spring current-run state remains distinct
+   - Path Convergence retains >=2 normal campaigns
+   - optional `fifth_path_candidate` is additive only
+   - raw optimization values never reach UI
+   - 360/390/430 accessibility contracts remain GREEN
+   - full test suite, `tsc -b`, production build GREEN
+8. Freeze Macro A Draft PR and hand exact head SHA to #144 / 06.
+
+## Authority and Scope Rules
+
+- `integration/v3` remains frozen during Macro A development.
+- 05 never merges directly to `integration/v3`, `main`, or production.
+- Macro A uses exact room candidate SHAs; 06 must not reconstruct room candidates one-by-one for the final gate.
+- Macro B owns authoritative NG+ state transition/reset/save behavior.
+- Fifth Path main campaign content remains CLOSED.
+- Hollow remains CLOSED.

--- a/src/NgPlusReplayHub.test.tsx
+++ b/src/NgPlusReplayHub.test.tsx
@@ -1,0 +1,99 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import NgPlusReplayHub, { type NgPlusReplayViewModel } from './NgPlusReplayHub';
+
+const model: NgPlusReplayViewModel = {
+  entry: {
+    title: '새로운 가능성',
+    previousRun: '지난 삶은 하나의 기억으로 남았어요.',
+    currentRun: '이번 봄은 새로운 선택으로 시작해요.',
+    cta: '새로운 봄 시작',
+  },
+  home: {
+    season: '봄 · 새로운 가능성',
+    runLabel: '현재 회차',
+    echoSummary: '익숙한 기억이 희미하게 따라와요.',
+    primaryCta: 'Journey 돌아보기',
+  },
+  journey: {
+    pastLife: ['지난 Caretaker의 삶이 희미하게 떠올라요.'],
+    reunions: ['미라와 다시 마주쳤어요.'],
+    worldEchoes: ['예전 세계의 흔적이 현재와 분리되어 보여요.'],
+    currentRun: ['이번 봄의 행동은 새로 기록돼요.'],
+  },
+  normalCandidates: [
+    {
+      id: 'caretaker',
+      title: 'Caretaker',
+      tendency: '떠오르는 가능성',
+      reasons: ['이번 회차의 행동이 이 길을 열었어요.'],
+    },
+    {
+      id: 'pathfinder',
+      title: 'Pathfinder',
+      tendency: '희미하게 보이는 길',
+      reasons: ['현재 봄의 선택이 이 방향을 가리켜요.'],
+    },
+  ],
+  specialCandidate: {
+    id: 'fifth_path_candidate',
+    title: '아직 이름 붙지 않은 가능성',
+    reasons: ['몇 번의 삶이 겹쳐 보여요.'],
+  },
+  vn: {
+    name: '미라',
+    dialogue: '처음 만나는 것 같은데, 이상하게 익숙해.',
+    choices: ['다시 시작하자'],
+    log: [],
+    seen: false,
+  },
+};
+
+describe('NgPlusReplayHub', () => {
+  it('keeps the replay home compressed and distinguishes the current run from inherited memory', () => {
+    const html = renderToStaticMarkup(
+      <NgPlusReplayHub open={false} model={model} onOpen={() => undefined} onClose={() => undefined} />,
+    );
+
+    expect(html).toContain('봄 · 새로운 가능성');
+    expect(html).toContain('현재 회차');
+    expect(html).toContain('익숙한 기억이 희미하게 따라와요.');
+    expect((html.match(/Journey 돌아보기/g) ?? []).length).toBe(1);
+    expect(html).toContain('새로운 가능성');
+  });
+
+  it('renders inherited and current-run Journey sections separately', () => {
+    const html = renderToStaticMarkup(
+      <NgPlusReplayHub open model={model} onOpen={() => undefined} onClose={() => undefined} />,
+    );
+
+    expect(html).toContain('지난 삶의 기억');
+    expect(html).toContain('다시 만난 관계');
+    expect(html).toContain('이어진 세계의 메아리');
+    expect(html).toContain('이번 회차의 기록');
+    expect(html).toContain('지난 Caretaker의 삶이 희미하게 떠올라요.');
+    expect(html).toContain('이번 봄의 행동은 새로 기록돼요.');
+  });
+
+  it('keeps at least two ordinary Path candidates and makes the special candidate additive only', () => {
+    const html = renderToStaticMarkup(
+      <NgPlusReplayHub open model={model} onOpen={() => undefined} onClose={() => undefined} />,
+    );
+
+    expect(html).toContain('Caretaker');
+    expect(html).toContain('Pathfinder');
+    expect(html).toContain('아직 이름 붙지 않은 가능성');
+    expect(html).toContain('추가로 보이는 가능성');
+    expect(html).not.toContain('Fifth Path 시작');
+  });
+
+  it('renders the reunion VN without optimization values or empty portrait source', () => {
+    const html = renderToStaticMarkup(
+      <NgPlusReplayHub open model={model} onOpen={() => undefined} onClose={() => undefined} />,
+    );
+
+    expect(html).toContain('처음 만나는 것 같은데, 이상하게 익숙해.');
+    expect(html).not.toMatch(/affinity|trust\s*[:=]|rawScore|careerScore|legacyPower|threshold|\d+\s*\/\s*100/i);
+    expect(html).not.toContain('src=""');
+  });
+});

--- a/src/NgPlusReplayHub.tsx
+++ b/src/NgPlusReplayHub.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef } from 'react';
+import './ngplus-replay.css';
+
+export type NgPlusReplayPathCard = {
+  id: string;
+  title: string;
+  tendency: string;
+  reasons: string[];
+};
+
+export type NgPlusReplaySpecialCard = {
+  id: 'fifth_path_candidate';
+  title: string;
+  reasons: string[];
+};
+
+export type NgPlusReplayViewModel = {
+  entry: {
+    title: string;
+    previousRun: string;
+    currentRun: string;
+    cta: string;
+  };
+  home: {
+    season: string;
+    runLabel: string;
+    echoSummary: string;
+    primaryCta: string;
+  };
+  journey: {
+    pastLife: string[];
+    reunions: string[];
+    worldEchoes: string[];
+    currentRun: string[];
+  };
+  normalCandidates: NgPlusReplayPathCard[];
+  specialCandidate: NgPlusReplaySpecialCard | null;
+  vn: {
+    portrait?: string;
+    name: string;
+    dialogue: string;
+    choices: string[];
+    log: string[];
+    seen: boolean;
+  };
+};
+
+type Props = {
+  open: boolean;
+  model: NgPlusReplayViewModel;
+  onOpen: () => void;
+  onClose: () => void;
+};
+
+const focusableSelector = 'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+
+function ReplayList({ items, empty }: { items: readonly string[]; empty: string }) {
+  return <div className="ngplus-replay-list">{items.length ? items.map(item => <p key={item}>{item}</p>) : <p>{empty}</p>}</div>;
+}
+
+export default function NgPlusReplayHub({ open, model, onOpen, onClose }: Props) {
+  const launcherRef = useRef<HTMLElement | null>(null);
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLElement | null>(null);
+  const wasOpen = useRef(false);
+
+  const openReplayJourney = () => {
+    const active = document.activeElement;
+    launcherRef.current = active instanceof HTMLElement && active !== document.body ? active : launcherRef.current;
+    onOpen();
+  };
+
+  useEffect(() => {
+    if (!open) {
+      if (wasOpen.current) launcherRef.current?.focus();
+      wasOpen.current = false;
+      return;
+    }
+
+    wasOpen.current = true;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    closeRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== 'Tab' || !panelRef.current) return;
+      const focusables = Array.from(panelRef.current.querySelectorAll<HTMLElement>(focusableSelector));
+      if (!focusables.length) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  if (!open) {
+    return <section
+      className="ngplus-replay-home ngplus-replay-shell"
+      aria-label={`새로운 가능성 · ${model.home.season}`}
+      ref={node => { launcherRef.current = node; }}
+    >
+      <div className="ngplus-entry-card">
+        <small>NEW POSSIBILITY</small>
+        <h2>{model.entry.title}</h2>
+        <p>{model.entry.previousRun}</p>
+        <p>{model.entry.currentRun}</p>
+        <strong>{model.entry.cta}</strong>
+      </div>
+      <div className="ngplus-home-card">
+        <small>{model.home.runLabel}</small>
+        <h3>{model.home.season}</h3>
+        <p>{model.home.echoSummary}</p>
+        <button type="button" onClick={openReplayJourney}>{model.home.primaryCta}</button>
+      </div>
+    </section>;
+  }
+
+  return <div className="ngplus-replay-backdrop" onMouseDown={event => event.target === event.currentTarget && onClose()}>
+    <section
+      className="ngplus-replay-panel ngplus-replay-shell"
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ngplus-replay-title"
+    >
+      <header className="ngplus-replay-header">
+        <div>
+          <small>{model.home.runLabel}</small>
+          <h2 id="ngplus-replay-title">Journey · 새로운 가능성</h2>
+          <p>{model.home.season}</p>
+        </div>
+        <button ref={closeRef} type="button" onClick={onClose} aria-label="Replay Journey 닫기">×</button>
+      </header>
+
+      <div className="ngplus-replay-scroll">
+        <section aria-labelledby="ngplus-past-life-title">
+          <small>INHERITED MEMORY</small>
+          <h3 id="ngplus-past-life-title">지난 삶의 기억</h3>
+          <ReplayList items={model.journey.pastLife} empty="이번 봄에는 지난 삶의 기억이 조용히 잠들어 있어요." />
+        </section>
+
+        <section aria-labelledby="ngplus-reunion-title">
+          <small>RELATIONSHIP REUNION</small>
+          <h3 id="ngplus-reunion-title">다시 만난 관계</h3>
+          <ReplayList items={model.journey.reunions} empty="아직 다시 이어진 관계의 기억은 없어요." />
+        </section>
+
+        <section aria-labelledby="ngplus-world-echo-title">
+          <small>INHERITED WORLD</small>
+          <h3 id="ngplus-world-echo-title">이어진 세계의 메아리</h3>
+          <ReplayList items={model.journey.worldEchoes} empty="이전 세계의 흔적이 이번 회차에 드러나지 않았어요." />
+        </section>
+
+        <section aria-labelledby="ngplus-current-run-title">
+          <small>CURRENT RUN</small>
+          <h3 id="ngplus-current-run-title">이번 회차의 기록</h3>
+          <ReplayList items={model.journey.currentRun} empty="이번 봄의 기록은 지금부터 새로 쌓여요." />
+        </section>
+
+        <section className="ngplus-paths" aria-labelledby="ngplus-path-title">
+          <small>PATH CONVERGENCE</small>
+          <h3 id="ngplus-path-title">이번 봄에 열리는 길</h3>
+          <p>지난 삶은 힌트가 될 뿐, 이번 회차의 선택이 길을 결정해요.</p>
+          <div className="ngplus-path-grid">
+            {model.normalCandidates.map(card => <article className="ngplus-path-card" key={card.id}>
+              <small>{card.tendency}</small>
+              <h4>{card.title}</h4>
+              <ul>{card.reasons.slice(0, 4).map(reason => <li key={reason}>{reason}</li>)}</ul>
+            </article>)}
+          </div>
+          {model.specialCandidate && <article className="ngplus-special-card">
+            <small>추가로 보이는 가능성</small>
+            <h4>{model.specialCandidate.title}</h4>
+            <ul>{model.specialCandidate.reasons.slice(0, 3).map(reason => <li key={reason}>{reason}</li>)}</ul>
+            <p>아직 선택 가능한 본편 경로가 아니라, 다음 가능성의 흔적이에요.</p>
+          </article>}
+        </section>
+
+        <section className="ngplus-vn" aria-labelledby="ngplus-vn-title">
+          <small>REUNION SCENE</small>
+          <h3 id="ngplus-vn-title">다시 시작하는 장면</h3>
+          <div className="ngplus-vn-stage">
+            {model.vn.portrait ? <img src={model.vn.portrait} alt="" className="ngplus-vn-portrait" /> : null}
+            <div>
+              <strong>{model.vn.name}</strong>
+              <p>{model.vn.dialogue}</p>
+            </div>
+          </div>
+          <div className="ngplus-vn-choices" aria-label="대화 선택지">
+            {model.vn.choices.map(choice => <button type="button" key={choice}>{choice}</button>)}
+          </div>
+          <details><summary>대화 기록</summary>{model.vn.log.map(line => <p key={line}>{line}</p>)}</details>
+          <button type="button" disabled={!model.vn.seen}>읽은 장면 빠르게</button>
+        </section>
+      </div>
+    </section>
+  </div>;
+}

--- a/src/ngplus-raising.test.ts
+++ b/src/ngplus-raising.test.ts
@@ -1,4 +1,5 @@
 import {describe,expect,it} from 'vitest';
+import {mainCampaignIds} from './campaign-model';
 import {emptyLegacyState,type LegacyState} from './legacy-state';
 import {pathConvergence,type SpringAffinityEvidence} from './spring-raising';
 import {resolveNgPlusRaisingReplay} from './ngplus-raising';
@@ -83,7 +84,7 @@ describe('V3 NG+ Raising replay semantics',()=>{
     }),evidence);
     expect(result.normalCandidates.length).toBeGreaterThanOrEqual(2);
     expect(result.specialCandidate).toMatchObject({id:'fifth_path_candidate',kind:'special_candidate'});
-    expect(result.normalCandidates.every(candidate=>candidate.campaign!=='true_path')).toBe(true);
+    expect(result.normalCandidates.every(candidate=>mainCampaignIds.includes(candidate.campaign))).toBe(true);
   });
 
   it('does not expose Fifth Path content when only ordinary NG+ replay unlocks exist',()=>{

--- a/src/ngplus-raising.test.ts
+++ b/src/ngplus-raising.test.ts
@@ -1,0 +1,107 @@
+import {describe,expect,it} from 'vitest';
+import {emptyLegacyState,type LegacyState} from './legacy-state';
+import {pathConvergence,type SpringAffinityEvidence} from './spring-raising';
+import {resolveNgPlusRaisingReplay} from './ngplus-raising';
+
+const evidence:SpringAffinityEvidence[]=[
+  {campaign:'caretaker',source:'training',amount:5,reason:'이번 봄에는 보호 훈련을 선택했다.'},
+  {campaign:'pathfinder',source:'exploration',amount:4,reason:'새 경로를 직접 탐색했다.'},
+  {campaign:'vanguard',source:'tactical',amount:2,reason:'정면 승부를 피하지 않았다.'},
+];
+
+const legacy=(patch:Partial<LegacyState>={}):LegacyState=>({
+  ...emptyLegacyState(),
+  completedRuns:1,
+  completedCampaigns:['caretaker'],
+  endingCollection:['winter.caretaker.team_solution.victory.epilogue'],
+  careerCollection:['winter.career.seasoned'],
+  ngPlusUnlocks:['past_life_dialogue','relationship_reunion'],
+  runSummaries:[{
+    runNumber:1,
+    campaign:'caretaker',
+    route:'normal',
+    ending:'winter.caretaker.team_solution.victory.epilogue',
+    career:'winter.career.seasoned',
+    majorWorldOutcomes:[],
+    keyBondMemories:[{characterId:'mira',memoryId:'mira_winter_victory'}],
+    trueClues:[],
+  }],
+  relationshipEchoes:{mira:['mira_winter_victory']},
+  ...patch,
+});
+
+describe('V3 NG+ Raising replay semantics',()=>{
+  it('surfaces qualitative past-life evidence from the latest completed run without raw optimization values',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    expect(result.pastLife).toMatchObject({campaign:'caretaker',runNumber:1});
+    expect(result.pastLife?.endingKey).toContain('winter.caretaker');
+    expect(result.pastLife?.careerKey).toBe('winter.career.seasoned');
+    expect(JSON.stringify(result.pastLife)).not.toMatch(/score|trust|affinit|threshold|bestScore|sGrades/i);
+  });
+
+  it('creates representative reunion hooks from relationship echoes and shared Noa/Eiden reunion hooks',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    expect(result.relationshipHooks).toEqual(expect.arrayContaining([
+      expect.objectContaining({character:'mira',kind:'reunion'}),
+      expect.objectContaining({character:'noa',kind:'shared_reunion'}),
+      expect.objectContaining({character:'eiden',kind:'shared_reunion'}),
+    ]));
+    expect(result.relationshipHooks.some(hook=>hook.character==='veyr')).toBe(false);
+  });
+
+  it('does not invent past-life or reunion semantics when the corresponding unlocks are absent',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy({ngPlusUnlocks:[]}),evidence);
+    expect(result.pastLife).toBeNull();
+    expect(result.relationshipHooks).toEqual([]);
+  });
+
+  it('keeps Lyra as a repetition/Fifth Path eligibility hint only',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy({ngPlusUnlocks:['past_life_dialogue','relationship_reunion','fifth_path_candidate']}),evidence);
+    expect(result.relationshipHooks).toContainEqual(expect.objectContaining({character:'lyra',kind:'possibility_hint'}));
+    expect(result.relationshipHooks).not.toContainEqual(expect.objectContaining({character:'lyra',kind:'reunion'}));
+  });
+
+  it('preserves ordinary Spring candidate tendencies instead of letting Legacy overpower current-run play',()=>{
+    const baseline=pathConvergence(evidence);
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    expect(result.normalCandidates.map(candidate=>[candidate.campaign,candidate.tendency]))
+      .toEqual(baseline.map(candidate=>[candidate.campaign,candidate.tendency]));
+    expect(result.normalCandidates).toHaveLength(2);
+  });
+
+  it('adds prior-life rationale qualitatively without replacing current-run reasons',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    const caretaker=result.normalCandidates.find(candidate=>candidate.campaign==='caretaker');
+    expect(caretaker?.reasons).toContain('이번 봄에는 보호 훈련을 선택했다.');
+    expect(caretaker?.legacyReasons?.some(reason=>reason.includes('caretaker'))).toBe(true);
+  });
+
+  it('adds fifth_path_candidate only as a special extra candidate and keeps at least two normal campaigns',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy({
+      ngPlusUnlocks:['past_life_dialogue','relationship_reunion','fifth_path_candidate'],
+      trueClues:['caretaker_life_anomaly','pathfinder_world_route'],
+    }),evidence);
+    expect(result.normalCandidates.length).toBeGreaterThanOrEqual(2);
+    expect(result.specialCandidate).toMatchObject({id:'fifth_path_candidate',kind:'special_candidate'});
+    expect(result.normalCandidates.every(candidate=>candidate.campaign!=='true_path')).toBe(true);
+  });
+
+  it('does not expose Fifth Path content when only ordinary NG+ replay unlocks exist',()=>{
+    const result=resolveNgPlusRaisingReplay(legacy(),evidence);
+    expect(result.specialCandidate).toBeNull();
+    expect(JSON.stringify(result)).not.toContain('true_path');
+  });
+
+  it('degrades malformed/stale legacy input to clean ordinary Spring replay',()=>{
+    const result=resolveNgPlusRaisingReplay({
+      completedRuns:999,
+      ngPlusUnlocks:['stale_unlock'],
+      relationshipEchoes:{mira:['mira_winter_stale']},
+      runSummaries:[{runNumber:'NaN',campaign:'stale'}],
+    } as never,evidence);
+    expect(result.pastLife).toBeNull();
+    expect(result.relationshipHooks).toEqual([]);
+    expect(result.specialCandidate).toBeNull();
+    expect(result.normalCandidates.map(candidate=>candidate.campaign)).toEqual(pathConvergence(evidence).map(candidate=>candidate.campaign));
+  });
+});

--- a/src/ngplus-raising.ts
+++ b/src/ngplus-raising.ts
@@ -1,0 +1,116 @@
+import {mainCampaignIds,type CampaignId,type CharacterId,type MainCampaignId} from './campaign-model';
+import {hydrateLegacyState,type LegacyState,type RunSummary} from './legacy-state';
+import {pathConvergence,type SpringAffinityEvidence,type SpringPathCandidate} from './spring-raising';
+
+export type NgPlusRelationshipHookKind='reunion'|'shared_reunion'|'possibility_hint';
+export type NgPlusRelationshipHook={
+  character:CharacterId;
+  kind:NgPlusRelationshipHookKind;
+  memoryKeys:string[];
+  summaryKey:string;
+};
+
+export type NgPlusPastLife={
+  runNumber:number;
+  campaign:CampaignId;
+  endingKey:string|null;
+  careerKey:string|null;
+  memoryKeys:string[];
+};
+
+export type NgPlusNormalCandidate=SpringPathCandidate&{legacyReasons:string[]};
+export type NgPlusSpecialCandidate={
+  id:'fifth_path_candidate';
+  kind:'special_candidate';
+  reasons:string[];
+};
+
+export type NgPlusRaisingReplay={
+  pastLife:NgPlusPastLife|null;
+  relationshipHooks:NgPlusRelationshipHook[];
+  normalCandidates:NgPlusNormalCandidate[];
+  specialCandidate:NgPlusSpecialCandidate|null;
+};
+
+const representativeByCampaign:Record<MainCampaignId,CharacterId>={
+  caretaker:'mira',
+  pathfinder:'kael',
+  vanguard:'rex',
+  arcanist:'selene',
+};
+
+const latestRun=(legacy:LegacyState):RunSummary|null=>legacy.runSummaries.at(-1)??null;
+const hasUnlock=(legacy:LegacyState,id:'past_life_dialogue'|'relationship_reunion'|'fifth_path_candidate')=>legacy.ngPlusUnlocks.includes(id);
+const isMainCampaign=(campaign:CampaignId):campaign is MainCampaignId=>(mainCampaignIds as readonly CampaignId[]).includes(campaign);
+
+function pastLifeFor(legacy:LegacyState):NgPlusPastLife|null{
+  if(!hasUnlock(legacy,'past_life_dialogue'))return null;
+  const run=latestRun(legacy);
+  if(!run)return null;
+  return {
+    runNumber:run.runNumber,
+    campaign:run.campaign,
+    endingKey:run.ending,
+    careerKey:run.career,
+    memoryKeys:run.keyBondMemories.map(item=>item.memoryId),
+  };
+}
+
+function reunionHooksFor(legacy:LegacyState):NgPlusRelationshipHook[]{
+  if(!hasUnlock(legacy,'relationship_reunion'))return [];
+  const latest=latestRun(legacy);
+  const hooks:NgPlusRelationshipHook[]=[];
+
+  for(const campaign of mainCampaignIds){
+    const character=representativeByCampaign[campaign];
+    const persisted=legacy.relationshipEchoes[character]??[];
+    const summaryMemories=(latest?.keyBondMemories??[])
+      .filter(item=>item.characterId===character)
+      .map(item=>item.memoryId);
+    const memoryKeys=[...new Set([...persisted,...summaryMemories])];
+    if(memoryKeys.length){
+      hooks.push({character,kind:'reunion',memoryKeys,summaryKey:`ngplus.reunion.${character}`});
+    }
+  }
+
+  hooks.push({character:'noa',kind:'shared_reunion',memoryKeys:[],summaryKey:'ngplus.reunion.noa.shared'});
+  hooks.push({character:'eiden',kind:'shared_reunion',memoryKeys:[],summaryKey:'ngplus.reunion.eiden.shared'});
+
+  if(hasUnlock(legacy,'fifth_path_candidate')){
+    hooks.push({character:'lyra',kind:'possibility_hint',memoryKeys:[],summaryKey:'ngplus.hint.lyra.repetition'});
+  }
+  return hooks;
+}
+
+function legacyReasonsFor(candidate:SpringPathCandidate,legacy:LegacyState):string[]{
+  const run=latestRun(legacy);
+  if(!run||!hasUnlock(legacy,'past_life_dialogue')||!isMainCampaign(run.campaign)||run.campaign!==candidate.campaign)return [];
+  const reasons=[`A past ${run.campaign} life leaves a familiar echo.`];
+  if(run.career)reasons.push('A former guardian career still feels faintly familiar.');
+  if(run.keyBondMemories.length)reasons.push('A remembered bond makes this path feel known.');
+  return reasons.slice(0,2);
+}
+
+function specialCandidateFor(legacy:LegacyState):NgPlusSpecialCandidate|null{
+  if(!hasUnlock(legacy,'fifth_path_candidate'))return null;
+  const reasons=legacy.trueClues.slice(0,2).map(clue=>`Legacy clue remembered: ${clue}.`);
+  if(reasons.length===0)reasons.push('Several past possibilities overlap in a way that did not exist before.');
+  return {id:'fifth_path_candidate',kind:'special_candidate',reasons};
+}
+
+export function resolveNgPlusRaisingReplay(
+  rawLegacy:unknown,
+  evidence:readonly SpringAffinityEvidence[],
+):NgPlusRaisingReplay{
+  const legacy=hydrateLegacyState(rawLegacy);
+  const normalCandidates=pathConvergence(evidence).map(candidate=>({
+    ...candidate,
+    legacyReasons:legacyReasonsFor(candidate,legacy),
+  }));
+  return {
+    pastLife:pastLifeFor(legacy),
+    relationshipHooks:reunionHooksFor(legacy),
+    normalCandidates,
+    specialCandidate:specialCandidateFor(legacy),
+  };
+}

--- a/src/ngplus-replay-experience.integration.test.tsx
+++ b/src/ngplus-replay-experience.integration.test.tsx
@@ -1,0 +1,99 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import NgPlusReplayHub from './NgPlusReplayHub';
+import { emptyLegacyState, type LegacyState } from './legacy-state';
+import { resolveNgPlusRaisingReplay } from './ngplus-raising';
+import { buildNgPlusWorldEchoPresentation } from './ngplus-world-echo';
+import type { SpringAffinityEvidence } from './spring-raising';
+import type { WorldHistoryState } from './world-history';
+import { buildNgPlusReplayViewModel } from './ngplus-replay-ui';
+
+const evidence: SpringAffinityEvidence[] = [
+  { campaign: 'caretaker', source: 'training', amount: 5, reason: '이번 봄에는 보호 훈련을 선택했다.' },
+  { campaign: 'pathfinder', source: 'exploration', amount: 4, reason: '이번 회차에서 새 경로를 직접 탐색했다.' },
+  { campaign: 'vanguard', source: 'tactical', amount: 2, reason: '이번 봄의 전투에서 정면 승부를 선택했다.' },
+];
+
+const legacy = (patch: Partial<LegacyState> = {}): LegacyState => ({
+  ...emptyLegacyState(),
+  completedRuns: 1,
+  completedCampaigns: ['caretaker'],
+  endingCollection: ['winter.caretaker.team_solution.victory.epilogue'],
+  careerCollection: ['winter.career.seasoned'],
+  ngPlusUnlocks: ['past_life_dialogue', 'relationship_reunion', 'world_echo', 'fifth_path_candidate'],
+  trueClues: ['caretaker_life_anomaly', 'pathfinder_world_route'],
+  runSummaries: [{
+    runNumber: 1,
+    campaign: 'caretaker',
+    route: 'normal',
+    ending: 'winter.caretaker.team_solution.victory.epilogue',
+    career: 'winter.career.seasoned',
+    majorWorldOutcomes: [],
+    keyBondMemories: [{ characterId: 'mira', memoryId: 'mira_winter_victory' }],
+    trueClues: [],
+  }],
+  relationshipEchoes: { mira: ['mira_winter_victory'] },
+  ...patch,
+});
+
+const worldHistory: WorldHistoryState = {
+  currentFacts: ['regional_alliance'],
+  inheritedFacts: ['regional_alliance', 'caretaker_team_solution', 'ancient_route_limited'],
+};
+
+describe('NG+ Macro A Replay Experience', () => {
+  it('composes past-life, reunion and inherited World echoes around a fresh authoritative Spring replay', () => {
+    const raising = resolveNgPlusRaisingReplay(legacy(), evidence);
+    const world = buildNgPlusWorldEchoPresentation(worldHistory, legacy().ngPlusUnlocks);
+    const model = buildNgPlusReplayViewModel({
+      raising,
+      world,
+      currentRunEvents: ['이번 봄의 첫 훈련을 새로 마쳤어요.', '현재 회차의 탐험 기록이 시작됐어요.'],
+    });
+
+    expect(model.normalCandidates).toHaveLength(2);
+    expect(model.normalCandidates.map(candidate => candidate.id)).toEqual(['caretaker', 'pathfinder']);
+    expect(model.specialCandidate?.id).toBe('fifth_path_candidate');
+    expect(world.currentFacts).toEqual(['regional_alliance']);
+    expect(world.inheritedEchoes.some(echo => echo.factId === 'regional_alliance')).toBe(true);
+
+    const html = renderToStaticMarkup(
+      <NgPlusReplayHub open model={model} onOpen={() => undefined} onClose={() => undefined} />,
+    );
+
+    expect(html).toContain('지난 삶의 기억');
+    expect(html).toContain('다시 만난 관계');
+    expect(html).toContain('이어진 세계의 메아리');
+    expect(html).toContain('이번 회차의 기록');
+    expect(html).toContain('Caretaker');
+    expect(html).toContain('Pathfinder');
+    expect(html).toContain('추가로 보이는 가능성');
+    expect(html).toContain('미라');
+    expect(html).toContain('노아');
+    expect(html).toContain('에이든');
+    expect(html).toContain('리라');
+    expect(html).not.toContain('베이르');
+
+    const serialized = JSON.stringify(model);
+    expect(serialized).not.toMatch(/campaignAffinities|trust\s*[:=]|rawScore|careerScore|legacyPower|threshold|bestScore|sGrades/i);
+    expect(html).not.toMatch(/affinity|trust\s*[:=]|rawScore|legacyPower|\d+\s*\/\s*100/i);
+  });
+
+  it('falls back to an ordinary fresh Spring replay when inherited presentation unlocks are absent', () => {
+    const cleanLegacy = legacy({ ngPlusUnlocks: [], runSummaries: [], relationshipEchoes: {}, trueClues: [] });
+    const raising = resolveNgPlusRaisingReplay(cleanLegacy, evidence);
+    const world = buildNgPlusWorldEchoPresentation(worldHistory, cleanLegacy.ngPlusUnlocks);
+    const model = buildNgPlusReplayViewModel({
+      raising,
+      world,
+      currentRunEvents: ['이번 회차의 봄 행동만 기록돼요.'],
+    });
+
+    expect(model.normalCandidates.length).toBeGreaterThanOrEqual(2);
+    expect(model.specialCandidate).toBeNull();
+    expect(model.journey.pastLife).toEqual([]);
+    expect(model.journey.reunions).toEqual([]);
+    expect(model.journey.worldEchoes).toEqual([]);
+    expect(model.journey.currentRun).toEqual(['이번 회차의 봄 행동만 기록돼요.']);
+  });
+});

--- a/src/ngplus-replay-mobile.test.ts
+++ b/src/ngplus-replay-mobile.test.ts
@@ -1,0 +1,29 @@
+// @ts-ignore node fs types are not included in this app tsconfig
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(new URL('./ngplus-replay.css', import.meta.url), 'utf8');
+
+describe('NG+ replay mobile/accessibility contract', () => {
+  it('keeps dynamic viewport, safe areas, touch targets and Korean wrapping', () => {
+    expect(css).toMatch(/min-height\s*:\s*100vh/);
+    expect(css).toMatch(/min-height\s*:\s*100dvh/);
+    expect(css).toContain('env(safe-area-inset-top)');
+    expect(css).toContain('env(safe-area-inset-bottom)');
+    expect(css).toMatch(/min-height\s*:\s*44px/);
+    expect(css).toContain('overflow-wrap:anywhere');
+    expect(css).toContain('word-break:keep-all');
+  });
+
+  it('has explicit 360, 390 and 430 width contracts', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*360px\)/);
+    expect(css).toMatch(/@media\s*\(max-width:\s*390px\)/);
+    expect(css).toMatch(/@media\s*\(max-width:\s*430px\)/);
+  });
+
+  it('respects reduced motion', () => {
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toContain('animation:none!important');
+    expect(css).toContain('transition:none!important');
+  });
+});

--- a/src/ngplus-replay-ui.ts
+++ b/src/ngplus-replay-ui.ts
@@ -1,0 +1,134 @@
+import type { MainCampaignId } from './campaign-model';
+import type { NgPlusRaisingReplay, NgPlusRelationshipHookKind } from './ngplus-raising';
+import type { NgPlusWorldEchoPresentation } from './ngplus-world-echo';
+import type { NgPlusReplayPathCard, NgPlusReplayViewModel } from './NgPlusReplayHub';
+
+export type NgPlusReplayUiInputs = {
+  raising: NgPlusRaisingReplay;
+  world: NgPlusWorldEchoPresentation;
+  currentRunEvents: readonly string[];
+};
+
+const campaignLabels: Record<MainCampaignId, string> = {
+  caretaker: 'Caretaker',
+  pathfinder: 'Pathfinder',
+  vanguard: 'Vanguard',
+  arcanist: 'Arcanist',
+};
+
+const tendencyLabels = {
+  faint_tendency: '희미하게 보이는 길',
+  emerging_possibility: '떠오르는 가능성',
+  strongly_opening_path: '강하게 열리는 길',
+} as const;
+
+const characterLabels: Record<string, string> = {
+  mira: '미라',
+  kael: '카엘',
+  rex: '렉스',
+  selene: '셀레네',
+  noa: '노아',
+  eiden: '에이든',
+  lyra: '리라',
+};
+
+const reunionCopy: Record<NgPlusRelationshipHookKind, (name: string) => string> = {
+  reunion: name => `${name}와 다시 마주치자, 설명하기 어려운 익숙함이 스쳐 지나가요.`,
+  shared_reunion: name => `${name}와의 만남에도 지난 가능성의 잔향이 아주 희미하게 남아 있어요.`,
+  possibility_hint: name => `${name}는 같은 순간이 한 번 더 겹친 듯한 가능성을 눈치채요.`,
+};
+
+const worldEchoCopy: Record<string, string> = {
+  'ngplus.world_echo.festival_saved': '예전에 지켜낸 축제의 기억이 이번 봄의 첫 풍경을 조금 다르게 보여줘요.',
+  'ngplus.world_echo.festival_heavy_losses': '지난 축제에 남은 상처가 이번 봄의 공기를 조용히 바꿔 놓았어요.',
+  'ngplus.world_echo.ancient_route_opened': '한 번 열었던 고대 경로가 Pathfinder의 선택에 희미한 친숙함을 남겨요.',
+  'ngplus.world_echo.ancient_route_sealed': '봉인했던 고대 경로의 기억이 다시 길을 고를 때 망설임으로 돌아와요.',
+  'ngplus.world_echo.ancient_route_limited': '제한적으로 남겨 둔 고대 경로가 이번 탐험의 숨은 단서처럼 느껴져요.',
+  'ngplus.world_echo.eiden_central_command': '한때 중앙 지휘를 택했던 세계의 기억이 권한을 바라보는 시선을 바꿔요.',
+  'ngplus.world_echo.regional_alliance': '지역 연합을 택했던 세계의 메아리가 협력의 가능성을 익숙하게 만들어요.',
+  'ngplus.world_echo.coalition_command': '연합 지휘를 세웠던 기억이 이번 회차의 협력 장면에 잔향을 남겨요.',
+  'ngplus.world_echo.forbidden_relic_used': '금지된 Relic을 사용했던 세계의 흔적이 숨은 위험을 먼저 눈치채게 해요.',
+  'ngplus.world_echo.forbidden_relic_destroyed': '금지된 Relic을 파괴했던 기억이 이번 봄의 이상 징후를 다르게 보게 해요.',
+  'ngplus.world_echo.forbidden_relic_controlled': '통제된 금지 Relic의 잔향이 Arcanist에게만 보이는 작은 균열을 남겨요.',
+  'ngplus.world_echo.rift_stabilized': '안정시킨 Rift의 기억이 이번 세계의 미세한 흔들림을 익숙하게 만들어요.',
+  'ngplus.world_echo.rift_unstable': '불안정했던 Rift의 메아리가 이번 봄의 숨은 위험을 먼저 떠올리게 해요.',
+  'ngplus.world_echo.caretaker_critical_person_saved': '끝까지 지켜낸 한 사람의 기억이 이번 Caretaker 선택에 온기를 남겨요.',
+  'ngplus.world_echo.caretaker_risk_shared': '위험을 함께 나눴던 세계의 기억이 혼자 책임지지 않는 선택을 떠올리게 해요.',
+  'ngplus.world_echo.caretaker_team_solution': '함께 해결했던 세계의 기억이 이번 봄에도 동료를 먼저 바라보게 해요.',
+};
+
+function pastLifeLines(raising: NgPlusRaisingReplay): string[] {
+  if (!raising.pastLife) return [];
+  const campaign = campaignLabels[raising.pastLife.campaign as MainCampaignId] ?? '이전';
+  const lines = [`지난 ${campaign}의 삶이 완전한 답이 아니라 희미한 기억으로 남아 있어요.`];
+  if (raising.pastLife.memoryKeys.length) lines.push('그때 맺었던 관계의 한 장면이 이름 없는 감각처럼 따라와요.');
+  if (raising.pastLife.careerKey) lines.push('예전에 걸었던 Guardian의 진로도 이번 선택을 대신하지 않는 익숙함으로만 남아요.');
+  return lines;
+}
+
+function reunionLines(raising: NgPlusRaisingReplay): string[] {
+  return raising.relationshipHooks
+    .filter(hook => hook.character !== 'veyr')
+    .map(hook => reunionCopy[hook.kind](characterLabels[hook.character] ?? '누군가'));
+}
+
+function worldEchoLines(world: NgPlusWorldEchoPresentation): string[] {
+  return world.inheritedEchoes.map(echo => worldEchoCopy[echo.presentationKey] ?? '이전 세계의 기억이 이번 회차에 아주 작은 메아리로 남아 있어요.');
+}
+
+function candidateCard(candidate: NgPlusRaisingReplay['normalCandidates'][number]): NgPlusReplayPathCard {
+  const legacyReasons = candidate.legacyReasons.map(() => '지난 삶의 익숙함이 이 길을 희미하게 알아보게 하지만, 이번 회차의 선택이 더 중요해요.');
+  return {
+    id: candidate.campaign,
+    title: campaignLabels[candidate.campaign],
+    tendency: tendencyLabels[candidate.tendency],
+    reasons: [...candidate.reasons, ...legacyReasons],
+  };
+}
+
+export function buildNgPlusReplayViewModel(input: NgPlusReplayUiInputs): NgPlusReplayViewModel {
+  const pastLife = pastLifeLines(input.raising);
+  const reunions = reunionLines(input.raising);
+  const worldEchoes = worldEchoLines(input.world);
+  const normalCandidates = input.raising.normalCandidates.map(candidateCard);
+  const firstReunion = input.raising.relationshipHooks.find(hook => hook.kind !== 'possibility_hint');
+  const vnName = firstReunion ? characterLabels[firstReunion.character] ?? '동료' : '루나';
+
+  return {
+    entry: {
+      title: '새로운 가능성',
+      previousRun: input.raising.pastLife ? '지난 삶은 하나의 기억으로 남았어요.' : '지난 결말은 닫히고, 새로운 가능성이 열렸어요.',
+      currentRun: '이번 봄의 행동과 선택은 지금부터 새로 기록돼요.',
+      cta: '새로운 봄 시작',
+    },
+    home: {
+      season: '봄 · 새로운 가능성',
+      runLabel: '현재 회차',
+      echoSummary: pastLife.length || reunions.length || worldEchoes.length
+        ? '이전 삶의 메아리는 남아 있지만, 이번 길은 새 선택으로 정해져요.'
+        : '이번 봄은 과거의 답 없이 새 선택으로 시작해요.',
+      primaryCta: 'Journey 돌아보기',
+    },
+    journey: {
+      pastLife,
+      reunions,
+      worldEchoes,
+      currentRun: [...input.currentRunEvents],
+    },
+    normalCandidates,
+    specialCandidate: input.raising.specialCandidate ? {
+      id: 'fifth_path_candidate',
+      title: '아직 이름 붙지 않은 가능성',
+      reasons: input.raising.specialCandidate.reasons.map(() => '여러 삶의 기억이 겹치며 아직 선택할 수 없는 새로운 가능성을 암시해요.'),
+    } : null,
+    vn: {
+      name: vnName,
+      dialogue: reunions.length
+        ? '처음 만나는 것 같은데, 이상하게 아주 오래전부터 알고 있던 기분이 들어.'
+        : '이번 봄은 정말 처음부터 다시 시작하는 것 같아.',
+      choices: ['이번 삶의 선택으로 답하자'],
+      log: [],
+      seen: false,
+    },
+  };
+}

--- a/src/ngplus-replay.css
+++ b/src/ngplus-replay.css
@@ -1,0 +1,24 @@
+.ngplus-replay-shell{box-sizing:border-box;min-height:100vh;min-height:100dvh;padding-top:env(safe-area-inset-top);padding-bottom:env(safe-area-inset-bottom);overflow-wrap:anywhere;word-break:keep-all}
+.ngplus-replay-shell button{min-height:44px}
+.ngplus-replay-home{display:grid;gap:12px;padding:16px;background:linear-gradient(180deg,#f4f1ff,#eef7ff)}
+.ngplus-entry-card,.ngplus-home-card,.ngplus-replay-panel section{background:#fff;border:1px solid rgba(53,42,91,.12);border-radius:18px;padding:16px;box-shadow:0 12px 30px rgba(46,35,84,.08)}
+.ngplus-entry-card small,.ngplus-replay-panel small{letter-spacing:.08em;font-weight:700}
+.ngplus-home-card button,.ngplus-vn-choices button,.ngplus-replay-header button,.ngplus-vn>button{border:0;border-radius:12px;padding:10px 14px;font:inherit}
+.ngplus-replay-backdrop{position:fixed;inset:0;z-index:70;background:rgba(19,16,36,.54);display:flex;align-items:stretch;justify-content:center}
+.ngplus-replay-panel{width:min(100%,760px);background:#f7f5ff;display:flex;flex-direction:column}
+.ngplus-replay-header{display:flex;justify-content:space-between;gap:12px;align-items:flex-start;padding:16px;border-bottom:1px solid rgba(53,42,91,.12)}
+.ngplus-replay-header button{min-width:44px}
+.ngplus-replay-scroll{overflow:auto;display:grid;gap:12px;padding:14px 14px calc(18px + env(safe-area-inset-bottom))}
+.ngplus-replay-list{display:grid;gap:8px}
+.ngplus-replay-list p{margin:0}
+.ngplus-path-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
+.ngplus-path-card,.ngplus-special-card{border:1px solid rgba(53,42,91,.14);border-radius:14px;padding:12px;background:#fbfaff}
+.ngplus-special-card{margin-top:10px;border-style:dashed}
+.ngplus-path-card ul,.ngplus-special-card ul{margin:8px 0 0;padding-left:20px}
+.ngplus-vn-stage{display:flex;gap:12px;align-items:flex-end}
+.ngplus-vn-portrait{width:96px;max-height:160px;object-fit:contain}
+.ngplus-vn-choices{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}
+@media (max-width:430px){.ngplus-replay-home{padding:14px}.ngplus-replay-scroll{padding-inline:12px}.ngplus-path-grid{grid-template-columns:1fr 1fr}}
+@media (max-width:390px){.ngplus-replay-header{padding:14px}.ngplus-entry-card,.ngplus-home-card,.ngplus-replay-panel section{padding:14px}.ngplus-path-grid{grid-template-columns:1fr}}
+@media (max-width:360px){.ngplus-replay-home{padding:10px}.ngplus-replay-scroll{padding-inline:10px}.ngplus-vn-stage{align-items:flex-start}.ngplus-vn-portrait{width:76px}}
+@media (prefers-reduced-motion: reduce){.ngplus-replay-shell *{animation:none!important;transition:none!important}}

--- a/src/ngplus-world-echo.test.ts
+++ b/src/ngplus-world-echo.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { NgPlusUnlockId } from './legacy-state';
+import { worldFactIds, type WorldHistoryState } from './world-history';
+import {
+  buildNgPlusWorldEchoPresentation,
+  ngPlusWorldEchoDefinitions,
+} from './ngplus-world-echo';
+
+const unlocked: readonly NgPlusUnlockId[] = ['world_echo'];
+
+const history = (
+  currentFacts: WorldHistoryState['currentFacts'],
+  inheritedFacts: WorldHistoryState['inheritedFacts'],
+): WorldHistoryState => ({ currentFacts, inheritedFacts });
+
+describe('NG+ world echoes', () => {
+  it('presents inherited facts as typed echoes without mixing current-run evidence', () => {
+    const result = buildNgPlusWorldEchoPresentation(
+      history(
+        ['festival_saved'],
+        ['caretaker_team_solution', 'ancient_route_limited', 'coalition_command', 'forbidden_relic_controlled'],
+      ),
+      unlocked,
+    );
+
+    expect(result.currentFacts).toEqual(['festival_saved']);
+    expect(result.inheritedEchoes).toEqual([
+      expect.objectContaining({ factId: 'caretaker_team_solution', source: 'inherited', effect: 'reward', campaign: 'caretaker' }),
+      expect.objectContaining({ factId: 'ancient_route_limited', source: 'inherited', effect: 'candidate_rationale', campaign: 'pathfinder' }),
+      expect.objectContaining({ factId: 'coalition_command', source: 'inherited', effect: 'candidate_rationale', campaign: 'vanguard' }),
+      expect.objectContaining({ factId: 'forbidden_relic_controlled', source: 'inherited', effect: 'hidden_quest', campaign: 'arcanist' }),
+    ]);
+    expect(result.normalCampaignAccessAffected).toBe(false);
+  });
+
+  it('does not expose inherited echoes before the world_echo NG+ unlock is active', () => {
+    const result = buildNgPlusWorldEchoPresentation(
+      history(['festival_saved'], ['ancient_route_opened']),
+      [],
+    );
+
+    expect(result.currentFacts).toEqual(['festival_saved']);
+    expect(result.inheritedEchoes).toEqual([]);
+    expect(result.normalCampaignAccessAffected).toBe(false);
+  });
+
+  it('keeps the same canonical fact distinct when it exists in both current and inherited history', () => {
+    const result = buildNgPlusWorldEchoPresentation(
+      history(['regional_alliance'], ['regional_alliance']),
+      unlocked,
+    );
+
+    expect(result.currentFacts).toEqual(['regional_alliance']);
+    expect(result.inheritedEchoes).toHaveLength(1);
+    expect(result.inheritedEchoes[0]).toMatchObject({
+      factId: 'regional_alliance',
+      source: 'inherited',
+      effect: 'candidate_rationale',
+      campaign: 'vanguard',
+    });
+  });
+
+  it('has exactly one deterministic presentation definition for every canonical World Fact', () => {
+    expect(Object.keys(ngPlusWorldEchoDefinitions).sort()).toEqual([...worldFactIds].sort());
+
+    for (const factId of worldFactIds) {
+      const definition = ngPlusWorldEchoDefinitions[factId];
+      expect(definition.presentationKey).toBe(`ngplus.world_echo.${factId}`);
+      expect(['flavor', 'starting_event', 'hidden_quest', 'candidate_rationale', 'reward']).toContain(definition.effect);
+      expect(definition.affectsNormalCampaignAccess).toBe(false);
+    }
+  });
+});

--- a/src/ngplus-world-echo.ts
+++ b/src/ngplus-world-echo.ts
@@ -1,0 +1,81 @@
+import type { MainCampaignId } from './campaign-model';
+import type { NgPlusUnlockId } from './legacy-state';
+import type { WorldFactId, WorldHistoryState } from './world-history';
+
+export type NgPlusWorldEchoEffect =
+  | 'flavor'
+  | 'starting_event'
+  | 'hidden_quest'
+  | 'candidate_rationale'
+  | 'reward';
+
+export type NgPlusWorldEchoDefinition = Readonly<{
+  effect: NgPlusWorldEchoEffect;
+  campaign: MainCampaignId | null;
+  presentationKey: string;
+  affectsNormalCampaignAccess: false;
+}>;
+
+export type NgPlusWorldEchoPresentationEntry = NgPlusWorldEchoDefinition & Readonly<{
+  factId: WorldFactId;
+  source: 'inherited';
+}>;
+
+export type NgPlusWorldEchoPresentation = Readonly<{
+  currentFacts: WorldFactId[];
+  inheritedEchoes: NgPlusWorldEchoPresentationEntry[];
+  normalCampaignAccessAffected: false;
+}>;
+
+const echo = (
+  factId: WorldFactId,
+  effect: NgPlusWorldEchoEffect,
+  campaign: MainCampaignId | null,
+): NgPlusWorldEchoDefinition => ({
+  effect,
+  campaign,
+  presentationKey: `ngplus.world_echo.${factId}`,
+  affectsNormalCampaignAccess: false,
+});
+
+export const ngPlusWorldEchoDefinitions: Readonly<Record<WorldFactId, NgPlusWorldEchoDefinition>> = {
+  festival_saved: echo('festival_saved', 'starting_event', null),
+  festival_heavy_losses: echo('festival_heavy_losses', 'flavor', null),
+
+  ancient_route_opened: echo('ancient_route_opened', 'candidate_rationale', 'pathfinder'),
+  ancient_route_sealed: echo('ancient_route_sealed', 'candidate_rationale', 'pathfinder'),
+  ancient_route_limited: echo('ancient_route_limited', 'candidate_rationale', 'pathfinder'),
+
+  eiden_central_command: echo('eiden_central_command', 'candidate_rationale', 'vanguard'),
+  regional_alliance: echo('regional_alliance', 'candidate_rationale', 'vanguard'),
+  coalition_command: echo('coalition_command', 'candidate_rationale', 'vanguard'),
+
+  forbidden_relic_used: echo('forbidden_relic_used', 'hidden_quest', 'arcanist'),
+  forbidden_relic_destroyed: echo('forbidden_relic_destroyed', 'hidden_quest', 'arcanist'),
+  forbidden_relic_controlled: echo('forbidden_relic_controlled', 'hidden_quest', 'arcanist'),
+  rift_stabilized: echo('rift_stabilized', 'hidden_quest', 'arcanist'),
+  rift_unstable: echo('rift_unstable', 'hidden_quest', 'arcanist'),
+
+  caretaker_critical_person_saved: echo('caretaker_critical_person_saved', 'reward', 'caretaker'),
+  caretaker_risk_shared: echo('caretaker_risk_shared', 'reward', 'caretaker'),
+  caretaker_team_solution: echo('caretaker_team_solution', 'reward', 'caretaker'),
+};
+
+export function buildNgPlusWorldEchoPresentation(
+  worldHistory: WorldHistoryState,
+  unlocks: readonly NgPlusUnlockId[],
+): NgPlusWorldEchoPresentation {
+  const inheritedEchoes = unlocks.includes('world_echo')
+    ? worldHistory.inheritedFacts.map(factId => ({
+        factId,
+        source: 'inherited' as const,
+        ...ngPlusWorldEchoDefinitions[factId],
+      }))
+    : [];
+
+  return {
+    currentFacts: [...worldHistory.currentFacts],
+    inheritedEchoes,
+    normalCampaignAccessAffected: false,
+  };
+}


### PR DESCRIPTION
Parent: #142
Final gate consumer: #144

## Macro A — NG+ Replay Experience GREEN candidate

Authoritative baseline: `integration/v3@ff6a8fe55b1b2df5d8cf1434bb9b607af4bda264`
Final Macro A head: `verify/v3-ngplus-replay-experience@08e4203fee078870ad677358e40129f31df7a5a7`
Status: **Draft / verification-only / DO NOT MERGE DIRECTLY**

### Exact frozen room candidates
- 01 Raising: `5130d28bab8ace114adc1f67ec39697f37889061` / PR #147
- 02 World: `88d30ce9b7a6c4c3c81209b95dab818cf93f3898` / PR #145
- 05 Hub: `db7c74a61b04643061dd0889090aa7ca3bf3364e` / PR #151
- exact three-parent composition commit: `fc701ffa2996a50237875c81113b149afc3497f6`

### Verified player-facing replay flow
completed prior run presentation
→ `새로운 가능성` entry
→ past-life memory / relationship reunion / inherited World Echo
→ clean Spring current-run presentation
→ ordinary qualitative Path Convergence with >=2 normal campaigns
→ optional additive `fifth_path_candidate` hint
→ Replay Home / Journey / reunion VN
→ 360 / 390 / 430 mobile/accessibility

Inherited context never becomes current-run authority. Current-run Spring candidate resolution remains authoritative, and the special candidate never replaces ordinary campaign candidates or exposes playable Fifth Path content.

### Presentation boundary
- no raw affinity values or `campaignAffinities`
- no numeric trust
- no raw career / score / threshold / Legacy-power optimization values
- current World Facts and inherited World Echoes remain separate even when the same canonical fact appears in both channels
- Mira/Kael/Rex/Selene representative reunion hooks supported
- Noa/Eiden shared reunion hooks supported
- Lyra is possibility-hint only
- Veyr excluded from ordinary NG+ reunion
- no shared NG+ archive/runNumber/reset/persist/save ownership in Macro A
- no shared `game/save/App/Root` edits from 05
- Fifth Path campaign content and Hollow remain CLOSED

### TDD / verification evidence
05 RED — CI #1672 / run `32561485516`
- existing baseline: **389 files / 1523 tests GREEN**
- only the new 05 replay UI suites failed because production Hub/CSS were intentionally absent.

05 independent GREEN — CI #1674 / run `32561574397`
- Replay Hub **4/4**
- mobile/accessibility **3/3**
- full **391/391 files, 1530/1530 tests GREEN**
- `tsc -b && vite build` GREEN, **190 modules transformed**

Macro RED — CI #1676 / run `32561911007`
- exact 01+02+05 composition existing suite: **393 files / 1543 tests GREEN**
- only new Macro E2E failed because `./ngplus-replay-ui` was intentionally absent.

Fresh final GREEN — CI #1677 / run `32561969325`
- Macro A replay E2E **2/2 GREEN**
- 01 NG+ Raising **9/9 GREEN**
- 02 NG+ World Echo **4/4 GREEN**
- 05 Replay Hub **4/4 GREEN**
- 05 mobile/accessibility **3/3 GREEN**
- Tactical stability **13/13** including AUTO 10/50/100 checkpoints
- full suite **394/394 test files, 1545/1545 tests GREEN**
- TypeScript `tsc -b` GREEN
- Vite 8.2.1 production build GREEN
- **190 modules transformed**

### Final diff isolation
Compared with exact NG+ baseline:
- ahead: **14 commits**
- behind: **0**
- changed files: **12**
  - 01: `src/ngplus-raising.ts`, `src/ngplus-raising.test.ts`
  - 02: `src/ngplus-world-echo.ts`, `src/ngplus-world-echo.test.ts`
  - 05: NG+ design/plan + `NgPlusReplayHub` + tests/CSS/mobile
  - Macro A: `src/ngplus-replay-ui.ts`, `src/ngplus-replay-experience.integration.test.tsx`
- authoritative `integration/v3` rechecked after final GREEN and remains exactly `ff6a8fe55b1b2df5d8cf1434bb9b607af4bda264`.

### Final gate ownership
Macro B #143 / 03+04+06 owns authoritative archive, runNumber, reset/persist split, Tactical/Season reset and save wiring. 06 must combine only this exact Macro A head with the exact GREEN Macro B head on #144. Do not reconstruct 01/02/05 candidates individually.