### PR TITLE
V3.1 hotfix: make telemetry function Node ESM-safe

### DIFF
--- a/api/client-telemetry.test.ts
+++ b/api/client-telemetry.test.ts
@@ -1,3 +1,4 @@
+import {readFileSync} from 'node:fs';
 import {afterEach,describe,expect,it,vi} from 'vitest';
 import handler from './client-telemetry';
 
@@ -14,6 +15,12 @@ function response():MockResponse{
 afterEach(()=>vi.restoreAllMocks());
 
 describe('/api/client-telemetry',()=>{
+  it('uses a Node ESM-safe runtime import for the shared telemetry contract',()=>{
+    const source=readFileSync(new URL('./client-telemetry.ts',import.meta.url),'utf8');
+    expect(source).toContain("from '../src/client-telemetry-contract.js'");
+    expect(source).not.toContain("from '../src/client-telemetry-contract';");
+  });
+
   it('serves a GET health check',async()=>{
     const res=response();
     await handler({method:'GET'},res);

--- a/api/client-telemetry.ts
+++ b/api/client-telemetry.ts
@@ -1,4 +1,4 @@
-import {parseClientTelemetryPayload} from '../src/client-telemetry-contract';
+import {parseClientTelemetryPayload} from '../src/client-telemetry-contract.js';
 
 type TelemetryRequest = {method?:string;body?:unknown};
 type TelemetryResponse = {


### PR DESCRIPTION
Production smoke found `/api/client-telemetry` returning 500 because the Vercel Function's compiled Node ESM entrypoint could not resolve the extensionless shared contract import. This PR starts with a regression test that requires a Node ESM-safe `.js` import specifier before applying the minimal runtime fix.