### PR TITLE
[00] V3 Production Release Gate

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
Single-room production release gate for V3 RC.

Baseline RC: `integration/v3@43463d0d0d84b7ccfb4cb5696492c058e51eac88`

This PR intentionally changes only Vercel build reproducibility:
- `npm ci`
- `npm run build`
- output `dist`

No gameplay/runtime/save changes. No production promotion from this PR without explicit user approval.

Gate: preview deployment must build from this exact head, serve HTTP 200, load emitted assets, and show no deployment/runtime errors before any production decision.