### PR TITLE
[06] NG+ shared NEW_RUN runtime verification

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -12,6 +12,8 @@ import {
 } from './tactical-encounters';
 import type { BattleResult } from './tactical-battle';
 import { grantBattleBond, type CompanionBondState, type CompanionId } from './tactical-companions';
+import { prepareNewPossibilityV3State } from './ngplus-replay';
+import { resetTacticalForNgPlus } from './tactical-ngplus-reset';
 import { hydrateTacticalPersistentState } from './tactical-state';
 import {
   emptyV3PersistentState,
@@ -156,7 +158,22 @@ export function hydrateGameState(raw:unknown):GameState {
 
 export function reducer(state:GameState,action:Action):GameState {
   if (action.type === 'RESET') return initialState;
-  if (action.type === 'NEW_RUN' || action.type === 'EVENT_CHOICE') return state;
+  if (action.type === 'NEW_RUN') {
+    const transition = prepareNewPossibilityV3State(pickV3PersistentState(state));
+    if (!transition.started) return state;
+    const tactical = resetTacticalForNgPlus(state);
+    return {
+      ...initialState,
+      ...transition.state,
+      tacticalBattleRecords:{...tactical.tacticalBattleRecords},
+      claimedTacticalFirstClears:[...tactical.claimedTacticalFirstClears],
+      selectedTacticalCompanions:[...tactical.selectedTacticalCompanions],
+      tacticalCompanionBonds:{...tactical.tacticalCompanionBonds},
+      tacticalAutoBattle:tactical.tacticalAutoBattle,
+      tacticalBattleSpeed:tactical.tacticalBattleSpeed,
+    } as GameState;
+  }
+  if (action.type === 'EVENT_CHOICE') return state;
 
   if (action.type === 'SET_TACTICAL_PARTY') {
     const companions = validParty(action.companions);


### PR DESCRIPTION
06 shared-runtime verification only.

Base Macro B RED head: `verify/v3-ngplus-replay-systems@ba9bd36446420c3385cdfdde4b1af36a5118688d`.
Shared production delta: exactly `src/game.ts` at commit `52b6c202e8a272fc4fc193d0e5ee4d23f5470736`.

Consumes already-composed 03 `prepareNewPossibilityV3State` and 04 `resetTacticalForNgPlus` contracts. No test weakening, no schema/App/Root/main/prod changes.

Gate: Macro B authoritative NEW_RUN + 3-cycle replay + save/reload + Tactical reset + full test + build GREEN before merge into Macro B verify. `integration/v3` remains frozen.