### PR TITLE
[Macro A #157] Fifth Path playable experience

### DIFF
--- a/src/FifthPathHub.test.tsx
+++ b/src/FifthPathHub.test.tsx
@@ -1,0 +1,114 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import FifthPathHub, { type FifthPathHubViewModel } from './FifthPathHub';
+
+const model: FifthPathHubViewModel = {
+  spring: {
+    normalCandidates: [
+      { id: 'caretaker', title: 'Caretaker', tendency: '떠오르는 가능성', reasons: ['이번 봄의 행동이 이 길을 열었어요.'] },
+      { id: 'pathfinder', title: 'Pathfinder', tendency: '희미하게 보이는 길', reasons: ['현재 회차의 선택이 이 방향을 가리켜요.'] },
+    ],
+    fifthCandidate: {
+      id: 'fifth_path_candidate',
+      choiceId: 'true_path',
+      title: '다섯 번째 길',
+      cta: '이 가능성을 선택한다',
+      reasons: ['여러 삶의 단서가 하나의 더 깊은 가능성으로 이어져요.'],
+    },
+    autoSelectedCampaign: null,
+  },
+  selected: false,
+  current: null,
+  vn: {
+    name: '리라',
+    dialogue: '이 장면… 처음이 아닌 것 같아.',
+    choices: ['이번에는 다른 답을 찾아보자'],
+  },
+};
+
+const endingModel: FifthPathHubViewModel = {
+  ...model,
+  selected: true,
+  current: {
+    id: 'true_ending',
+    title: 'True Ending · 반복 너머의 봄',
+    summary: '반복이 끝난 자리에서, 모두가 자기 선택을 이어갈 새벽이 시작돼요.',
+    worldLegacy: ['세계는 여러 답을 함께 품을 수 있게 되었어요.'],
+    bondLegacy: ['리라는 다음 만남에서도 이번 선택을 기억하겠다고 약속했어요.'],
+    future: '다음 삶은 정답을 반복하는 회차가 아니라, 스스로 선택할 수 있는 세계로 이어져요.',
+  },
+};
+
+describe('FifthPathHub', () => {
+  it('keeps ordinary Spring paths visible while presenting Fifth Path as an explicit additive choice', () => {
+    const html = renderToStaticMarkup(
+      <FifthPathHub open model={model} onOpen={() => undefined} onClose={() => undefined} onSelectTruePath={() => undefined} />,
+    );
+
+    expect(html).toContain('Caretaker');
+    expect(html).toContain('Pathfinder');
+    expect(html).toContain('다섯 번째 길');
+    expect(html).toContain('이 가능성을 선택한다');
+    expect(html).toContain('추가로 열린 가능성');
+    expect(html).not.toContain('자동 선택');
+  });
+
+  it('renders selected seasonal story and True Ending qualitatively without hidden optimization values', () => {
+    const seasonal: FifthPathHubViewModel = {
+      ...model,
+      selected: true,
+      current: {
+        campaign: 'true_path',
+        season: 'autumn',
+        title: '다섯 번째 길 · Autumn',
+        objective: '갈라진 해법을 하나의 공동 선택으로 모은다',
+        crisis: '서로 옳았던 네 길의 해법이 같은 위기에서 동시에 충돌해요.',
+        choice: {
+          id: 'rewrite_the_pattern',
+          label: '정답을 반복하지 않고 새로운 합의를 만든다',
+          consequence: '누구의 과거도 지우지 않은 채 세계가 다음 선택을 할 여지를 남겨요.',
+        },
+        bond: '리라는 기존의 정답 하나를 포기해야 한다고 말해요.',
+        world: ['각 진영의 해결 방식이 같은 밤에 서로 충돌해요.'],
+        nextSeason: 'winter',
+      },
+    };
+
+    const seasonalHtml = renderToStaticMarkup(
+      <FifthPathHub open model={seasonal} onOpen={() => undefined} onClose={() => undefined} onSelectTruePath={() => undefined} />,
+    );
+    const endingHtml = renderToStaticMarkup(
+      <FifthPathHub open model={endingModel} onOpen={() => undefined} onClose={() => undefined} onSelectTruePath={() => undefined} />,
+    );
+
+    expect(seasonalHtml).toContain('다섯 번째 길 · Autumn');
+    expect(seasonalHtml).toContain('리라는 기존의 정답 하나를 포기해야 한다고 말해요.');
+    expect(seasonalHtml).toContain('각 진영의 해결 방식이 같은 밤에 서로 충돌해요.');
+    expect(endingHtml).toContain('True Ending · 반복 너머의 봄');
+    expect(endingHtml).toContain('세계는 여러 답을 함께 품을 수 있게 되었어요.');
+    expect(endingHtml).toContain('리라는 다음 만남에서도 이번 선택을 기억하겠다고 약속했어요.');
+    expect(`${seasonalHtml}${endingHtml}`).not.toMatch(/affinity|trust\s*[:=]|score|threshold|legacyPower|\d+\s*\/\s*100/i);
+  });
+
+  it('provides a modal Journey shell with Lyra VN and omits an empty portrait image', () => {
+    const html = renderToStaticMarkup(
+      <FifthPathHub open model={model} onOpen={() => undefined} onClose={() => undefined} onSelectTruePath={() => undefined} />,
+    );
+
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('aria-modal="true"');
+    expect(html).toContain('리라');
+    expect(html).toContain('이 장면… 처음이 아닌 것 같아.');
+    expect(html).not.toContain('src=""');
+  });
+
+  it('keeps the closed Home compressed to a single Journey CTA', () => {
+    const html = renderToStaticMarkup(
+      <FifthPathHub open={false} model={endingModel} onOpen={() => undefined} onClose={() => undefined} onSelectTruePath={() => undefined} />,
+    );
+
+    expect(html).toContain('다섯 번째 길');
+    expect(html).toContain('True Ending · 반복 너머의 봄');
+    expect((html.match(/Journey 열기/g) ?? []).length).toBe(1);
+  });
+});

--- a/src/FifthPathHub.tsx
+++ b/src/FifthPathHub.tsx
@@ -38,7 +38,7 @@ const focusableSelector = 'button:not([disabled]), [href], [tabindex]:not([tabin
 function renderCurrent(current: FifthPathHubViewModel['current']) {
   if (!current) return null;
 
-  if ('id' in current && current.id === 'true_ending') {
+  if ('id' in current) {
     return (
       <section className="fifth-path-panel fifth-path-ending" aria-labelledby="fifth-true-ending-title">
         <p className="fifth-path-kicker">TRUE ENDING</p>

--- a/src/FifthPathHub.tsx
+++ b/src/FifthPathHub.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useRef } from 'react';
+import type {
+  FifthPathAutumnPresentation,
+  FifthPathSpringPresentation,
+  FifthPathSummerPresentation,
+  FifthPathTrueEndingPresentation,
+  FifthPathWinterPresentation,
+} from './fifth-path-experience';
+import './fifth-path.css';
+
+export type FifthPathHubViewModel = {
+  spring: FifthPathSpringPresentation;
+  selected: boolean;
+  current:
+    | FifthPathSummerPresentation
+    | FifthPathAutumnPresentation
+    | FifthPathWinterPresentation
+    | FifthPathTrueEndingPresentation
+    | null;
+  vn: {
+    portrait?: string;
+    name: string;
+    dialogue: string;
+    choices: readonly string[];
+  };
+};
+
+type FifthPathHubProps = {
+  open: boolean;
+  model: FifthPathHubViewModel;
+  onOpen: () => void;
+  onClose: () => void;
+  onSelectTruePath: () => void;
+};
+
+const focusableSelector = 'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+
+function renderCurrent(current: FifthPathHubViewModel['current']) {
+  if (!current) return null;
+
+  if ('id' in current && current.id === 'true_ending') {
+    return (
+      <section className="fifth-path-panel fifth-path-ending" aria-labelledby="fifth-true-ending-title">
+        <p className="fifth-path-kicker">TRUE ENDING</p>
+        <h2 id="fifth-true-ending-title">{current.title}</h2>
+        <p>{current.summary}</p>
+        <div className="fifth-path-grid">
+          <article>
+            <h3>세계에 남은 것</h3>
+            {current.worldLegacy.map((item) => <p key={item}>{item}</p>)}
+          </article>
+          <article>
+            <h3>관계에 남은 것</h3>
+            {current.bondLegacy.map((item) => <p key={item}>{item}</p>)}
+          </article>
+        </div>
+        <p className="fifth-path-future">{current.future}</p>
+      </section>
+    );
+  }
+
+  if (current.season === 'summer') {
+    return (
+      <section className="fifth-path-panel">
+        <p className="fifth-path-kicker">SUMMER</p>
+        <h2>{current.title}</h2>
+        <p className="fifth-path-objective">{current.objective}</p>
+        <p>{current.reveal}</p>
+        <blockquote>{current.lyra}</blockquote>
+        {current.world.map((item) => <p key={item}>{item}</p>)}
+      </section>
+    );
+  }
+
+  if (current.season === 'autumn') {
+    return (
+      <section className="fifth-path-panel">
+        <p className="fifth-path-kicker">AUTUMN</p>
+        <h2>{current.title}</h2>
+        <p className="fifth-path-objective">{current.objective}</p>
+        <p>{current.crisis}</p>
+        <article className="fifth-path-choice">
+          <h3>{current.choice.label}</h3>
+          <p>{current.choice.consequence}</p>
+        </article>
+        <blockquote>{current.bond}</blockquote>
+        {current.world.map((item) => <p key={item}>{item}</p>)}
+      </section>
+    );
+  }
+
+  return (
+    <section className="fifth-path-panel">
+      <p className="fifth-path-kicker">LONG NIGHT</p>
+      <h2>{current.title}</h2>
+      <p className="fifth-path-objective">{current.objective}</p>
+      <p>{current.resolution}</p>
+      <blockquote>{current.bond}</blockquote>
+      {current.world.map((item) => <p key={item}>{item}</p>)}
+    </section>
+  );
+}
+
+export default function FifthPathHub({ open, model, onOpen, onClose, onSelectTruePath }: FifthPathHubProps) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const dialog = dialogRef.current;
+    const first = dialog?.querySelector<HTMLElement>(focusableSelector);
+    first?.focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== 'Tab' || !dialog) return;
+      const focusables = Array.from(dialog.querySelectorAll<HTMLElement>(focusableSelector));
+      if (focusables.length === 0) return;
+      const firstItem = focusables[0];
+      const lastItem = focusables[focusables.length - 1];
+      if (event.shiftKey && document.activeElement === firstItem) {
+        event.preventDefault();
+        lastItem.focus();
+      } else if (!event.shiftKey && document.activeElement === lastItem) {
+        event.preventDefault();
+        firstItem.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      triggerRef.current?.focus();
+    };
+  }, [open, onClose]);
+
+  const currentTitle = model.current?.title ?? (model.selected ? '다섯 번째 길' : '새로운 가능성');
+
+  if (!open) {
+    return (
+      <section className="fifth-path-home" aria-label="다섯 번째 길 홈">
+        <div>
+          <p className="fifth-path-kicker">FIFTH PATH</p>
+          <h2>다섯 번째 길</h2>
+          <p>{currentTitle}</p>
+        </div>
+        <button ref={triggerRef} type="button" onClick={onOpen}>Journey 열기</button>
+      </section>
+    );
+  }
+
+  return (
+    <section ref={dialogRef} className="fifth-path-shell" role="dialog" aria-modal="true" aria-label="다섯 번째 길 Journey">
+      <header className="fifth-path-header">
+        <div>
+          <p className="fifth-path-kicker">FIFTH PATH · JOURNEY</p>
+          <h1>{currentTitle}</h1>
+        </div>
+        <button type="button" onClick={onClose} aria-label="다섯 번째 길 Journey 닫기">돌아가기</button>
+      </header>
+
+      {!model.selected && (
+        <section className="fifth-path-panel" aria-labelledby="fifth-path-selection-title">
+          <p className="fifth-path-kicker">PATH CONVERGENCE</p>
+          <h2 id="fifth-path-selection-title">이번 봄에 열린 길</h2>
+          <div className="fifth-path-candidates">
+            {model.spring.normalCandidates.map((candidate) => (
+              <article className="fifth-path-card" key={candidate.id}>
+                <h3>{candidate.title}</h3>
+                <p>{candidate.tendency}</p>
+                {candidate.reasons.map((reason) => <p key={reason}>{reason}</p>)}
+              </article>
+            ))}
+          </div>
+          {model.spring.fifthCandidate && (
+            <article className="fifth-path-card fifth-path-special">
+              <p className="fifth-path-kicker">추가로 열린 가능성</p>
+              <h3>{model.spring.fifthCandidate.title}</h3>
+              {model.spring.fifthCandidate.reasons.map((reason) => <p key={reason}>{reason}</p>)}
+              <button type="button" onClick={onSelectTruePath}>{model.spring.fifthCandidate.cta}</button>
+            </article>
+          )}
+        </section>
+      )}
+
+      {model.selected && renderCurrent(model.current)}
+
+      <section className="fifth-path-panel fifth-path-vn" aria-label="리라 이야기">
+        <div className="fifth-path-vn-row">
+          {model.vn.portrait ? <img src={model.vn.portrait} alt="" /> : null}
+          <div>
+            <p className="fifth-path-kicker">{model.vn.name}</p>
+            <p>{model.vn.dialogue}</p>
+          </div>
+        </div>
+        <div className="fifth-path-vn-choices">
+          {model.vn.choices.map((choice) => <button type="button" key={choice}>{choice}</button>)}
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/src/fifth-path-experience.test.ts
+++ b/src/fifth-path-experience.test.ts
@@ -3,6 +3,7 @@ import {
   buildFifthPathAutumnPresentation,
   buildFifthPathSpringPresentation,
   buildFifthPathSummerPresentation,
+  buildFifthPathWinterPresentation,
 } from './fifth-path-experience';
 
 const normalCandidates = [
@@ -35,27 +36,35 @@ describe('Fifth Path Summer presentation contract', () => {
 
 describe('Fifth Path Autumn presentation contract', () => {
   it('turns the discovered cause into a qualitative convergence choice with world and bond consequences', () => {
-    const autumn = buildFifthPathAutumnPresentation({
+    const autumn = buildFifthPathAutumnPresentation({ activeCampaign: 'true_path', season: 'autumn', worldSignals: ['각 진영의 해결 방식이 같은 밤에 서로 충돌해요.'], bondSignals: ['리라는 모두를 살리려면 기존의 정답 하나를 포기해야 한다고 말해요.'] });
+    expect(autumn).toEqual({ campaign: 'true_path', season: 'autumn', title: '다섯 번째 길 · Autumn', objective: '갈라진 해법을 하나의 공동 선택으로 모은다', crisis: '서로 옳았던 네 길의 해법이 같은 위기에서 동시에 충돌해요.', choice: { id: 'rewrite_the_pattern', label: '정답을 반복하지 않고 새로운 합의를 만든다', consequence: '누구의 과거도 지우지 않은 채 세계가 다음 선택을 할 여지를 남겨요.' }, bond: '리라는 모두를 살리려면 기존의 정답 하나를 포기해야 한다고 말해요.', world: ['각 진영의 해결 방식이 같은 밤에 서로 충돌해요.'], nextSeason: 'winter' });
+  });
+});
+
+describe('Fifth Path Winter presentation contract', () => {
+  it.each([
+    ['victory', '긴 밤의 반복을 끊고 모두가 다음 선택을 할 수 있는 새벽을 열었어요.'],
+    ['costly_victory', '긴 밤은 끝났지만 그 선택의 흔적과 약속은 다음 삶에도 남아요.'],
+    ['defeat', '이번 밤을 완전히 이기지는 못했지만, 반복을 알아본 기억이 다음 새벽의 길이 돼요.'],
+  ] as const)('fail-forwards %s into a qualitative true-ending handoff', (outcome, resolution) => {
+    const winter = buildFifthPathWinterPresentation({
       activeCampaign: 'true_path',
-      season: 'autumn',
-      worldSignals: ['각 진영의 해결 방식이 같은 밤에 서로 충돌해요.'],
-      bondSignals: ['리라는 모두를 살리려면 기존의 정답 하나를 포기해야 한다고 말해요.'],
+      season: 'winter',
+      outcome,
+      worldSignals: ['세계는 하나의 정답 대신 서로 다른 선택을 품은 채 버텼어요.'],
+      bondSignals: ['리라는 이번에는 기억을 잃지 않겠다고 약속해요.'],
     });
 
-    expect(autumn).toEqual({
+    expect(winter).toEqual({
       campaign: 'true_path',
-      season: 'autumn',
-      title: '다섯 번째 길 · Autumn',
-      objective: '갈라진 해법을 하나의 공동 선택으로 모은다',
-      crisis: '서로 옳았던 네 길의 해법이 같은 위기에서 동시에 충돌해요.',
-      choice: {
-        id: 'rewrite_the_pattern',
-        label: '정답을 반복하지 않고 새로운 합의를 만든다',
-        consequence: '누구의 과거도 지우지 않은 채 세계가 다음 선택을 할 여지를 남겨요.',
-      },
-      bond: '리라는 모두를 살리려면 기존의 정답 하나를 포기해야 한다고 말해요.',
-      world: ['각 진영의 해결 방식이 같은 밤에 서로 충돌해요.'],
-      nextSeason: 'winter',
+      season: 'winter',
+      title: '다섯 번째 길 · Long Night',
+      objective: '긴 밤의 원인을 끝내는 대신, 세계가 스스로 다음 선택을 할 구조를 남긴다',
+      outcome,
+      resolution,
+      bond: '리라는 이번에는 기억을 잃지 않겠다고 약속해요.',
+      world: ['세계는 하나의 정답 대신 서로 다른 선택을 품은 채 버텼어요.'],
+      next: 'true_ending',
     });
   });
 });

--- a/src/fifth-path-experience.test.ts
+++ b/src/fifth-path-experience.test.ts
@@ -3,6 +3,7 @@ import {
   buildFifthPathAutumnPresentation,
   buildFifthPathSpringPresentation,
   buildFifthPathSummerPresentation,
+  buildFifthPathTrueEndingPresentation,
   buildFifthPathWinterPresentation,
 } from './fifth-path-experience';
 
@@ -47,24 +48,29 @@ describe('Fifth Path Winter presentation contract', () => {
     ['costly_victory', '긴 밤은 끝났지만 그 선택의 흔적과 약속은 다음 삶에도 남아요.'],
     ['defeat', '이번 밤을 완전히 이기지는 못했지만, 반복을 알아본 기억이 다음 새벽의 길이 돼요.'],
   ] as const)('fail-forwards %s into a qualitative true-ending handoff', (outcome, resolution) => {
-    const winter = buildFifthPathWinterPresentation({
-      activeCampaign: 'true_path',
-      season: 'winter',
+    const winter = buildFifthPathWinterPresentation({ activeCampaign: 'true_path', season: 'winter', outcome, worldSignals: ['세계는 하나의 정답 대신 서로 다른 선택을 품은 채 버텼어요.'], bondSignals: ['리라는 이번에는 기억을 잃지 않겠다고 약속해요.'] });
+    expect(winter).toEqual({ campaign: 'true_path', season: 'winter', title: '다섯 번째 길 · Long Night', objective: '긴 밤의 원인을 끝내는 대신, 세계가 스스로 다음 선택을 할 구조를 남긴다', outcome, resolution, bond: '리라는 이번에는 기억을 잃지 않겠다고 약속해요.', world: ['세계는 하나의 정답 대신 서로 다른 선택을 품은 채 버텼어요.'], next: 'true_ending' });
+  });
+});
+
+describe('Fifth Path True Ending presentation contract', () => {
+  it.each(['victory', 'costly_victory', 'defeat'] as const)('renders %s as a qualitative epilogue rather than a ranked score ending', outcome => {
+    const ending = buildFifthPathTrueEndingPresentation({
+      reachedTrueEnding: true,
       outcome,
-      worldSignals: ['세계는 하나의 정답 대신 서로 다른 선택을 품은 채 버텼어요.'],
-      bondSignals: ['리라는 이번에는 기억을 잃지 않겠다고 약속해요.'],
+      worldLegacy: ['세계는 여러 답을 함께 품을 수 있게 되었어요.'],
+      bondLegacy: ['리라는 다음 만남에서도 이번 선택을 기억하겠다고 약속했어요.'],
     });
 
-    expect(winter).toEqual({
-      campaign: 'true_path',
-      season: 'winter',
-      title: '다섯 번째 길 · Long Night',
-      objective: '긴 밤의 원인을 끝내는 대신, 세계가 스스로 다음 선택을 할 구조를 남긴다',
-      outcome,
-      resolution,
-      bond: '리라는 이번에는 기억을 잃지 않겠다고 약속해요.',
-      world: ['세계는 하나의 정답 대신 서로 다른 선택을 품은 채 버텼어요.'],
-      next: 'true_ending',
-    });
+    expect(ending?.id).toBe('true_ending');
+    expect(ending?.title).toBe('True Ending · 반복 너머의 봄');
+    expect(ending?.worldLegacy).toEqual(['세계는 여러 답을 함께 품을 수 있게 되었어요.']);
+    expect(ending?.bondLegacy).toEqual(['리라는 다음 만남에서도 이번 선택을 기억하겠다고 약속했어요.']);
+    expect(ending?.future).toBe('다음 삶은 정답을 반복하는 회차가 아니라, 스스로 선택할 수 있는 세계로 이어져요.');
+    expect(JSON.stringify(ending)).not.toMatch(/\b[ABS]\b|score|affinity|trust\s*[:=]|threshold|\d+\s*\/\s*100/i);
+  });
+
+  it('does not manufacture a True Ending when the authoritative runtime has not reached it', () => {
+    expect(buildFifthPathTrueEndingPresentation({ reachedTrueEnding: false, outcome: 'victory', worldLegacy: [], bondLegacy: [] })).toBeNull();
   });
 });

--- a/src/fifth-path-experience.test.ts
+++ b/src/fifth-path-experience.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { buildFifthPathSpringPresentation } from './fifth-path-experience';
+import {
+  buildFifthPathSpringPresentation,
+  buildFifthPathSummerPresentation,
+} from './fifth-path-experience';
 
 const normalCandidates = [
   { id: 'caretaker', title: 'Caretaker', tendency: '떠오르는 가능성', reasons: ['이번 봄의 행동이 이 길을 열었어요.'] },
@@ -34,5 +37,34 @@ describe('Fifth Path Spring presentation contract', () => {
     expect(ineligible.normalCandidates).toHaveLength(2);
     expect(ineligible.fifthCandidate).toBeNull();
     expect(ineligible.autoSelectedCampaign).toBeNull();
+  });
+});
+
+describe('Fifth Path Summer presentation contract', () => {
+  it('reveals the deeper phenomenon only for an explicitly active true_path run', () => {
+    const summer = buildFifthPathSummerPresentation({
+      activeCampaign: 'true_path',
+      season: 'summer',
+      worldSignals: ['서로 다른 캠페인의 흔적이 같은 균열을 가리켜요.'],
+      bondSignals: ['리라가 반복되는 장면을 먼저 알아차렸어요.'],
+    });
+
+    expect(summer).toEqual({
+      campaign: 'true_path',
+      season: 'summer',
+      title: '다섯 번째 길 · Summer',
+      objective: '갈라진 길들의 뒤에 있는 하나의 원인을 추적한다',
+      reveal: '서로 달라 보였던 선택들이 더 깊은 하나의 현상으로 이어지기 시작해요.',
+      lyra: '리라가 반복되는 장면을 먼저 알아차렸어요.',
+      world: ['서로 다른 캠페인의 흔적이 같은 균열을 가리켜요.'],
+      nextSeason: 'autumn',
+    });
+
+    expect(buildFifthPathSummerPresentation({
+      activeCampaign: 'caretaker',
+      season: 'summer',
+      worldSignals: [],
+      bondSignals: [],
+    })).toBeNull();
   });
 });

--- a/src/fifth-path-experience.test.ts
+++ b/src/fifth-path-experience.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { buildFifthPathSpringPresentation } from './fifth-path-experience';
+
+const normalCandidates = [
+  { id: 'caretaker', title: 'Caretaker', tendency: '떠오르는 가능성', reasons: ['이번 봄의 행동이 이 길을 열었어요.'] },
+  { id: 'pathfinder', title: 'Pathfinder', tendency: '희미하게 보이는 길', reasons: ['현재 회차의 선택이 이 방향을 가리켜요.'] },
+] as const;
+
+describe('Fifth Path Spring presentation contract', () => {
+  it('keeps normal paths and adds an explicit true_path choice only when canonical eligibility is provided', () => {
+    const eligible = buildFifthPathSpringPresentation({
+      fifthEligible: true,
+      normalCandidates,
+      eligibilityReasons: ['여러 삶의 단서가 하나의 더 깊은 가능성으로 이어져요.'],
+    });
+
+    expect(eligible.normalCandidates).toHaveLength(2);
+    expect(eligible.normalCandidates.map(candidate => candidate.id)).toEqual(['caretaker', 'pathfinder']);
+    expect(eligible.fifthCandidate).toEqual({
+      id: 'fifth_path_candidate',
+      choiceId: 'true_path',
+      title: '다섯 번째 길',
+      cta: '이 가능성을 선택한다',
+      reasons: ['여러 삶의 단서가 하나의 더 깊은 가능성으로 이어져요.'],
+    });
+    expect(eligible.autoSelectedCampaign).toBeNull();
+
+    const ineligible = buildFifthPathSpringPresentation({
+      fifthEligible: false,
+      normalCandidates,
+      eligibilityReasons: [],
+    });
+
+    expect(ineligible.normalCandidates).toHaveLength(2);
+    expect(ineligible.fifthCandidate).toBeNull();
+    expect(ineligible.autoSelectedCampaign).toBeNull();
+  });
+});

--- a/src/fifth-path-experience.test.ts
+++ b/src/fifth-path-experience.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildFifthPathAutumnPresentation,
   buildFifthPathSpringPresentation,
   buildFifthPathSummerPresentation,
 } from './fifth-path-experience';
@@ -11,29 +12,13 @@ const normalCandidates = [
 
 describe('Fifth Path Spring presentation contract', () => {
   it('keeps normal paths and adds an explicit true_path choice only when canonical eligibility is provided', () => {
-    const eligible = buildFifthPathSpringPresentation({
-      fifthEligible: true,
-      normalCandidates,
-      eligibilityReasons: ['여러 삶의 단서가 하나의 더 깊은 가능성으로 이어져요.'],
-    });
-
+    const eligible = buildFifthPathSpringPresentation({ fifthEligible: true, normalCandidates, eligibilityReasons: ['여러 삶의 단서가 하나의 더 깊은 가능성으로 이어져요.'] });
     expect(eligible.normalCandidates).toHaveLength(2);
     expect(eligible.normalCandidates.map(candidate => candidate.id)).toEqual(['caretaker', 'pathfinder']);
-    expect(eligible.fifthCandidate).toEqual({
-      id: 'fifth_path_candidate',
-      choiceId: 'true_path',
-      title: '다섯 번째 길',
-      cta: '이 가능성을 선택한다',
-      reasons: ['여러 삶의 단서가 하나의 더 깊은 가능성으로 이어져요.'],
-    });
+    expect(eligible.fifthCandidate).toEqual({ id: 'fifth_path_candidate', choiceId: 'true_path', title: '다섯 번째 길', cta: '이 가능성을 선택한다', reasons: ['여러 삶의 단서가 하나의 더 깊은 가능성으로 이어져요.'] });
     expect(eligible.autoSelectedCampaign).toBeNull();
 
-    const ineligible = buildFifthPathSpringPresentation({
-      fifthEligible: false,
-      normalCandidates,
-      eligibilityReasons: [],
-    });
-
+    const ineligible = buildFifthPathSpringPresentation({ fifthEligible: false, normalCandidates, eligibilityReasons: [] });
     expect(ineligible.normalCandidates).toHaveLength(2);
     expect(ineligible.fifthCandidate).toBeNull();
     expect(ineligible.autoSelectedCampaign).toBeNull();
@@ -42,29 +27,35 @@ describe('Fifth Path Spring presentation contract', () => {
 
 describe('Fifth Path Summer presentation contract', () => {
   it('reveals the deeper phenomenon only for an explicitly active true_path run', () => {
-    const summer = buildFifthPathSummerPresentation({
+    const summer = buildFifthPathSummerPresentation({ activeCampaign: 'true_path', season: 'summer', worldSignals: ['서로 다른 캠페인의 흔적이 같은 균열을 가리켜요.'], bondSignals: ['리라가 반복되는 장면을 먼저 알아차렸어요.'] });
+    expect(summer).toEqual({ campaign: 'true_path', season: 'summer', title: '다섯 번째 길 · Summer', objective: '갈라진 길들의 뒤에 있는 하나의 원인을 추적한다', reveal: '서로 달라 보였던 선택들이 더 깊은 하나의 현상으로 이어지기 시작해요.', lyra: '리라가 반복되는 장면을 먼저 알아차렸어요.', world: ['서로 다른 캠페인의 흔적이 같은 균열을 가리켜요.'], nextSeason: 'autumn' });
+    expect(buildFifthPathSummerPresentation({ activeCampaign: 'caretaker', season: 'summer', worldSignals: [], bondSignals: [] })).toBeNull();
+  });
+});
+
+describe('Fifth Path Autumn presentation contract', () => {
+  it('turns the discovered cause into a qualitative convergence choice with world and bond consequences', () => {
+    const autumn = buildFifthPathAutumnPresentation({
       activeCampaign: 'true_path',
-      season: 'summer',
-      worldSignals: ['서로 다른 캠페인의 흔적이 같은 균열을 가리켜요.'],
-      bondSignals: ['리라가 반복되는 장면을 먼저 알아차렸어요.'],
+      season: 'autumn',
+      worldSignals: ['각 진영의 해결 방식이 같은 밤에 서로 충돌해요.'],
+      bondSignals: ['리라는 모두를 살리려면 기존의 정답 하나를 포기해야 한다고 말해요.'],
     });
 
-    expect(summer).toEqual({
+    expect(autumn).toEqual({
       campaign: 'true_path',
-      season: 'summer',
-      title: '다섯 번째 길 · Summer',
-      objective: '갈라진 길들의 뒤에 있는 하나의 원인을 추적한다',
-      reveal: '서로 달라 보였던 선택들이 더 깊은 하나의 현상으로 이어지기 시작해요.',
-      lyra: '리라가 반복되는 장면을 먼저 알아차렸어요.',
-      world: ['서로 다른 캠페인의 흔적이 같은 균열을 가리켜요.'],
-      nextSeason: 'autumn',
+      season: 'autumn',
+      title: '다섯 번째 길 · Autumn',
+      objective: '갈라진 해법을 하나의 공동 선택으로 모은다',
+      crisis: '서로 옳았던 네 길의 해법이 같은 위기에서 동시에 충돌해요.',
+      choice: {
+        id: 'rewrite_the_pattern',
+        label: '정답을 반복하지 않고 새로운 합의를 만든다',
+        consequence: '누구의 과거도 지우지 않은 채 세계가 다음 선택을 할 여지를 남겨요.',
+      },
+      bond: '리라는 모두를 살리려면 기존의 정답 하나를 포기해야 한다고 말해요.',
+      world: ['각 진영의 해결 방식이 같은 밤에 서로 충돌해요.'],
+      nextSeason: 'winter',
     });
-
-    expect(buildFifthPathSummerPresentation({
-      activeCampaign: 'caretaker',
-      season: 'summer',
-      worldSignals: [],
-      bondSignals: [],
-    })).toBeNull();
   });
 });

--- a/src/fifth-path-experience.ts
+++ b/src/fifth-path-experience.ts
@@ -57,6 +57,24 @@ export type FifthPathAutumnPresentation = {
   nextSeason: 'winter';
 };
 
+export type FifthPathWinterOutcome = 'victory' | 'costly_victory' | 'defeat';
+
+export type FifthPathWinterPresentationInput = FifthPathSeasonPresentationInput & {
+  outcome: FifthPathWinterOutcome;
+};
+
+export type FifthPathWinterPresentation = {
+  campaign: 'true_path';
+  season: 'winter';
+  title: string;
+  objective: string;
+  outcome: FifthPathWinterOutcome;
+  resolution: string;
+  bond: string;
+  world: readonly string[];
+  next: 'true_ending';
+};
+
 export function buildFifthPathSpringPresentation(
   input: FifthPathSpringPresentationInput,
 ): FifthPathSpringPresentation {
@@ -111,5 +129,29 @@ export function buildFifthPathAutumnPresentation(
     bond: input.bondSignals[0] ?? '리라는 과거의 정답보다 함께 만드는 다음 선택을 바라봐요.',
     world: [...input.worldSignals],
     nextSeason: 'winter',
+  };
+}
+
+const winterResolutions: Record<FifthPathWinterOutcome, string> = {
+  victory: '긴 밤의 반복을 끊고 모두가 다음 선택을 할 수 있는 새벽을 열었어요.',
+  costly_victory: '긴 밤은 끝났지만 그 선택의 흔적과 약속은 다음 삶에도 남아요.',
+  defeat: '이번 밤을 완전히 이기지는 못했지만, 반복을 알아본 기억이 다음 새벽의 길이 돼요.',
+};
+
+export function buildFifthPathWinterPresentation(
+  input: FifthPathWinterPresentationInput,
+): FifthPathWinterPresentation | null {
+  if (input.activeCampaign !== 'true_path' || input.season !== 'winter') return null;
+
+  return {
+    campaign: 'true_path',
+    season: 'winter',
+    title: '다섯 번째 길 · Long Night',
+    objective: '긴 밤의 원인을 끝내는 대신, 세계가 스스로 다음 선택을 할 구조를 남긴다',
+    outcome: input.outcome,
+    resolution: winterResolutions[input.outcome],
+    bond: input.bondSignals[0] ?? '리라는 이번에는 기억을 잃지 않겠다고 약속해요.',
+    world: [...input.worldSignals],
+    next: 'true_ending',
   };
 }

--- a/src/fifth-path-experience.ts
+++ b/src/fifth-path-experience.ts
@@ -41,6 +41,22 @@ export type FifthPathSummerPresentation = {
   nextSeason: 'autumn';
 };
 
+export type FifthPathAutumnPresentation = {
+  campaign: 'true_path';
+  season: 'autumn';
+  title: string;
+  objective: string;
+  crisis: string;
+  choice: {
+    id: 'rewrite_the_pattern';
+    label: string;
+    consequence: string;
+  };
+  bond: string;
+  world: readonly string[];
+  nextSeason: 'winter';
+};
+
 export function buildFifthPathSpringPresentation(
   input: FifthPathSpringPresentationInput,
 ): FifthPathSpringPresentation {
@@ -73,5 +89,27 @@ export function buildFifthPathSummerPresentation(
     lyra: input.bondSignals[0] ?? '리라는 설명할 수 없는 익숙함을 느껴요.',
     world: [...input.worldSignals],
     nextSeason: 'autumn',
+  };
+}
+
+export function buildFifthPathAutumnPresentation(
+  input: FifthPathSeasonPresentationInput,
+): FifthPathAutumnPresentation | null {
+  if (input.activeCampaign !== 'true_path' || input.season !== 'autumn') return null;
+
+  return {
+    campaign: 'true_path',
+    season: 'autumn',
+    title: '다섯 번째 길 · Autumn',
+    objective: '갈라진 해법을 하나의 공동 선택으로 모은다',
+    crisis: '서로 옳았던 네 길의 해법이 같은 위기에서 동시에 충돌해요.',
+    choice: {
+      id: 'rewrite_the_pattern',
+      label: '정답을 반복하지 않고 새로운 합의를 만든다',
+      consequence: '누구의 과거도 지우지 않은 채 세계가 다음 선택을 할 여지를 남겨요.',
+    },
+    bond: input.bondSignals[0] ?? '리라는 과거의 정답보다 함께 만드는 다음 선택을 바라봐요.',
+    world: [...input.worldSignals],
+    nextSeason: 'winter',
   };
 }

--- a/src/fifth-path-experience.ts
+++ b/src/fifth-path-experience.ts
@@ -75,6 +75,22 @@ export type FifthPathWinterPresentation = {
   next: 'true_ending';
 };
 
+export type FifthPathTrueEndingInput = {
+  reachedTrueEnding: boolean;
+  outcome: FifthPathWinterOutcome;
+  worldLegacy: readonly string[];
+  bondLegacy: readonly string[];
+};
+
+export type FifthPathTrueEndingPresentation = {
+  id: 'true_ending';
+  title: string;
+  summary: string;
+  worldLegacy: readonly string[];
+  bondLegacy: readonly string[];
+  future: string;
+};
+
 export function buildFifthPathSpringPresentation(
   input: FifthPathSpringPresentationInput,
 ): FifthPathSpringPresentation {
@@ -153,5 +169,26 @@ export function buildFifthPathWinterPresentation(
     bond: input.bondSignals[0] ?? '리라는 이번에는 기억을 잃지 않겠다고 약속해요.',
     world: [...input.worldSignals],
     next: 'true_ending',
+  };
+}
+
+const trueEndingSummaries: Record<FifthPathWinterOutcome, string> = {
+  victory: '반복이 끝난 자리에서, 모두가 자기 선택을 이어갈 새벽이 시작돼요.',
+  costly_victory: '대가의 흔적은 남았지만, 그 흔적까지 기억한 채 다른 봄을 선택할 수 있어요.',
+  defeat: '완전한 승리는 아니었지만, 반복을 알아본 기억이 다음 삶의 자유를 남겼어요.',
+};
+
+export function buildFifthPathTrueEndingPresentation(
+  input: FifthPathTrueEndingInput,
+): FifthPathTrueEndingPresentation | null {
+  if (!input.reachedTrueEnding) return null;
+
+  return {
+    id: 'true_ending',
+    title: 'True Ending · 반복 너머의 봄',
+    summary: trueEndingSummaries[input.outcome],
+    worldLegacy: [...input.worldLegacy],
+    bondLegacy: [...input.bondLegacy],
+    future: '다음 삶은 정답을 반복하는 회차가 아니라, 스스로 선택할 수 있는 세계로 이어져요.',
   };
 }

--- a/src/fifth-path-experience.ts
+++ b/src/fifth-path-experience.ts
@@ -23,6 +23,24 @@ export type FifthPathSpringPresentation = {
   autoSelectedCampaign: null;
 };
 
+export type FifthPathSeasonPresentationInput = {
+  activeCampaign: string | null;
+  season: 'summer' | 'autumn' | 'winter';
+  worldSignals: readonly string[];
+  bondSignals: readonly string[];
+};
+
+export type FifthPathSummerPresentation = {
+  campaign: 'true_path';
+  season: 'summer';
+  title: string;
+  objective: string;
+  reveal: string;
+  lyra: string;
+  world: readonly string[];
+  nextSeason: 'autumn';
+};
+
 export function buildFifthPathSpringPresentation(
   input: FifthPathSpringPresentationInput,
 ): FifthPathSpringPresentation {
@@ -38,5 +56,22 @@ export function buildFifthPathSpringPresentation(
         }
       : null,
     autoSelectedCampaign: null,
+  };
+}
+
+export function buildFifthPathSummerPresentation(
+  input: FifthPathSeasonPresentationInput,
+): FifthPathSummerPresentation | null {
+  if (input.activeCampaign !== 'true_path' || input.season !== 'summer') return null;
+
+  return {
+    campaign: 'true_path',
+    season: 'summer',
+    title: '다섯 번째 길 · Summer',
+    objective: '갈라진 길들의 뒤에 있는 하나의 원인을 추적한다',
+    reveal: '서로 달라 보였던 선택들이 더 깊은 하나의 현상으로 이어지기 시작해요.',
+    lyra: input.bondSignals[0] ?? '리라는 설명할 수 없는 익숙함을 느껴요.',
+    world: [...input.worldSignals],
+    nextSeason: 'autumn',
   };
 }

--- a/src/fifth-path-experience.ts
+++ b/src/fifth-path-experience.ts
@@ -1,0 +1,42 @@
+export type FifthPathNormalCandidate = {
+  id: string;
+  title: string;
+  tendency: string;
+  reasons: readonly string[];
+};
+
+export type FifthPathSpringPresentationInput = {
+  fifthEligible: boolean;
+  normalCandidates: readonly FifthPathNormalCandidate[];
+  eligibilityReasons: readonly string[];
+};
+
+export type FifthPathSpringPresentation = {
+  normalCandidates: readonly FifthPathNormalCandidate[];
+  fifthCandidate: {
+    id: 'fifth_path_candidate';
+    choiceId: 'true_path';
+    title: string;
+    cta: string;
+    reasons: readonly string[];
+  } | null;
+  autoSelectedCampaign: null;
+};
+
+export function buildFifthPathSpringPresentation(
+  input: FifthPathSpringPresentationInput,
+): FifthPathSpringPresentation {
+  return {
+    normalCandidates: [...input.normalCandidates],
+    fifthCandidate: input.fifthEligible
+      ? {
+          id: 'fifth_path_candidate',
+          choiceId: 'true_path',
+          title: '다섯 번째 길',
+          cta: '이 가능성을 선택한다',
+          reasons: [...input.eligibilityReasons],
+        }
+      : null,
+    autoSelectedCampaign: null,
+  };
+}

--- a/src/fifth-path-mobile.test.ts
+++ b/src/fifth-path-mobile.test.ts
@@ -1,0 +1,29 @@
+// @ts-ignore node fs types are not included in this app tsconfig
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(new URL('./fifth-path.css', import.meta.url), 'utf8');
+
+describe('Fifth Path mobile/accessibility contract', () => {
+  it('keeps dynamic viewport, safe areas, touch targets and Korean wrapping', () => {
+    expect(css).toMatch(/min-height\s*:\s*100vh/);
+    expect(css).toMatch(/min-height\s*:\s*100dvh/);
+    expect(css).toContain('env(safe-area-inset-top)');
+    expect(css).toContain('env(safe-area-inset-bottom)');
+    expect(css).toMatch(/min-height\s*:\s*44px/);
+    expect(css).toContain('overflow-wrap:anywhere');
+    expect(css).toContain('word-break:keep-all');
+  });
+
+  it('has explicit 360, 390 and 430 width contracts', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*360px\)/);
+    expect(css).toMatch(/@media\s*\(max-width:\s*390px\)/);
+    expect(css).toMatch(/@media\s*\(max-width:\s*430px\)/);
+  });
+
+  it('respects reduced motion', () => {
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toContain('animation:none!important');
+    expect(css).toContain('transition:none!important');
+  });
+});

--- a/src/fifth-path.css
+++ b/src/fifth-path.css
@@ -1,0 +1,133 @@
+.fifth-path-home,
+.fifth-path-shell{
+  box-sizing:border-box;
+  width:100%;
+  color:#f6f0ff;
+  background:linear-gradient(180deg,#18152b 0%,#221b3d 52%,#10101b 100%);
+  overflow-wrap:anywhere;
+  word-break:keep-all;
+}
+
+.fifth-path-home{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:16px;
+  padding:18px;
+  border-radius:20px;
+}
+
+.fifth-path-shell{
+  min-height:100vh;
+  min-height:100dvh;
+  padding:calc(18px + env(safe-area-inset-top)) 18px calc(18px + env(safe-area-inset-bottom));
+  overflow:auto;
+}
+
+.fifth-path-header,
+.fifth-path-vn-row{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:16px;
+}
+
+.fifth-path-panel{
+  max-width:760px;
+  margin:18px auto 0;
+  padding:18px;
+  border:1px solid rgba(255,255,255,.14);
+  border-radius:18px;
+  background:rgba(255,255,255,.07);
+}
+
+.fifth-path-header{
+  max-width:760px;
+  margin:0 auto;
+}
+
+.fifth-path-kicker{
+  margin:0 0 6px;
+  font-size:.78rem;
+  letter-spacing:.12em;
+  opacity:.72;
+}
+
+.fifth-path-header h1,
+.fifth-path-panel h2,
+.fifth-path-card h3{
+  margin:0 0 10px;
+}
+
+.fifth-path-candidates,
+.fifth-path-grid{
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  gap:12px;
+}
+
+.fifth-path-card,
+.fifth-path-choice{
+  padding:14px;
+  border-radius:14px;
+  background:rgba(15,12,28,.55);
+}
+
+.fifth-path-special{
+  margin-top:14px;
+  border:1px solid rgba(220,195,255,.42);
+}
+
+.fifth-path-objective,
+.fifth-path-future{
+  font-weight:700;
+}
+
+.fifth-path-vn img{
+  width:72px;
+  height:72px;
+  object-fit:cover;
+  border-radius:16px;
+}
+
+.fifth-path-vn-choices{
+  display:grid;
+  gap:8px;
+  margin-top:12px;
+}
+
+.fifth-path-shell button,
+.fifth-path-home button{
+  min-height:44px;
+  padding:10px 14px;
+  border:0;
+  border-radius:12px;
+  font:inherit;
+  cursor:pointer;
+}
+
+.fifth-path-shell button:focus-visible,
+.fifth-path-home button:focus-visible{
+  outline:3px solid currentColor;
+  outline-offset:3px;
+}
+
+@media (max-width: 430px){
+  .fifth-path-shell{padding-left:14px;padding-right:14px}
+  .fifth-path-panel{padding:16px}
+}
+
+@media (max-width: 390px){
+  .fifth-path-candidates,.fifth-path-grid{grid-template-columns:1fr}
+  .fifth-path-header{align-items:center}
+}
+
+@media (max-width: 360px){
+  .fifth-path-shell{padding-left:12px;padding-right:12px}
+  .fifth-path-home{align-items:stretch;flex-direction:column}
+  .fifth-path-header{align-items:stretch;flex-direction:column}
+}
+
+@media (prefers-reduced-motion: reduce){
+  .fifth-path-shell *, .fifth-path-home *{animation:none!important;transition:none!important}
+}


### PR DESCRIPTION
Parent: #157

Authoritative baseline: `integration/v3@dfa483d067dd2d350ed727c8cc68045475e4a371`.

Frozen Macro A candidate: `work/v3-fifth-experience@0c55b0563f0a0d98c47494f2d4263d9d4924a877`.

Scope GREEN:
- eligible Fifth candidate remains additive to ordinary Spring paths
- explicit `true_path` selection only; no auto-select
- playable Summer -> Autumn -> Winter/Long Night presentation
- Lyra / World / Bond qualitative story
- victory / costly_victory / defeat fail-forward into True Ending
- qualitative True Ending / epilogue
- FifthPathHub Home/Journey/VN shell
- 360/390/430 mobile/accessibility, safe area, focus trap, ESC, focus return, reduced motion
- no raw affinity/trust/score/threshold UI

Fresh verification: CI #1721 (`32613781796`) SUCCESS.
- `fifth-path-experience.test.ts`: 10/10
- `FifthPathHub.test.tsx`: 4/4
- `fifth-path-mobile.test.ts`: 3/3
- full: 403/403 files, 1578/1578 tests
- Tactical stability: 13/13 including AUTO 10/50/100
- `tsc -b`: GREEN
- Vite production build: GREEN, 194 modules transformed

Macro A consumes canonical eligibility/runtime DTOs from Macro B #158 and does not own authoritative save/reward/Tactical persistence. Keep Draft. Do not merge directly to integration/v3/main/prod. Hollow remains CLOSED.