### PR TITLE
Release V7 Mobile UX Cleanup to main

### DIFF
--- a/docs/superpowers/plans/2026-08-26-v7-mobile-ux.md
+++ b/docs/superpowers/plans/2026-08-26-v7-mobile-ux.md
@@ -1,0 +1,194 @@
+# V7 Mobile UX Cleanup / Home Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the crowded mobile home with a readable six-category navigation system, cohesive custom icons, consistent typography/controls, and progressive disclosure without changing game progression semantics.
+
+**Architecture:** `LayeredHome` remains the presentation owner and the sole consumer of `hubNextAction`. A new semantic navigation layer maps `홈 / 생활 / 성장 / 모험 / 인연 / 기록` to existing callbacks and `HomeMenuId` destinations. New SVG icons and CSS tokens provide a single mobile visual language, while Weekly/Lineage/World details move out of the default home and into category sheets.
+
+**Tech Stack:** React 19, TypeScript, CSS, Vitest, Vite.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-puppy-maker-v7-mobile-ux-design.md`
+
+## Global Constraints
+- Work only on `work/v7-mobile-ux` until final gate.
+- `hubNextAction(state)` remains the one authoritative primary CTA selector.
+- Save schema and reducer/game progression semantics are unchanged.
+- Existing `HomeMenuId` destinations/callbacks remain internally compatible.
+- Navigation labels are exactly `홈 / 생활 / 성장 / 모험 / 인연 / 기록`.
+- No actionable text below 14px; essential status/body text >=13px.
+- Touch targets >=44px; primary CTA >=52px; list/secondary buttons >=48px.
+- Mobile contracts: 360×640, 390×844, 430px class, safe-area, `100dvh`, reduced motion.
+- No force push and no release promotion before fresh CI/build evidence.
+
+---
+
+### Task 1: Lock V7 information architecture with RED contracts
+
+**Files:**
+- Create: `src/v7-mobile-home-architecture.test.tsx`
+- Inspect: `src/LayeredHome.tsx`
+- Inspect: `src/layered-home.css`
+
+**Interfaces:**
+- Produces source/UI contracts used by every later task.
+- Requires exactly six semantic category labels and one authoritative `.lh-primary-action`.
+
+- [ ] Write failing source/render contracts asserting that current home does not yet expose six semantic categories, still contains legacy shortcuts/promos, and still renders the full weekly planner on the default scene.
+- [ ] Push the RED-only test commit and verify PR CI fails only for the new V7 contract.
+- [ ] Do not modify production code until the RED failure is observed.
+
+### Task 2: Add shared mobile design tokens and custom SVG icon system
+
+**Files:**
+- Create: `src/mobile-ui-tokens.css`
+- Create: `src/MobileNavIcon.tsx`
+- Create: `src/v7-mobile-icons.test.tsx`
+- Modify: `src/layered-home.css`
+
+**Interfaces:**
+- `type MobileNavIconName = 'home'|'life'|'growth'|'adventure'|'bond'|'records'|'bell'|'chevron'`
+- `MobileNavIcon({name, className?})` renders a 24×24 rounded-stroke SVG using `currentColor`.
+- CSS variables: `--ui-text-caption`, `--ui-text-small`, `--ui-text-body`, `--ui-text-button`, `--ui-text-subtitle`, `--ui-text-title`, `--ui-text-display`, plus touch/radius/surface tokens.
+
+- [ ] Write RED tests for all six icon names, `currentColor`, 24×24 viewBox, and token values.
+- [ ] Implement the minimal icon component and token stylesheet.
+- [ ] Import tokens into layered-home styles.
+- [ ] Run targeted tests and build; fix only V7 token/icon failures.
+
+### Task 3: Build compact home status header
+
+**Files:**
+- Create: `src/MobileHomeStatus.tsx`
+- Create: `src/v7-mobile-home-status.test.tsx`
+- Modify: `src/layered-home.css`
+
+**Interfaces:**
+- Props: `state: GameState`, `notificationCount: number`, `onNotifications: () => void`.
+- Renders generation/year/month/week, gold, gems, stamina, short guardian status and optional notification affordance.
+
+- [ ] Write RED render contracts for readable status copy and conditional notification badge.
+- [ ] Implement display-only component; no reducer mutation.
+- [ ] Add safe-area-aware compact styling with >=13px essential text and >=44px notification target.
+- [ ] Verify targeted tests/build GREEN.
+
+### Task 4: Build six-category mobile navigation and category sheet
+
+**Files:**
+- Create: `src/MobileCategorySheet.tsx`
+- Create: `src/v7-mobile-category-sheet.test.tsx`
+- Modify: `src/LayeredHome.tsx`
+- Modify: `src/layered-home.css`
+
+**Interfaces:**
+- `type MobileCategoryId = 'home'|'life'|'growth'|'adventure'|'bond'|'records'`.
+- Category navigation labels: `홈 / 생활 / 성장 / 모험 / 인연 / 기록`.
+- Sheet receives existing destination callbacks instead of dispatching game state directly.
+
+- [ ] Write RED contracts for six category items, icon+text labels, selected-state semantics and home-close behavior.
+- [ ] Implement six-item bottom navigation with 44px+ hit targets.
+- [ ] Implement parchment/glass category sheet with grouped entry cards and 48px+ controls.
+- [ ] Map `생활` to weekly planner/schedule/mission/attendance/mail.
+- [ ] Map `성장` to achievements/status/season.
+- [ ] Map `모험` to outing and Expedition/Tactical.
+- [ ] Map `인연` to bond/gifts/story event.
+- [ ] Map `기록` to lineage/world/collection records.
+- [ ] Verify no seventh permanent content category is introduced.
+
+### Task 5: Refactor default LayeredHome to one-action composition
+
+**Files:**
+- Modify: `src/LayeredHome.tsx`
+- Modify: `src/layered-home.css`
+- Modify: `src/layered-home-mobile.css`
+- Test: `src/v7-mobile-home-architecture.test.tsx`
+
+**Interfaces:**
+- Keeps existing `runPrimaryTask()` behavior and `hubNextAction(state)` source.
+- Uses `MobileHomeStatus` and semantic category state.
+
+- [ ] Remove always-visible `.lh-shortcuts` row from the default scene.
+- [ ] Remove always-visible `.lh-promos` and `.lh-goal` decision surfaces.
+- [ ] Remove permanent full `WeeklyPlannerCard` from default home.
+- [ ] Preserve Luna scene and affection interaction.
+- [ ] Keep exactly one `.lh-primary-action` with >=52px height and >=15px main label.
+- [ ] Simplify Luna dialogue to a readable compact context line that cannot overlap primary CTA/nav.
+- [ ] Run architecture test and existing LayeredHome tests.
+
+### Task 6: Move weekly planning under 생활 and chronicles under 기록
+
+**Files:**
+- Modify: `src/WeeklyPlannerCard.tsx`
+- Modify: `src/MobileCategorySheet.tsx`
+- Modify: `src/lineage-chronicle.css`
+- Modify: `src/world-chronicle.css`
+- Create: `src/v7-mobile-progressive-disclosure.test.tsx`
+
+**Interfaces:**
+- Weekly select/complete/advance callbacks are unchanged.
+- `LineageChronicle` and `WorldChronicle` retain existing state/event contracts.
+
+- [ ] Write RED contract proving weekly focus grid and chronicles are not present on default home but are reachable in their semantic categories.
+- [ ] Add planner content to 생활 detail presentation.
+- [ ] Render Lineage/World Chronicle in 기록 presentation only.
+- [ ] Ensure chronology actions do not become a competing home primary CTA.
+- [ ] Verify reducer-focused weekly/lineage/world tests remain GREEN.
+
+### Task 7: Normalize home-launched panel typography and controls
+
+**Files:**
+- Modify: `src/layered-home.css`
+- Modify: `src/hub-flow-mobile.css`
+- Modify: `src/layered-home-mobile.css`
+- Create: `src/v7-mobile-typography.test.ts`
+
+**Interfaces:**
+- Uses only shared V7 token variables for important home/panel text sizes.
+
+- [ ] Write RED source contracts rejecting important 8px/9px home action labels and requiring shared tokens.
+- [ ] Replace important shortcut/panel/action text sizing with 13/15/17/21px token hierarchy.
+- [ ] Normalize panel headers, list rows, close button and badges.
+- [ ] Keep 12px only for nonessential eyebrow/caption text.
+- [ ] Verify long Korean text wraps intentionally and no control depends on tiny text to fit.
+
+### Task 8: Mobile layout and accessibility hardening
+
+**Files:**
+- Create: `src/v7-mobile-layout-contract.test.ts`
+- Modify: `src/layered-home.css`
+- Modify: `src/layered-home-mobile.css`
+
+**Interfaces:**
+- CSS contracts for 360×640, 390×844 and 430px-class widths.
+
+- [ ] Write RED contracts for safe-area, `100dvh`, reduced-motion, six-item nav hit areas and reserved primary/nav bands.
+- [ ] Replace conflicting percentage offsets with explicit safe layout bands where needed.
+- [ ] Ensure no horizontal overflow and no primary/dialogue/nav overlap contract.
+- [ ] Preserve `focus-visible`, Escape close and focus return behavior.
+- [ ] Run all targeted V7 UI tests.
+
+### Task 9: Full regression and source-candidate gate
+
+**Files:**
+- No new feature code unless a regression is demonstrated.
+
+- [ ] Run full Vitest suite in PR CI.
+- [ ] Verify TypeScript and Vite production build.
+- [ ] Verify audit 0 vulnerabilities.
+- [ ] Confirm V3/V4/V5/V6, Spring/Summer/Autumn/Winter/Fifth/Hollow/NG+ tests remain GREEN.
+- [ ] Inspect final PR diff for accidental reducer/save changes.
+- [ ] Mark PR ready only after all evidence is fresh for exact work head.
+
+### Task 10: Integration, main and production gate
+
+**Files:**
+- No feature edits expected.
+
+- [ ] Merge exact verified work head to `integration/v3` without force.
+- [ ] Open `integration/v3 → main` release PR and verify synthetic merge CI.
+- [ ] Merge only after release CI is GREEN.
+- [ ] Verify exact main push CI.
+- [ ] Verify exact main SHA Vercel production deployment is READY.
+- [ ] Smoke production root and `/api/client-telemetry` for HTTP 200.
+- [ ] Check production runtime `error`/`fatal` logs.
+- [ ] Close V7 tracking issue only after production evidence is complete.

--- a/docs/superpowers/specs/2026-08-26-puppy-maker-v7-mobile-ux-design.md
+++ b/docs/superpowers/specs/2026-08-26-puppy-maker-v7-mobile-ux-design.md
@@ -1,7 +1,7 @@
 # V7 Mobile UX Cleanup / Home Simplification — Design
 
 ## Goal
-Rebuild the mobile-first home and major interactive panels so players can immediately understand what to do next, read every important label comfortably, and avoid overlapping or duplicated controls on 360px, 390px, and 430px-class phones.
+Rebuild the mobile-first home and major interactive panels so players can immediately understand what to do next, read every important label comfortably, and navigate the expanded game through clear categories without overlapping or duplicated controls on 360px, 390px, and 430px-class phones.
 
 ## Baseline
 - production main: `0166df866e51fae6e320edd5cc76dd5d166b3a57`
@@ -12,32 +12,126 @@ Rebuild the mobile-first home and major interactive panels so players can immedi
 ## Problems confirmed in current code
 1. `LayeredHome` simultaneously renders rank, currency/stamina, weather, RunGuidance, WeeklyPlanner, four shortcut buttons, collection goal, two promo buttons, the authoritative primary action, Luna dialogue, and five bottom-nav buttons. That creates too many simultaneous decision surfaces on mobile.
 2. The home uses many absolute-positioned percentage blocks. `lh-shortcuts`, `lh-goal`, `lh-primary-action`, `lh-dialogue`, `lh-bottom-nav`, `lh-weekly-planner`, and companion cards can visually compete or overlap as viewport height changes.
-3. Font sizes vary widely and include very small values such as 8px/9px/10px in actionable and explanatory UI. This is below the desired mobile reading comfort for a game designed mobile-first.
-4. WeeklyPlanner currently renders seven focus buttons plus Lineage Chronicle and World Chronicle directly in the same home flow, increasing control density.
-5. Overlay/panel content inherits multiple ad-hoc text sizes and button styles instead of a small shared mobile type/button scale.
+3. Font sizes vary widely and include very small values such as 8px/9px/10px in actionable and explanatory UI.
+4. WeeklyPlanner renders seven focus buttons plus Lineage Chronicle and World Chronicle directly in the same home flow.
+5. Existing bottom categories (`스케줄 / 가방 / 퀘스트 / 외출 / 교감`) describe individual features, not the now-larger game domains, so new systems accumulate as duplicate shortcuts and floating cards.
 
-## Design principles
-### 1. One dominant action
-`hubNextAction(state)` remains the only authoritative home primary action. V7 must not add a second prominent CTA competing with it.
+## Information architecture — six clear mobile categories
+The bottom navigation becomes six semantic destinations. Labels stay short enough for 360px while each category is broad enough to remain stable as the game grows.
 
-### 2. Progressive disclosure
-The home should show only the information needed for the next decision. Detailed weekly focus choices, chronicles, achievements, mail, collection detail, and long-form records move behind a single expandable/action-sheet style surface rather than being fully expanded at once.
+### 1. 홈
+Purpose: only the current situation and the single most important action.
+- compact generation/year/month/week status
+- gold / gems / stamina
+- current Luna/context line
+- exactly one authoritative `hubNextAction(state)` CTA
+- notification badge only when there is actionable mail/attendance/reward information
 
-### 3. Four mobile layers
-The default home is organized conceptually into four layers:
-- **Status bar:** generation/year/month/week, stamina, gold/gems, guardian rank in compact readable form.
-- **Primary task card:** `hubNextAction` label and short detail, one large action.
-- **Today/This week summary:** compact summary of weekly plan, Luna relationship/status, and active world/generation signals with at most 2 secondary buttons visible.
-- **Navigation:** five bottom destinations remain, but shortcut duplication above them is removed or folded into a single `더보기`/utility entry.
+### 2. 생활
+Purpose: time management and routine progression.
+- weekly plan and weekly focus
+- schedule
+- monthly focus / monthly missions
+- attendance
+- mail / routine notices
+- week/month advancement context
 
-### 4. Utility consolidation
-The four top shortcuts (`출석체크`, `이벤트`, `우편함`, `미션`) and the two promo circles are not all shown simultaneously. They are consolidated into one compact utility launcher with badges for actionable items. Existing destinations and reducer behavior stay intact.
+### 3. 성장
+Purpose: raising and long-term character progression.
+- growth achievements
+- mastery / talents / guardian rank / career records already exposed by current panels
+- season progression entry
+- inventory/status information that supports raising
 
-### 5. Weekly planner simplification
-The home no longer shows all seven weekly focus buttons at once. The compact weekly card shows current selection/status and one `이번 주 계획` secondary action. Opening it reveals the seven focus choices in a sheet/panel. `LineageChronicle` and `WorldChronicle` remain available but are collapsed under history/world sections rather than permanently occupying the home stack.
+### 4. 모험
+Purpose: leaving home to actively play content.
+- outing
+- Expedition
+- Tactical
+- world/campaign activity entry points
+- generational public project progress where it is actionable
 
-### 6. Mobile typography tokens
-Introduce a small shared mobile scale used by home and major home-launched panels:
+### 5. 인연
+Purpose: Luna and character relationships.
+- bond / affection
+- gifts
+- character story/event archive
+- living NPC relationship context
+
+### 6. 기록
+Purpose: history, collection and multi-generation records.
+- Lineage Chronicle
+- World Chronicle
+- memories / discoveries / collection summary
+- campaign/ending history where already available
+
+The navigation labels are exactly `홈 / 생활 / 성장 / 모험 / 인연 / 기록`.
+
+## Navigation behavior
+- Home is not an overlay; selecting `홈` closes category/detail sheets and returns to the clean scene.
+- The other five categories open a large mobile category sheet with 2–4 clearly grouped destinations rather than placing every destination on the home scene.
+- Existing `HomeMenuId` destinations remain internally valid for compatibility. New semantic categories map to them instead of deleting reducer or callback behavior.
+- Category sheets use progressive disclosure: category overview → detail panel. Do not show every system at once.
+
+## Icon and visual language
+V7 creates an in-app SVG icon system instead of adding mismatched raster assets.
+
+### Six primary icons
+- `home`: cottage/roof + small star accent — safe return / current place
+- `life`: calendar page + sun dot — weekly/monthly routine
+- `growth`: sprout + upward spark — raising/progression
+- `adventure`: compass/waypoint — expedition/exploration
+- `bond`: heart + paw accent — relationships
+- `records`: open book + constellation spark — history/archive
+
+### Icon rules
+- shared `24×24` viewBox
+- 1.8–2px rounded stroke, `currentColor`
+- no text baked into icon assets
+- inactive: warm ivory line at reduced opacity
+- active: gold/cream foreground plus subtle filled circular/rounded backing
+- notification badge is separate from the icon
+- minimum rendered icon 22px on bottom navigation; category-sheet icons 24–28px
+- selected state must also use shape/background/label weight, not color alone
+
+### Visual tone
+Keep the existing warm fantasy home scene, parchment/gold language and Luna character art. V7 makes the chrome quieter and cleaner instead of replacing the game's visual identity.
+- dark translucent navigation glass over the scene
+- warm parchment sheets for detailed reading
+- gold only for focus/selection/reward, not every control
+- fewer ornamental frames around small controls
+- cards use consistent radius/shadow/border tokens
+
+## Default home composition
+The default mobile home has only four persistent interactive zones.
+1. **Compact status header** — generation/year/month/week, currency, stamina, guardian rank, notification icon.
+2. **Luna scene** — character remains the visual center and can still be tapped for affection feedback.
+3. **Primary task card** — `hubNextAction` label and short detail, exactly one large action.
+4. **Six-item bottom navigation** — `홈 / 생활 / 성장 / 모험 / 인연 / 기록`.
+
+The existing always-visible shortcut row, promo circles, collection goal panel, full weekly planner, Lineage Chronicle and World Chronicle are removed from the default scene.
+
+## Home status
+Create a compact status surface rather than separate rank/currency/weather frames.
+- first line: `N세대 · X년차 · M월 W주차`
+- second line: gold, gems, stamina
+- guardian rank as a small readable chip or short label
+- one notification bell/message affordance only when actionable; notification access routes to the correct semantic category/detail instead of becoming a seventh content category
+
+## Weekly planner simplification
+- Weekly planning lives under `생활`.
+- Home never renders all seven weekly focus buttons.
+- `생활` overview shows current week, selected focus and completion state.
+- `이번 주 계획` opens the seven focus choices in a dedicated sheet/detail region.
+- select/complete/advance reducer semantics remain unchanged.
+
+## Records simplification
+- `LineageChronicle` and `WorldChronicle` move to the `기록` category.
+- They are not permanently rendered on home.
+- The records overview may show one short summary for generation/legacy, then expandable/detail content.
+
+## Mobile typography tokens
+Create shared tokens used by home, category sheets and home-launched detail panels.
 - `--ui-text-caption: 12px`
 - `--ui-text-small: 13px`
 - `--ui-text-body: 15px`
@@ -47,67 +141,73 @@ Introduce a small shared mobile scale used by home and major home-launched panel
 - `--ui-text-display: 24px`
 
 Rules:
-- Actionable button text must not be below 14px; primary/secondary button labels target 15px+.
-- Essential status/body text must not be below 13px.
-- 12px is reserved for nonessential captions/eyebrows only.
-- Existing 8px/9px home labels are removed from important content.
-- Line height uses at least 1.35 for body copy.
+- actionable button text must not be below 14px
+- primary/secondary labels target 15px+
+- essential status/body text must not be below 13px
+- 12px only for nonessential captions/eyebrows
+- remove current 8px/9px important home labels
+- body line-height >= 1.35
 
-### 7. Shared control tokens
-- minimum touch target: 44px × 44px
-- primary button min-height: 52px
-- secondary/list button min-height: 48px
-- sheet close button: 44px
-- consistent radius, padding, focus-visible outline, pressed state
-- controls that are not immediate binary settings must not masquerade as toggles
+## Shared control tokens
+- minimum touch target: `44px × 44px`
+- primary button min-height: `52px`
+- secondary/list button min-height: `48px`
+- bottom navigation target: at least `48px` high with 44px hit area
+- sheet close button: `44px`
+- consistent radius, padding, focus-visible outline and pressed state
+- no decorative toggle treatment for non-binary actions
 
-### 8. Layout safety
-The home remains 9:16/mobile-first but should rely less on independent overlapping absolute blocks. The scene/character can remain layered, while interactive UI is placed in deliberate top / middle / bottom bands with reserved space.
+## Layout safety
+The scene can remain layered/absolute, but interactive chrome uses reserved top/middle/bottom bands rather than independently overlapping percentage blocks.
 
 Viewport contracts:
-- 360×640
-- 390×844
-- 430px-class width
+- `360×640`
+- `390×844`
+- `430px` class
 - `100dvh`
-- safe-area top/bottom/left/right
+- all safe-area insets
 - no horizontal overflow
 - no primary-action/dialogue/nav overlap
-- long Korean labels wrap or truncate intentionally
-
-### 9. Desktop compatibility
-Desktop is secondary. V7 must not make the existing desktop shell unusable, but no desktop-specific redesign is required. Wider viewports should center the same mobile-first composition rather than introduce a different information architecture.
+- six bottom items remain independently tappable
+- long Korean labels wrap/truncate intentionally
 
 ## Proposed component boundaries
-### `MobileHomeStatus`
-Compact display-only status summary. No navigation authority.
+### `MobileNavIcon`
+Reusable SVG icon renderer for the six category icons and common utility icons.
 
-### `HomeUtilitySheet`
-Owns utility destinations previously shown as multiple top shortcuts/promos. It calls existing `openMenu` destinations; no game-state mutations are duplicated.
+### `MobileHomeStatus`
+Compact display-only status summary plus actionable notification affordance. No game progression authority.
+
+### `MobileCategorySheet`
+Semantic category overview for `생활 / 성장 / 모험 / 인연 / 기록`. Routes to existing destinations/callbacks and can host compact records/planner content.
 
 ### `WeeklyPlannerCard`
-Supports compact mode on home. Detailed focus grid is rendered only when its planner panel/sheet is open.
+Gains a detail/compact composition suitable for the `생활` category. It no longer owns persistent home placement.
 
 ### `LayeredHome`
-Continues to own presentation state and `openMenu`. It consumes `hubNextAction` and renders exactly one prominent primary action.
+Owns presentation state, semantic category state and existing `openMenu`. It still consumes `hubNextAction` and renders exactly one prominent primary action.
 
 ### Shared CSS tokens
-Add a focused mobile UI token stylesheet and reuse it from layered-home / planner / chronicle / home panel CSS. No dependency/framework replacement.
+Add `mobile-ui-tokens.css` and apply it to layered home, category sheets, planner, chronicles and home panels.
 
 ## Interaction behavior
-1. Player lands on home and sees current status + one obvious next action.
-2. If the player wants a different activity, bottom navigation remains available.
-3. Utility notifications are represented by one utility launcher/badge rather than four always-visible shortcut buttons.
-4. Weekly planning opens into a dedicated panel/sheet; choosing a focus closes or updates the detail state without adding another persistent home control row.
-5. Home-launched panels use consistent title/body/button typography and fixed close-target behavior.
+1. Player lands on home and sees status, Luna and one obvious next action.
+2. Bottom navigation changes semantic category, not individual low-level feature.
+3. Category overview explains what belongs there and presents only the most useful sub-destinations.
+4. Existing detail panels remain reachable through category destinations.
+5. `홈` always closes open category/detail presentation state.
+6. Notification badge opens the relevant existing reward/detail destination; it does not duplicate content.
+7. Focus returns correctly when detail dialogs close.
 
 ## Accessibility
-- preserve focus return on panel close
-- Escape closes dialogs where currently supported
+- preserve focus return on detail panel close
+- Escape closes modal/detail layers where currently supported
 - `aria-modal`, labels, pressed/current states preserved
+- every navigation item has visible text plus icon
 - no touch target below 44px
 - visible focus outline
 - `prefers-reduced-motion: reduce` disables nonessential transitions/animations
-- color is not the only indication of selected/available state
+- color is not the only selected/available indication
 
 ## Compatibility invariants
 - `hubNextAction` remains authoritative and unique
@@ -115,30 +215,36 @@ Add a focused mobile UI token stylesheet and reuse it from layered-home / planne
 - save schema unchanged
 - V3/V4/V5/V6 systems unchanged
 - NG+/generation/True/Hollow rules unchanged
-- existing menu IDs and callbacks remain valid
+- existing `HomeMenuId` and callbacks remain valid internally
 - no raw progression reset or migration
 
 ## Testing strategy
-### Source/UI contract tests
+### Source/UI contracts
+- navigation labels exactly contain `홈 / 생활 / 성장 / 모험 / 인연 / 기록`
+- six semantic nav items each have icon + label and >=44px hit target
 - exactly one `.lh-primary-action`
-- no always-visible legacy shortcut cluster on <=430px
-- utility launcher exposes existing destinations
-- weekly focus grid is hidden from default compact home and available in planner detail
-- actionable home/panel text uses tokenized size classes/variables instead of 8px/9px hard-coded values
-- mobile control minimum heights are 44/48/52px as designed
+- legacy shortcut cluster and promo circles are absent from default mobile home
+- full weekly focus grid is absent from default home
+- Lineage/World Chronicle are absent from default home and available in records category
+- actionable home/panel text uses shared token values rather than 8px/9px important labels
 - safe-area and reduced-motion declarations exist
 
-### Functional tests
-- every existing shortcut destination still opens
+### Functional contracts
+- home nav closes category/detail surfaces
+- life category can reach schedule, weekly planner, missions, attendance and mail
+- growth category can reach achievements/status/season progression
+- adventure category can reach outing and Expedition/Tactical callbacks
+- bond category can reach bond and story/event content
+- records category renders lineage/world records
 - `hubNextAction` routing remains unchanged
-- weekly select/complete/advance still works
-- panel focus/close behavior still works
+- weekly select/complete/advance remains unchanged
+- panel focus/close behavior remains intact
 
 ### Regression
 - full Vitest suite
 - TypeScript build
 - Vite production build
-- existing mobile tests for Spring/Summer/Autumn/Winter/Fifth/Hollow/NG+ remain green
+- existing Spring/Summer/Autumn/Winter/Fifth/Hollow/NG+/V4/V5/V6 tests remain green
 
 ## Release gate
 RED contracts → minimal refactor → targeted UI tests → full regression/build → preview visual smoke → integration tree verification → release PR synthetic CI → exact main push CI → exact Vercel production SHA → root/API 200 → production runtime error/fatal log check.

--- a/docs/superpowers/specs/2026-08-26-puppy-maker-v7-mobile-ux-design.md
+++ b/docs/superpowers/specs/2026-08-26-puppy-maker-v7-mobile-ux-design.md
@@ -1,0 +1,144 @@
+# V7 Mobile UX Cleanup / Home Simplification — Design
+
+## Goal
+Rebuild the mobile-first home and major interactive panels so players can immediately understand what to do next, read every important label comfortably, and avoid overlapping or duplicated controls on 360px, 390px, and 430px-class phones.
+
+## Baseline
+- production main: `0166df866e51fae6e320edd5cc76dd5d166b3a57`
+- integration baseline: `bec20da540c3417cb804c06f85224bc18cc0d258`
+- shared tree: `63256404d8f484b30745aefac1bd8d7560e6939a`
+- work branch: `work/v7-mobile-ux`
+
+## Problems confirmed in current code
+1. `LayeredHome` simultaneously renders rank, currency/stamina, weather, RunGuidance, WeeklyPlanner, four shortcut buttons, collection goal, two promo buttons, the authoritative primary action, Luna dialogue, and five bottom-nav buttons. That creates too many simultaneous decision surfaces on mobile.
+2. The home uses many absolute-positioned percentage blocks. `lh-shortcuts`, `lh-goal`, `lh-primary-action`, `lh-dialogue`, `lh-bottom-nav`, `lh-weekly-planner`, and companion cards can visually compete or overlap as viewport height changes.
+3. Font sizes vary widely and include very small values such as 8px/9px/10px in actionable and explanatory UI. This is below the desired mobile reading comfort for a game designed mobile-first.
+4. WeeklyPlanner currently renders seven focus buttons plus Lineage Chronicle and World Chronicle directly in the same home flow, increasing control density.
+5. Overlay/panel content inherits multiple ad-hoc text sizes and button styles instead of a small shared mobile type/button scale.
+
+## Design principles
+### 1. One dominant action
+`hubNextAction(state)` remains the only authoritative home primary action. V7 must not add a second prominent CTA competing with it.
+
+### 2. Progressive disclosure
+The home should show only the information needed for the next decision. Detailed weekly focus choices, chronicles, achievements, mail, collection detail, and long-form records move behind a single expandable/action-sheet style surface rather than being fully expanded at once.
+
+### 3. Four mobile layers
+The default home is organized conceptually into four layers:
+- **Status bar:** generation/year/month/week, stamina, gold/gems, guardian rank in compact readable form.
+- **Primary task card:** `hubNextAction` label and short detail, one large action.
+- **Today/This week summary:** compact summary of weekly plan, Luna relationship/status, and active world/generation signals with at most 2 secondary buttons visible.
+- **Navigation:** five bottom destinations remain, but shortcut duplication above them is removed or folded into a single `더보기`/utility entry.
+
+### 4. Utility consolidation
+The four top shortcuts (`출석체크`, `이벤트`, `우편함`, `미션`) and the two promo circles are not all shown simultaneously. They are consolidated into one compact utility launcher with badges for actionable items. Existing destinations and reducer behavior stay intact.
+
+### 5. Weekly planner simplification
+The home no longer shows all seven weekly focus buttons at once. The compact weekly card shows current selection/status and one `이번 주 계획` secondary action. Opening it reveals the seven focus choices in a sheet/panel. `LineageChronicle` and `WorldChronicle` remain available but are collapsed under history/world sections rather than permanently occupying the home stack.
+
+### 6. Mobile typography tokens
+Introduce a small shared mobile scale used by home and major home-launched panels:
+- `--ui-text-caption: 12px`
+- `--ui-text-small: 13px`
+- `--ui-text-body: 15px`
+- `--ui-text-button: 15px`
+- `--ui-text-subtitle: 17px`
+- `--ui-text-title: 21px`
+- `--ui-text-display: 24px`
+
+Rules:
+- Actionable button text must not be below 14px; primary/secondary button labels target 15px+.
+- Essential status/body text must not be below 13px.
+- 12px is reserved for nonessential captions/eyebrows only.
+- Existing 8px/9px home labels are removed from important content.
+- Line height uses at least 1.35 for body copy.
+
+### 7. Shared control tokens
+- minimum touch target: 44px × 44px
+- primary button min-height: 52px
+- secondary/list button min-height: 48px
+- sheet close button: 44px
+- consistent radius, padding, focus-visible outline, pressed state
+- controls that are not immediate binary settings must not masquerade as toggles
+
+### 8. Layout safety
+The home remains 9:16/mobile-first but should rely less on independent overlapping absolute blocks. The scene/character can remain layered, while interactive UI is placed in deliberate top / middle / bottom bands with reserved space.
+
+Viewport contracts:
+- 360×640
+- 390×844
+- 430px-class width
+- `100dvh`
+- safe-area top/bottom/left/right
+- no horizontal overflow
+- no primary-action/dialogue/nav overlap
+- long Korean labels wrap or truncate intentionally
+
+### 9. Desktop compatibility
+Desktop is secondary. V7 must not make the existing desktop shell unusable, but no desktop-specific redesign is required. Wider viewports should center the same mobile-first composition rather than introduce a different information architecture.
+
+## Proposed component boundaries
+### `MobileHomeStatus`
+Compact display-only status summary. No navigation authority.
+
+### `HomeUtilitySheet`
+Owns utility destinations previously shown as multiple top shortcuts/promos. It calls existing `openMenu` destinations; no game-state mutations are duplicated.
+
+### `WeeklyPlannerCard`
+Supports compact mode on home. Detailed focus grid is rendered only when its planner panel/sheet is open.
+
+### `LayeredHome`
+Continues to own presentation state and `openMenu`. It consumes `hubNextAction` and renders exactly one prominent primary action.
+
+### Shared CSS tokens
+Add a focused mobile UI token stylesheet and reuse it from layered-home / planner / chronicle / home panel CSS. No dependency/framework replacement.
+
+## Interaction behavior
+1. Player lands on home and sees current status + one obvious next action.
+2. If the player wants a different activity, bottom navigation remains available.
+3. Utility notifications are represented by one utility launcher/badge rather than four always-visible shortcut buttons.
+4. Weekly planning opens into a dedicated panel/sheet; choosing a focus closes or updates the detail state without adding another persistent home control row.
+5. Home-launched panels use consistent title/body/button typography and fixed close-target behavior.
+
+## Accessibility
+- preserve focus return on panel close
+- Escape closes dialogs where currently supported
+- `aria-modal`, labels, pressed/current states preserved
+- no touch target below 44px
+- visible focus outline
+- `prefers-reduced-motion: reduce` disables nonessential transitions/animations
+- color is not the only indication of selected/available state
+
+## Compatibility invariants
+- `hubNextAction` remains authoritative and unique
+- no game progression/reducer semantics change
+- save schema unchanged
+- V3/V4/V5/V6 systems unchanged
+- NG+/generation/True/Hollow rules unchanged
+- existing menu IDs and callbacks remain valid
+- no raw progression reset or migration
+
+## Testing strategy
+### Source/UI contract tests
+- exactly one `.lh-primary-action`
+- no always-visible legacy shortcut cluster on <=430px
+- utility launcher exposes existing destinations
+- weekly focus grid is hidden from default compact home and available in planner detail
+- actionable home/panel text uses tokenized size classes/variables instead of 8px/9px hard-coded values
+- mobile control minimum heights are 44/48/52px as designed
+- safe-area and reduced-motion declarations exist
+
+### Functional tests
+- every existing shortcut destination still opens
+- `hubNextAction` routing remains unchanged
+- weekly select/complete/advance still works
+- panel focus/close behavior still works
+
+### Regression
+- full Vitest suite
+- TypeScript build
+- Vite production build
+- existing mobile tests for Spring/Summer/Autumn/Winter/Fifth/Hollow/NG+ remain green
+
+## Release gate
+RED contracts → minimal refactor → targeted UI tests → full regression/build → preview visual smoke → integration tree verification → release PR synthetic CI → exact main push CI → exact Vercel production SHA → root/API 200 → production runtime error/fatal log check.

--- a/docs/superpowers/specs/README-v7-mobile-ux-review.txt
+++ b/docs/superpowers/specs/README-v7-mobile-ux-review.txt
@@ -1,0 +1,1 @@
+V7 mobile UX design review marker. Authoritative spec: 2026-08-26-puppy-maker-v7-mobile-ux-design.md

--- a/src/CollectionArchiveOverlay.tsx
+++ b/src/CollectionArchiveOverlay.tsx
@@ -28,12 +28,21 @@ export default function CollectionArchiveOverlay({
   state,
   onNavigate,
   onExpedition,
+  open:controlledOpen,
+  onOpenChange,
 }: {
   state: GameState;
   onNavigate?: (id: HomeMenuId) => void;
   onExpedition?: () => void;
+  open?: boolean;
+  onOpenChange?: (open:boolean) => void;
 }) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (next:boolean) => {
+    if (controlledOpen === undefined) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
   const unlockedRelics = new Set(unlockedLegacyRelics(state.annualRecords));
   const streak = ambitionStreak(state.annualRecords, state.yearlyAmbitions);
   const unlockedAmbitionHonors = ambitionStreakHonors.filter(honor => streak >= honor.required);
@@ -108,7 +117,7 @@ export default function CollectionArchiveOverlay({
             <b>{recommendedCategory ? `${recommendedCategory.label} ${recommendedCategory.current} / ${recommendedCategory.total}` : '100 / 100'}</b>
             <p>{recommendation.reason}</p>
             {(homeRoute || recommendation.action === 'expedition') && <button onClick={followRecommendation}>바로 이동</button>}
-            {!homeRoute && recommendationRoute === 'ambition' && <small>홈의 올해의 야망 카드에서 현재 진행률과 다음 행동을 확인하세요.</small>}
+            {!homeRoute && recommendationRoute === 'ambition' && <small>성장 메뉴의 올해의 야망에서 현재 진행률과 다음 행동을 확인하세요.</small>}
             {!homeRoute && recommendationRoute === 'archive' && <small>연간 수호 기록을 쌓으면 이 도감에서 레거시 유물이 열려요.</small>}
           </div>
           <div className="legacy-card">

--- a/src/LayeredHomeV7.tsx
+++ b/src/LayeredHomeV7.tsx
@@ -1,7 +1,7 @@
 import {useCallback,useMemo,useState,type MouseEvent} from 'react';
 import type {GiftItemId,OutingLocationId} from './adventure';
 import {attendanceKey} from './attendance';
-import {currentAvailableMail,eligibleAchievements,type AchievementId,type GameState,type MailRewardId} from './game';
+import {currentAvailableMail,eligibleAchievements,relationshipRank,type AchievementId,type GameState,type MailRewardId} from './game';
 import {hubNextAction} from './hub-next-action';
 import type {HomeMenuId} from './home-panels';
 import LayeredHome from './LayeredHome';
@@ -28,11 +28,20 @@ type Props={
   onMenuReady?:(openMenu:(id:HomeMenuId)=>void)=>void;
 };
 
+const relationshipLabels={acquaintance:'낯선 사이',familiar:'익숙한 사이',friend:'친구',close_friend:'가까운 친구',precious:'소중한 사람'} as const;
+const conditionCopy:Record<GameState['condition'],string>={
+  energetic:'오늘은 몸이 가벼워요. 새로운 일에 도전해볼까요?',
+  normal:'오늘의 흐름을 천천히 골라봐요.',
+  focused:'집중하기 좋은 날이에요. 중요한 일을 해볼까요?',
+  tired:'조금 지쳐 보여요. 무리하지 않아도 괜찮아요.',
+};
+
 export default function LayeredHomeV7(props:Props){
   const {state,onMenuReady}=props;
   const [category,setCategory]=useState<MobileCategoryId>('home');
   const [legacyOpenMenu,setLegacyOpenMenu]=useState<((id:HomeMenuId)=>void)|null>(null);
   const primaryTask=hubNextAction(state);
+  const relationship=relationshipLabels[relationshipRank(state.stats.affection)];
 
   const captureMenu=useCallback((openMenu:(id:HomeMenuId)=>void)=>{
     setLegacyOpenMenu(()=>openMenu);
@@ -79,6 +88,9 @@ export default function LayeredHomeV7(props:Props){
   return <div className="v7-home-shell" onClickCapture={handleCapture}>
     <LayeredHome {...props} onMenuReady={captureMenu}/>
     <MobileHomeStatus state={state} notificationCount={notificationCount} onNotifications={openNotifications}/>
+    <div className="v7-luna-context" aria-label="루나 상태">
+      <b>루나 · {relationship}</b><span>{conditionCopy[state.condition]}</span>
+    </div>
 
     <nav className="v7-bottom-nav" aria-label="주요 메뉴">
       {mobileCategories.map(item=><button

--- a/src/LayeredHomeV7.tsx
+++ b/src/LayeredHomeV7.tsx
@@ -1,0 +1,109 @@
+import {useCallback,useMemo,useState,type MouseEvent} from 'react';
+import type {GiftItemId,OutingLocationId} from './adventure';
+import {attendanceKey} from './attendance';
+import {currentAvailableMail,eligibleAchievements,type AchievementId,type GameState,type MailRewardId} from './game';
+import {hubNextAction} from './hub-next-action';
+import type {HomeMenuId} from './home-panels';
+import LayeredHome from './LayeredHome';
+import MobileCategorySheet,{mobileCategories,type MobileCategoryId} from './MobileCategorySheet';
+import MobileHomeStatus from './MobileHomeStatus';
+import MobileNavIcon from './MobileNavIcon';
+import type {WeeklyFocusId} from './weekly-life';
+import './layered-home-v7.css';
+
+type Props={
+  state:GameState;
+  onSchedule:()=>void;
+  onClaimAchievement:(achievement:AchievementId)=>void;
+  onOuting:(location:OutingLocationId)=>void;
+  onGift:(item:GiftItemId)=>void;
+  onAttendance:()=>void;
+  onMail:(mail:MailRewardId)=>void;
+  onMonthlyFocus:(focus:GameState['monthlyFocus'])=>void;
+  onWeeklyFocus?:(focus:WeeklyFocusId)=>void;
+  onCompleteWeek?:()=>void;
+  onAdvanceWeek?:()=>void;
+  onExpedition?:()=>void;
+  onSeason?:()=>void;
+  onMenuReady?:(openMenu:(id:HomeMenuId)=>void)=>void;
+};
+
+export default function LayeredHomeV7(props:Props){
+  const {state,onMenuReady}=props;
+  const [category,setCategory]=useState<MobileCategoryId>('home');
+  const [legacyOpenMenu,setLegacyOpenMenu]=useState<((id:HomeMenuId)=>void)|null>(null);
+  const primaryTask=hubNextAction(state);
+
+  const captureMenu=useCallback((openMenu:(id:HomeMenuId)=>void)=>{
+    setLegacyOpenMenu(()=>openMenu);
+    onMenuReady?.(openMenu);
+  },[onMenuReady]);
+
+  const openLegacy=useCallback((id:HomeMenuId)=>{
+    setCategory('home');
+    legacyOpenMenu?.(id);
+  },[legacyOpenMenu]);
+
+  const notificationCount=useMemo(()=>{
+    const mail=new Set(currentAvailableMail(state));
+    const unclaimedMail=[...mail].filter(id=>!state.claimedMailRewards.includes(id)).length;
+    const attendanceId=attendanceKey(state.year,state.month);
+    const attendance=state.claimedAttendanceMonths.includes(attendanceId)?0:1;
+    const achievement=new Set(eligibleAchievements(state));
+    const achievements=[...achievement].filter(id=>!state.claimedAchievements.includes(id)).length;
+    return unclaimedMail+attendance+achievements;
+  },[state]);
+
+  const openNotifications=useCallback(()=>{
+    const mail=new Set(currentAvailableMail(state));
+    const hasMail=[...mail].some(id=>!state.claimedMailRewards.includes(id));
+    if(hasMail)return openLegacy('mail');
+    const attendanceId=attendanceKey(state.year,state.month);
+    if(!state.claimedAttendanceMonths.includes(attendanceId))return openLegacy('attendance');
+    const achievement=new Set(eligibleAchievements(state));
+    if([...achievement].some(id=>!state.claimedAchievements.includes(id)))return openLegacy('quest');
+    setCategory('life');
+  },[state,openLegacy]);
+
+  const handleCapture=(event:MouseEvent<HTMLDivElement>)=>{
+    const target=event.target;
+    if(!(target instanceof Element)||!target.closest('.lh-primary-action'))return;
+    if(primaryTask.route!=='weekly_planner')return;
+    event.preventDefault();
+    event.stopPropagation();
+    setCategory('life');
+  };
+
+  const activeSheet=category==='home'?null:category;
+
+  return <div className="v7-home-shell" onClickCapture={handleCapture}>
+    <LayeredHome {...props} onMenuReady={captureMenu}/>
+    <MobileHomeStatus state={state} notificationCount={notificationCount} onNotifications={openNotifications}/>
+
+    <nav className="v7-bottom-nav" aria-label="주요 메뉴">
+      {mobileCategories.map(item=><button
+        key={item.id}
+        type="button"
+        className={category===item.id?'is-active':''}
+        aria-current={category===item.id?'page':undefined}
+        aria-pressed={category===item.id}
+        onClick={()=>setCategory(item.id)}
+      >
+        <span><MobileNavIcon name={item.icon}/></span><b>{item.label}</b>
+      </button>)}
+    </nav>
+
+    {activeSheet&&<MobileCategorySheet
+      category={activeSheet}
+      state={state}
+      onClose={()=>setCategory('home')}
+      onOpenMenu={openLegacy}
+      onSchedule={()=>{setCategory('home');props.onSchedule();}}
+      onExpedition={()=>{setCategory('home');props.onExpedition?.();}}
+      onSeason={()=>{setCategory('home');props.onSeason?.();}}
+      onWeeklyFocus={props.onWeeklyFocus}
+      onCompleteWeek={props.onCompleteWeek}
+      onAdvanceWeek={props.onAdvanceWeek}
+    />}
+  </div>;
+}

--- a/src/LayeredHomeV7.tsx
+++ b/src/LayeredHomeV7.tsx
@@ -25,6 +25,11 @@ type Props={
   onAdvanceWeek?:()=>void;
   onExpedition?:()=>void;
   onSeason?:()=>void;
+  onRaising?:()=>void;
+  onSanctuary?:()=>void;
+  onWorldProgress?:()=>void;
+  onArchive?:()=>void;
+  onAmbition?:()=>void;
   onMenuReady?:(openMenu:(id:HomeMenuId)=>void)=>void;
 };
 
@@ -52,6 +57,11 @@ export default function LayeredHomeV7(props:Props){
     setCategory('home');
     legacyOpenMenu?.(id);
   },[legacyOpenMenu]);
+
+  const leaveSheet=useCallback((action?:()=>void)=>{
+    setCategory('home');
+    action?.();
+  },[]);
 
   const notificationCount=useMemo(()=>{
     const mail=new Set(currentAvailableMail(state));
@@ -110,9 +120,14 @@ export default function LayeredHomeV7(props:Props){
       state={state}
       onClose={()=>setCategory('home')}
       onOpenMenu={openLegacy}
-      onSchedule={()=>{setCategory('home');props.onSchedule();}}
-      onExpedition={()=>{setCategory('home');props.onExpedition?.();}}
-      onSeason={()=>{setCategory('home');props.onSeason?.();}}
+      onSchedule={()=>leaveSheet(props.onSchedule)}
+      onExpedition={()=>leaveSheet(props.onExpedition)}
+      onSeason={()=>leaveSheet(props.onSeason)}
+      onRaising={()=>leaveSheet(props.onRaising)}
+      onSanctuary={()=>leaveSheet(props.onSanctuary)}
+      onWorldProgress={()=>leaveSheet(props.onWorldProgress)}
+      onArchive={()=>leaveSheet(props.onArchive)}
+      onAmbition={()=>leaveSheet(props.onAmbition)}
       onWeeklyFocus={props.onWeeklyFocus}
       onCompleteWeek={props.onCompleteWeek}
       onAdvanceWeek={props.onAdvanceWeek}

--- a/src/MobileCategorySheet.tsx
+++ b/src/MobileCategorySheet.tsx
@@ -1,4 +1,5 @@
 import type {GameState} from './game';
+import {publicProjectDefinitions} from './generational-world';
 import type {HomeMenuId} from './home-panels';
 import LineageChronicle from './LineageChronicle';
 import MobileNavIcon,{type MobileNavIconName} from './MobileNavIcon';
@@ -48,6 +49,8 @@ const meta:Record<Exclude<MobileCategoryId,'home'>,{label:string;eyebrow:string;
 
 export default function MobileCategorySheet({category,state,onClose,onOpenMenu,onSchedule,onExpedition,onSeason,onWeeklyFocus,onCompleteWeek,onAdvanceWeek}:Props){
   const info=meta[category];
+  const activeProject=state.generationalWorld.activeProject;
+  const activeProjectLabel=activeProject?publicProjectDefinitions[activeProject].label:null;
   return <div className="v7-category-backdrop" onClick={onClose}>
     <section className="v7-category-sheet" role="dialog" aria-modal="true" aria-label={`${info.label} 메뉴`} onClick={event=>event.stopPropagation()}>
       <header className="v7-category-header">
@@ -75,7 +78,7 @@ export default function MobileCategorySheet({category,state,onClose,onOpenMenu,o
       {category==='adventure'&&<div className="v7-category-grid">
         <Entry icon="adventure" title="외출" description="마을과 주변 지역에서 새로운 일을 찾아요." onClick={()=>onOpenMenu('outing')}/>
         <Entry icon="adventure" title="원정과 전투" description="Expedition과 Tactical 전투에 도전해요." onClick={()=>onExpedition?.()}/>
-        <div className="v7-category-summary"><small>WORLD</small><b>세계 프로젝트</b><span>{state.generationalWorld.activeProject?`진행 중 · ${state.generationalWorld.activeProject}`:'진행 중인 장기 프로젝트가 없어요.'}</span></div>
+        <div className="v7-category-summary"><small>WORLD</small><b>세계 프로젝트</b><span>{activeProjectLabel?`진행 중 · ${activeProjectLabel} ${state.generationalWorld.projectProgress}%`:'진행 중인 장기 프로젝트가 없어요.'}</span></div>
       </div>}
 
       {category==='bond'&&<div className="v7-category-grid">

--- a/src/MobileCategorySheet.tsx
+++ b/src/MobileCategorySheet.tsx
@@ -26,6 +26,11 @@ type Props={
   onSchedule:()=>void;
   onExpedition?:()=>void;
   onSeason?:()=>void;
+  onRaising?:()=>void;
+  onSanctuary?:()=>void;
+  onWorldProgress?:()=>void;
+  onArchive?:()=>void;
+  onAmbition?:()=>void;
   onWeeklyFocus?:(focus:WeeklyFocusId)=>void;
   onCompleteWeek?:()=>void;
   onAdvanceWeek?:()=>void;
@@ -47,7 +52,10 @@ const meta:Record<Exclude<MobileCategoryId,'home'>,{label:string;eyebrow:string;
   records:{label:'기록',eyebrow:'CHRONICLE',description:'세대와 세계에 남긴 흔적을 돌아봐요.',icon:'records'},
 };
 
-export default function MobileCategorySheet({category,state,onClose,onOpenMenu,onSchedule,onExpedition,onSeason,onWeeklyFocus,onCompleteWeek,onAdvanceWeek}:Props){
+export default function MobileCategorySheet({
+  category,state,onClose,onOpenMenu,onSchedule,onExpedition,onSeason,onRaising,onSanctuary,
+  onWorldProgress,onArchive,onAmbition,onWeeklyFocus,onCompleteWeek,onAdvanceWeek,
+}:Props){
   const info=meta[category];
   const activeProject=state.generationalWorld.activeProject;
   const activeProjectLabel=activeProject?publicProjectDefinitions[activeProject].label:null;
@@ -70,14 +78,18 @@ export default function MobileCategorySheet({category,state,onClose,onOpenMenu,o
       </div>}
 
       {category==='growth'&&<div className="v7-category-grid">
+        <Entry icon="growth" title="성장 정체성" description="Calling, Trait, 관계 장면과 루나의 성장 방향을 확인해요." onClick={()=>onRaising?.()}/>
+        <Entry icon="growth" title="올해의 야망" description="한 해 동안 집중할 성장 목표와 현재 진행률을 봐요." onClick={()=>onAmbition?.()}/>
         <Entry icon="growth" title="성장 업적" description="성장 목표와 받을 보상을 확인해요." onClick={()=>onOpenMenu('quest')}/>
         <Entry icon="growth" title="능력과 보유품" description="숙련도와 성장에 필요한 보유품을 살펴봐요." onClick={()=>onOpenMenu('bag')}/>
-        <Entry icon="records" title="시즌 성장" description="시즌 여정과 장기 성장을 확인해요." onClick={()=>onSeason?.()}/>
+        <Entry icon="records" title="시즌 여정" description="시즌 점수, 보상, Legacy 성장을 확인해요." onClick={()=>onSeason?.()}/>
+        <Entry icon="records" title="별빛 성소" description="시설, 전문화, Masterwork와 천상 성장을 관리해요." onClick={()=>onSanctuary?.()}/>
       </div>}
 
       {category==='adventure'&&<div className="v7-category-grid">
         <Entry icon="adventure" title="외출" description="마을과 주변 지역에서 새로운 일을 찾아요." onClick={()=>onOpenMenu('outing')}/>
-        <Entry icon="adventure" title="원정과 전투" description="Expedition과 Tactical 전투에 도전해요." onClick={()=>onExpedition?.()}/>
+        <Entry icon="adventure" title="수호자 원정" description="Expedition과 Tactical 전투에 도전해요." onClick={()=>onExpedition?.()}/>
+        <Entry icon="adventure" title="월드 진행" description="지역 명성, 월간 월드 이벤트와 의뢰를 확인해요." onClick={()=>onWorldProgress?.()}/>
         <div className="v7-category-summary"><small>WORLD</small><b>세계 프로젝트</b><span>{activeProjectLabel?`진행 중 · ${activeProjectLabel} ${state.generationalWorld.projectProgress}%`:'진행 중인 장기 프로젝트가 없어요.'}</span></div>
       </div>}
 
@@ -90,6 +102,7 @@ export default function MobileCategorySheet({category,state,onClose,onOpenMenu,o
       {category==='records'&&<div className="v7-category-content v7-records-content">
         <LineageChronicle state={state}/>
         <WorldChronicle generation={state.lineage.generation} world={state.generationalWorld}/>
+        <Entry icon="records" title="성장 도감" description="성장, 원정, 유산과 연간 수호 기록을 한곳에서 봐요." onClick={()=>onArchive?.()}/>
         <div className="v7-category-summary"><small>COLLECTION</small><b>발견과 기억</b><span>발견물 {state.discoveries.length}개 · 세대 {state.lineage.generation}</span></div>
       </div>}
     </section>

--- a/src/MobileCategorySheet.tsx
+++ b/src/MobileCategorySheet.tsx
@@ -1,0 +1,94 @@
+import type {GameState} from './game';
+import type {HomeMenuId} from './home-panels';
+import LineageChronicle from './LineageChronicle';
+import MobileNavIcon,{type MobileNavIconName} from './MobileNavIcon';
+import WeeklyPlannerCard from './WeeklyPlannerCard';
+import WorldChronicle from './WorldChronicle';
+import type {WeeklyFocusId} from './weekly-life';
+
+export type MobileCategoryId='home'|'life'|'growth'|'adventure'|'bond'|'records';
+
+export const mobileCategories:Array<{id:MobileCategoryId;label:string;icon:MobileNavIconName}>=[
+  {id:'home',label:'홈',icon:'home'},
+  {id:'life',label:'생활',icon:'life'},
+  {id:'growth',label:'성장',icon:'growth'},
+  {id:'adventure',label:'모험',icon:'adventure'},
+  {id:'bond',label:'인연',icon:'bond'},
+  {id:'records',label:'기록',icon:'records'},
+];
+
+type Props={
+  category:Exclude<MobileCategoryId,'home'>;
+  state:GameState;
+  onClose:()=>void;
+  onOpenMenu:(id:HomeMenuId)=>void;
+  onSchedule:()=>void;
+  onExpedition?:()=>void;
+  onSeason?:()=>void;
+  onWeeklyFocus?:(focus:WeeklyFocusId)=>void;
+  onCompleteWeek?:()=>void;
+  onAdvanceWeek?:()=>void;
+};
+
+function Entry({icon,title,description,onClick}: {icon:MobileNavIconName;title:string;description:string;onClick:()=>void}){
+  return <button type="button" className="v7-category-entry" onClick={onClick}>
+    <span className="v7-category-entry-icon"><MobileNavIcon name={icon}/></span>
+    <span><b>{title}</b><small>{description}</small></span>
+    <MobileNavIcon name="chevron" className="v7-chevron"/>
+  </button>;
+}
+
+const meta:Record<Exclude<MobileCategoryId,'home'>,{label:string;eyebrow:string;description:string;icon:MobileNavIconName}>={
+  life:{label:'생활',eyebrow:'LIVING',description:'이번 주와 이번 달의 일상을 정리해요.',icon:'life'},
+  growth:{label:'성장',eyebrow:'GROWTH',description:'훈련과 성과, 장기 성장을 확인해요.',icon:'growth'},
+  adventure:{label:'모험',eyebrow:'ADVENTURE',description:'밖으로 나가 탐험하고 전투해요.',icon:'adventure'},
+  bond:{label:'인연',eyebrow:'BONDS',description:'루나와 친구들의 관계와 이야기를 만나요.',icon:'bond'},
+  records:{label:'기록',eyebrow:'CHRONICLE',description:'세대와 세계에 남긴 흔적을 돌아봐요.',icon:'records'},
+};
+
+export default function MobileCategorySheet({category,state,onClose,onOpenMenu,onSchedule,onExpedition,onSeason,onWeeklyFocus,onCompleteWeek,onAdvanceWeek}:Props){
+  const info=meta[category];
+  return <div className="v7-category-backdrop" onClick={onClose}>
+    <section className="v7-category-sheet" role="dialog" aria-modal="true" aria-label={`${info.label} 메뉴`} onClick={event=>event.stopPropagation()}>
+      <header className="v7-category-header">
+        <span className="v7-category-icon"><MobileNavIcon name={info.icon}/></span>
+        <div><small>{info.eyebrow}</small><h2>{info.label}</h2><p>{info.description}</p></div>
+        <button type="button" className="v7-category-close" onClick={onClose} aria-label="홈으로 돌아가기">×</button>
+      </header>
+
+      {category==='life'&&<div className="v7-category-content">
+        <WeeklyPlannerCard state={state} onSelectFocus={focus=>onWeeklyFocus?.(focus)} onComplete={()=>onCompleteWeek?.()} onAdvance={()=>onAdvanceWeek?.()} showChronicles={false}/>
+        <div className="v7-category-grid">
+          <Entry icon="life" title="스케줄" description="훈련과 하루 일정을 선택해요." onClick={onSchedule}/>
+          <Entry icon="life" title="이번 달 목표" description="월간 집중과 미션을 확인해요." onClick={()=>onOpenMenu('mission')}/>
+          <Entry icon="bell" title="출석 보상" description="이번 달 출석 보상을 받아요." onClick={()=>onOpenMenu('attendance')}/>
+          <Entry icon="records" title="우편함" description="도착한 편지와 보상을 확인해요." onClick={()=>onOpenMenu('mail')}/>
+        </div>
+      </div>}
+
+      {category==='growth'&&<div className="v7-category-grid">
+        <Entry icon="growth" title="성장 업적" description="성장 목표와 받을 보상을 확인해요." onClick={()=>onOpenMenu('quest')}/>
+        <Entry icon="growth" title="능력과 보유품" description="숙련도와 성장에 필요한 보유품을 살펴봐요." onClick={()=>onOpenMenu('bag')}/>
+        <Entry icon="records" title="시즌 성장" description="시즌 여정과 장기 성장을 확인해요." onClick={()=>onSeason?.()}/>
+      </div>}
+
+      {category==='adventure'&&<div className="v7-category-grid">
+        <Entry icon="adventure" title="외출" description="마을과 주변 지역에서 새로운 일을 찾아요." onClick={()=>onOpenMenu('outing')}/>
+        <Entry icon="adventure" title="원정과 전투" description="Expedition과 Tactical 전투에 도전해요." onClick={()=>onExpedition?.()}/>
+        <div className="v7-category-summary"><small>WORLD</small><b>세계 프로젝트</b><span>{state.generationalWorld.activeProject?`진행 중 · ${state.generationalWorld.activeProject}`:'진행 중인 장기 프로젝트가 없어요.'}</span></div>
+      </div>}
+
+      {category==='bond'&&<div className="v7-category-grid">
+        <Entry icon="bond" title="루나와 교감" description="관계와 선물, 교감 기록을 확인해요." onClick={()=>onOpenMenu('bond')}/>
+        <Entry icon="bond" title="선물" description="보유한 선물을 확인하고 마음을 전해요." onClick={()=>onOpenMenu('bag')}/>
+        <Entry icon="records" title="이야기" description="열린 캐릭터 이야기와 이벤트를 다시 봐요." onClick={()=>onOpenMenu('event')}/>
+      </div>}
+
+      {category==='records'&&<div className="v7-category-content v7-records-content">
+        <LineageChronicle state={state}/>
+        <WorldChronicle generation={state.lineage.generation} world={state.generationalWorld}/>
+        <div className="v7-category-summary"><small>COLLECTION</small><b>발견과 기억</b><span>발견물 {state.discoveries.length}개 · 세대 {state.lineage.generation}</span></div>
+      </div>}
+    </section>
+  </div>;
+}

--- a/src/MobileHomeStatus.tsx
+++ b/src/MobileHomeStatus.tsx
@@ -1,0 +1,23 @@
+import {currentGuardianStatus,type GameState} from './game';
+import MobileNavIcon from './MobileNavIcon';
+
+type Props={state:GameState;notificationCount:number;onNotifications:()=>void};
+
+export default function MobileHomeStatus({state,notificationCount,onNotifications}:Props){
+  const stamina=Math.max(0,Math.min(100,100-state.stats.fatigue));
+  const guardian=currentGuardianStatus(state);
+  return <header className="v7-home-status" aria-label="현재 상태">
+    <div className="v7-home-status-main">
+      <strong>{state.lineage.generation}세대 · {state.year}년차 · {state.month}월 {state.week}주차</strong>
+      <span className="v7-guardian-chip">수호 {guardian.points}</span>
+    </div>
+    <div className="v7-home-resources" aria-label="보유 자원">
+      <span><b>G</b>{state.gold.toLocaleString()}</span>
+      <span><b>◆</b>{state.gems.toLocaleString()}</span>
+      <span><b>체력</b>{stamina}%</span>
+    </div>
+    {notificationCount>0&&<button type="button" className="v7-notification" onClick={onNotifications} aria-label={`새 소식 ${notificationCount}개`}>
+      <MobileNavIcon name="bell"/><b>{notificationCount>9?'9+':notificationCount}</b>
+    </button>}
+  </header>;
+}

--- a/src/MobileNavIcon.tsx
+++ b/src/MobileNavIcon.tsx
@@ -1,0 +1,20 @@
+export type MobileNavIconName='home'|'life'|'growth'|'adventure'|'bond'|'records'|'bell'|'chevron';
+
+type Props={name:MobileNavIconName;className?:string};
+
+const paths:Record<MobileNavIconName,string[]>={
+  home:['M3.5 10.5 12 3.8l8.5 6.7','M5.5 9.6V20h13V9.6','M9.2 20v-6.4h5.6V20','M18.5 4.3v3.2'],
+  life:['M5 5.5h14v15H5z','M8 3v5m8-5v5M5 9.5h14','M8.3 13h.1m3.6 0h.1m3.6 0h.1M8.3 16.5h.1m3.6 0h.1'],
+  growth:['M12 20v-8','M12 13c-4.4 0-7-2.4-7-6 4.4 0 7 2.4 7 6Z','M12 11c4.4 0 7-2.4 7-6-4.4 0-7 2.4-7 6Z','M18.5 14.5v4m-2-2h4'],
+  adventure:['M12 3.5a8.5 8.5 0 1 0 0 17 8.5 8.5 0 0 0 0-17Z','m15.7 8.3-2.2 5.2-5.2 2.2 2.2-5.2 5.2-2.2Z'],
+  bond:['M12 20s-7.2-4.2-7.2-9.4A4.1 4.1 0 0 1 12 8a4.1 4.1 0 0 1 7.2 2.6C19.2 15.8 12 20 12 20Z','M8.3 7.2c-.8-.8-.5-2.2.5-2.7m2.1 1.8c-.5-1 .1-2.2 1.2-2.4m2 2.5c.1-1.1 1.2-1.8 2.2-1.4'],
+  records:['M4.5 5.2c2.7-.7 5.1-.2 7.5 1.4v13c-2.4-1.6-4.8-2.1-7.5-1.4v-13Z','M19.5 5.2c-2.7-.7-5.1-.2-7.5 1.4v13c2.4-1.6 4.8-2.1 7.5-1.4v-13Z','m17.4 2 .5 1.1 1.1.5-1.1.5-.5 1.1-.5-1.1-1.1-.5 1.1-.5.5-1.1Z'],
+  bell:['M6.5 17h11l-1.5-2.1V10a4 4 0 0 0-8 0v4.9L6.5 17Z','M10 19.2a2.2 2.2 0 0 0 4 0'],
+  chevron:['m9 6 6 6-6 6'],
+};
+
+export default function MobileNavIcon({name,className}:Props){
+  return <svg className={className} viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+    {paths[name].map((path,index)=><path key={index} d={path}/>) }
+  </svg>;
+}

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -87,6 +87,9 @@ export default function Root() {
   const [raisingOpen, setRaisingOpen] = useState(false);
   const [seasonLiveOpen, setSeasonLiveOpen] = useState(false);
   const [sanctuaryOpen, setSanctuaryOpen] = useState(false);
+  const [worldProgressOpen, setWorldProgressOpen] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const [ambitionOpen, setAmbitionOpen] = useState(false);
 
   const captureNavigate = useCallback((nextNavigate: (screen: Screen) => void) => setNavigate(() => nextNavigate), []);
   const captureClaimAchievement = useCallback((nextClaim: (achievement: AchievementId) => void) => setClaimAchievement(() => nextClaim), []);
@@ -184,6 +187,11 @@ export default function Root() {
         onAdvanceWeek={handleAdvanceWeek}
         onExpedition={handleOpenExpedition}
         onSeason={() => setSeasonLiveOpen(true)}
+        onRaising={() => setRaisingOpen(true)}
+        onSanctuary={() => setSanctuaryOpen(true)}
+        onWorldProgress={() => setWorldProgressOpen(true)}
+        onArchive={() => setArchiveOpen(true)}
+        onAmbition={() => setAmbitionOpen(true)}
         onMenuReady={captureHomeMenu}
       />
       <SeasonalHomeBadge month={gameState.month} stamps={gameState.seasonStamps} />
@@ -208,9 +216,9 @@ export default function Root() {
         onConvergenceClear={() => undefined}
         onGuardianBoon={() => undefined}
       />
-      <YearlyAmbitionOverlay state={gameState} onSelect={handleYearlyAmbition} />
-      <CollectionArchiveOverlay state={gameState} onNavigate={handleArchiveNavigate} onExpedition={handleOpenExpedition} />
-      <WorldProgressOverlay state={gameState} />
+      <YearlyAmbitionOverlay state={gameState} onSelect={handleYearlyAmbition} open={ambitionOpen} onOpenChange={setAmbitionOpen} />
+      <CollectionArchiveOverlay state={gameState} onNavigate={handleArchiveNavigate} onExpedition={handleOpenExpedition} open={archiveOpen} onOpenChange={setArchiveOpen} />
+      <WorldProgressOverlay state={gameState} open={worldProgressOpen} onOpenChange={setWorldProgressOpen} />
       <YearEndCeremonyOverlay state={gameState} />
       <RaisingIdentityOverlay
         state={gameState}

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -95,8 +95,8 @@ export default function Root() {
   const captureAttendance = useCallback((nextClaim: () => void) => setClaimAttendance(() => nextClaim), []);
   const captureMail = useCallback((nextClaim: (mail: MailRewardId) => void) => setClaimMail(() => nextClaim), []);
   const captureMonthlyFocus = useCallback((nextSetFocus: (focus: GameState['monthlyFocus']) => void) => setSetMonthlyFocus(() => nextSetFocus), []);
-  const captureYearlyAmbition = useCallback((nextSetAmbition: (ambition: YearlyAmbitionId) => void) => setYearlyAmbition(() => nextSetAmbition), []);
-  const captureGuardianCalling = useCallback((nextSetCalling: (calling: GuardianCallingId) => void) => setGuardianCalling(() => nextSetCalling), []);
+  const captureYearlyAmbition = useCallback((nextSetAmbition: (ambition: YearlyAmbitionId) => void) => setSetYearlyAmbition(() => nextSetAmbition), []);
+  const captureGuardianCalling = useCallback((nextSetCalling: (calling: GuardianCallingId) => void) => setSetGuardianCalling(() => nextSetCalling), []);
   const captureGrowthTrait = useCallback((nextPurchaseTrait: (trait: GrowthTraitId) => void) => setPurchaseGrowthTrait(() => nextPurchaseTrait), []);
   const captureSeasonPurchase = useCallback((nextPurchase: (offer: SeasonShopOfferId) => void) => setPurchaseSeasonOffer(() => nextPurchase), []);
   const captureSeasonLegacyUnlock = useCallback((nextUnlock: (nodeId: SeasonLegacyNodeId) => void) => setUnlockSeasonLegacyNode(() => nextUnlock), []);

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -3,7 +3,7 @@ import type { GiftItemId, OutingLocationId } from './adventure';
 import App from './App';
 import CollectionArchiveOverlay from './CollectionArchiveOverlay';
 import GuardianExpeditionOverlay from './GuardianExpeditionOverlay';
-import LayeredHome from './LayeredHome';
+import LayeredHomeV7 from './LayeredHomeV7';
 import RaisingIdentityOverlay from './RaisingIdentityOverlay';
 import SanctuaryOverlay from './SanctuaryOverlay';
 import SeasonalHomeBadge from './SeasonalHomeBadge';
@@ -95,8 +95,8 @@ export default function Root() {
   const captureAttendance = useCallback((nextClaim: () => void) => setClaimAttendance(() => nextClaim), []);
   const captureMail = useCallback((nextClaim: (mail: MailRewardId) => void) => setClaimMail(() => nextClaim), []);
   const captureMonthlyFocus = useCallback((nextSetFocus: (focus: GameState['monthlyFocus']) => void) => setSetMonthlyFocus(() => nextSetFocus), []);
-  const captureYearlyAmbition = useCallback((nextSetAmbition: (ambition: YearlyAmbitionId) => void) => setSetYearlyAmbition(() => nextSetAmbition), []);
-  const captureGuardianCalling = useCallback((nextSetCalling: (calling: GuardianCallingId) => void) => setSetGuardianCalling(() => nextSetCalling), []);
+  const captureYearlyAmbition = useCallback((nextSetAmbition: (ambition: YearlyAmbitionId) => void) => setYearlyAmbition(() => nextSetAmbition), []);
+  const captureGuardianCalling = useCallback((nextSetCalling: (calling: GuardianCallingId) => void) => setGuardianCalling(() => nextSetCalling), []);
   const captureGrowthTrait = useCallback((nextPurchaseTrait: (trait: GrowthTraitId) => void) => setPurchaseGrowthTrait(() => nextPurchaseTrait), []);
   const captureSeasonPurchase = useCallback((nextPurchase: (offer: SeasonShopOfferId) => void) => setPurchaseSeasonOffer(() => nextPurchase), []);
   const captureSeasonLegacyUnlock = useCallback((nextUnlock: (nodeId: SeasonLegacyNodeId) => void) => setUnlockSeasonLegacyNode(() => nextUnlock), []);
@@ -170,7 +170,7 @@ export default function Root() {
       onWeeklyAdvanceReady={captureWeeklyAdvance}
     />
     {gameState.screen === 'hub' && <>
-      <LayeredHome
+      <LayeredHomeV7
         state={gameState}
         onSchedule={openSchedule}
         onClaimAchievement={handleClaimAchievement}

--- a/src/WeeklyPlannerCard.tsx
+++ b/src/WeeklyPlannerCard.tsx
@@ -21,9 +21,10 @@ type Props={
   onSelectFocus:(focus:WeeklyFocusId)=>void;
   onComplete:()=>void;
   onAdvance:()=>void;
+  showChronicles?:boolean;
 };
 
-export default function WeeklyPlannerCard({state,onSelectFocus,onComplete,onAdvance}:Props){
+export default function WeeklyPlannerCard({state,onSelectFocus,onComplete,onAdvance,showChronicles=true}:Props){
   const current=weekKey(state.year,state.month,state.week);
   const selected=state.weeklyLife.focusKey===current?state.weeklyLife.focus:null;
   const completed=state.weeklyLife.completedWeekKey===current;
@@ -60,7 +61,6 @@ export default function WeeklyPlannerCard({state,onSelectFocus,onComplete,onAdva
         ? <button type="button" className="weekly-planner-advance" onClick={onAdvance}>다음 주 시작</button>
         : selected&&<button type="button" className="weekly-planner-resolve" onClick={onComplete}>이번 주 마무리</button>}
     </section>
-    <LineageChronicle state={state}/>
-    <WorldChronicle generation={state.lineage.generation} world={state.generationalWorld}/>
+    {showChronicles&&<><LineageChronicle state={state}/><WorldChronicle generation={state.lineage.generation} world={state.generationalWorld}/></>}
   </>;
 }

--- a/src/WorldProgressOverlay.tsx
+++ b/src/WorldProgressOverlay.tsx
@@ -2,11 +2,24 @@ import { useEffect, useRef, useState } from 'react';
 import type { GameState } from './game';
 import { worldUiSummary } from './world-ui';
 
-export default function WorldProgressOverlay({ state }: { state: GameState }) {
-  const [open, setOpen] = useState(false);
+export default function WorldProgressOverlay({
+  state,
+  open:controlledOpen,
+  onOpenChange,
+}: {
+  state: GameState;
+  open?: boolean;
+  onOpenChange?: (open:boolean) => void;
+}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
   const launcherRef = useRef<HTMLButtonElement>(null);
   const wasOpen = useRef(open);
   const summary = worldUiSummary(state);
+  const setOpen = (next:boolean) => {
+    if (controlledOpen === undefined) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
 
   useEffect(() => {
     if (wasOpen.current && !open) launcherRef.current?.focus();

--- a/src/YearlyAmbitionOverlay.tsx
+++ b/src/YearlyAmbitionOverlay.tsx
@@ -5,8 +5,23 @@ import { currentYearAmbitionRecord } from './yearly-ambition-progress';
 import { ambitionRecommendation } from './yearly-ambition-recommendation';
 import { ambitionDefinitions, ambitionProgress, type YearlyAmbitionId } from './yearly-ambitions';
 
-export default function YearlyAmbitionOverlay({ state, onSelect }: { state: GameState; onSelect: (ambition: YearlyAmbitionId) => void }) {
-  const [detailsOpen, setDetailsOpen] = useState(false);
+export default function YearlyAmbitionOverlay({
+  state,
+  onSelect,
+  open:controlledOpen,
+  onOpenChange,
+}: {
+  state: GameState;
+  onSelect: (ambition: YearlyAmbitionId) => void;
+  open?: boolean;
+  onOpenChange?: (open:boolean) => void;
+}) {
+  const [internalDetailsOpen, setInternalDetailsOpen] = useState(false);
+  const detailsOpen = controlledOpen ?? internalDetailsOpen;
+  const setDetailsOpen = (next:boolean) => {
+    if (controlledOpen === undefined) setInternalDetailsOpen(next);
+    onOpenChange?.(next);
+  };
   const selected = state.yearlyAmbitions[state.year] ?? null;
   const definition = selected ? ambitionDefinitions.find(item => item.id === selected) ?? null : null;
   const liveRecord = useMemo(() => currentYearAmbitionRecord({

--- a/src/layered-home-v7.css
+++ b/src/layered-home-v7.css
@@ -7,7 +7,7 @@
 .v7-home-shell .lh-primary-action small{font-size:var(--ui-text-caption);letter-spacing:.08em}
 .v7-home-shell .lh-primary-action b{font-size:var(--ui-text-subtitle);line-height:1.25}
 .v7-home-shell .lh-primary-action span{font-size:var(--ui-text-small);line-height:1.35;margin-top:3px}
-.v7-home-shell .lh-character{bottom:24%;width:min(51%,230px)}
+.v7-home-shell .lh-character{bottom:25%;width:min(49%,224px)}
 
 .v7-home-status{position:absolute;z-index:72;pointer-events:auto;left:max(12px,env(safe-area-inset-left));right:max(12px,env(safe-area-inset-right));top:max(10px,env(safe-area-inset-top));min-height:66px;padding:10px 50px 10px 12px;border:1px solid var(--ui-border);border-radius:var(--ui-radius-md);background:linear-gradient(180deg,rgba(22,16,34,.9),rgba(22,16,34,.72));box-shadow:0 8px 24px rgba(0,0,0,.28);backdrop-filter:blur(10px)}
 .v7-home-status-main{display:flex;align-items:center;gap:8px;min-width:0}
@@ -18,9 +18,13 @@
 .v7-notification{position:absolute;right:8px;top:10px;width:var(--ui-touch-min);height:var(--ui-touch-min);min-width:var(--ui-touch-min);min-height:var(--ui-touch-min);display:grid;place-items:center;border:0;border-radius:14px;background:rgba(255,255,255,.09);color:var(--ui-ivory)}
 .v7-notification svg{width:22px;height:22px}.v7-notification b{position:absolute;right:1px;top:0;min-width:18px;height:18px;padding:0 4px;display:grid;place-items:center;border-radius:999px;background:#d45e62;color:white;font-size:11px;line-height:1}
 
+.v7-luna-context{position:absolute;z-index:64;pointer-events:none;left:clamp(22px,8vw,38px);right:clamp(22px,8vw,38px);bottom:calc(max(158px,env(safe-area-inset-bottom) + 150px));padding:9px 13px;border:1px solid rgba(241,207,120,.38);border-radius:var(--ui-radius-md);background:rgba(23,16,36,.76);box-shadow:0 7px 18px rgba(0,0,0,.24);backdrop-filter:blur(7px);text-align:left}
+.v7-luna-context b{display:block;font-size:var(--ui-text-body);line-height:1.25;color:var(--ui-gold)}
+.v7-luna-context span{display:block;margin-top:3px;font-size:var(--ui-text-small);line-height:1.35;color:var(--ui-ivory);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+
 .v7-bottom-nav{position:absolute;z-index:74;pointer-events:auto;left:max(6px,env(safe-area-inset-left));right:max(6px,env(safe-area-inset-right));bottom:max(6px,env(safe-area-inset-bottom));height:72px;padding:6px 4px;display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:2px;border:1px solid rgba(241,207,120,.42);border-radius:20px;background:var(--ui-glass-strong);box-shadow:0 10px 28px rgba(0,0,0,.4);backdrop-filter:blur(12px)}
 .v7-bottom-nav button{position:relative;min-width:0;min-height:var(--ui-touch-min);padding:4px 1px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:3px;border:0;border-radius:14px;background:transparent;color:rgba(255,244,210,.72);font:inherit}
-.v7-bottom-nav button>span{width:23px;height:23px}.v7-bottom-nav svg{width:100%;height:100%}.v7-bottom-nav b{font-size:var(--ui-text-caption);line-height:1.05;font-weight:800;white-space:nowrap}
+.v7-bottom-nav button>span{width:23px;height:23px}.v7-bottom-nav svg{width:100%;height:100%}.v7-bottom-nav b{font-size:var(--ui-text-button);line-height:1.05;font-weight:800;white-space:nowrap}
 .v7-bottom-nav button.is-active{background:linear-gradient(180deg,rgba(241,207,120,.22),rgba(217,156,69,.12));color:var(--ui-gold);box-shadow:inset 0 0 0 1px rgba(241,207,120,.35)}
 .v7-bottom-nav button.is-active b{font-weight:900}.v7-bottom-nav button:focus-visible,.v7-category-sheet button:focus-visible,.v7-home-status button:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
 
@@ -42,17 +46,19 @@
 
 @media(max-width:390px){
   .v7-home-status{left:max(8px,env(safe-area-inset-left));right:max(8px,env(safe-area-inset-right));padding-left:10px}
-  .v7-home-status-main strong{font-size:14px}.v7-home-resources{gap:8px;font-size:12px}
-  .v7-bottom-nav{left:max(4px,env(safe-area-inset-left));right:max(4px,env(safe-area-inset-right));height:68px;padding-inline:2px}.v7-bottom-nav b{font-size:11px}
+  .v7-home-status-main strong{font-size:14px}.v7-home-resources{gap:8px;font-size:var(--ui-text-small)}
+  .v7-bottom-nav{left:max(4px,env(safe-area-inset-left));right:max(4px,env(safe-area-inset-right));height:68px;padding-inline:2px}.v7-bottom-nav b{font-size:14px}
   .v7-home-shell .lh-primary-action{left:16px;right:16px;bottom:calc(max(86px,env(safe-area-inset-bottom) + 78px));min-height:var(--ui-control-primary)}
-  .v7-home-shell .lh-primary-action b{font-size:16px}.v7-home-shell .lh-primary-action span{font-size:13px}
+  .v7-home-shell .lh-primary-action b{font-size:var(--ui-text-subtitle)}.v7-home-shell .lh-primary-action span{font-size:var(--ui-text-small)}
+  .v7-luna-context{left:16px;right:16px;bottom:calc(max(150px,env(safe-area-inset-bottom) + 142px))}
   .v7-category-backdrop{padding-left:6px;padding-right:6px;padding-bottom:calc(max(6px,env(safe-area-inset-bottom)) + 70px)}
 }
 
 @media(max-width:360px) and (max-height:660px){
   .v7-home-status{min-height:60px;padding-top:7px;padding-bottom:7px}.v7-guardian-chip{display:none}
-  .v7-home-shell .lh-character{width:43%;bottom:26%}
+  .v7-home-shell .lh-character{width:42%;bottom:28%}
   .v7-home-shell .lh-primary-action span{display:none}.v7-home-shell .lh-primary-action{min-height:var(--ui-control-primary);bottom:calc(max(82px,env(safe-area-inset-bottom) + 76px))}
+  .v7-luna-context{bottom:calc(max(140px,env(safe-area-inset-bottom) + 134px));padding-block:7px}.v7-luna-context span{font-size:var(--ui-text-small)}
   .v7-category-backdrop{padding-top:64px}.v7-category-sheet{max-height:72dvh}
 }
 

--- a/src/layered-home-v7.css
+++ b/src/layered-home-v7.css
@@ -1,0 +1,60 @@
+@import './mobile-ui-tokens.css';
+
+.v7-home-shell{position:absolute;inset:0;z-index:40;pointer-events:none;color:#fff;font-family:'Noto Sans KR',sans-serif;isolation:isolate}
+.v7-home-shell .lh-level,.v7-home-shell .lh-currency,.v7-home-shell .lh-weather,.v7-home-shell .lh-shortcuts,.v7-home-shell .lh-goal,.v7-home-shell .lh-promos,.v7-home-shell .lh-weekly-planner,.v7-home-shell .lh-bottom-nav,.v7-home-shell .run-guidance-card{display:none!important}
+.v7-home-shell .lh-dialogue{display:none!important}
+.v7-home-shell .lh-primary-action{left:clamp(20px,7vw,34px);right:clamp(20px,7vw,34px);bottom:calc(max(92px,env(safe-area-inset-bottom) + 84px));min-height:var(--ui-control-primary);padding:10px 16px;border-radius:var(--ui-radius-md);background:linear-gradient(180deg,#e8b85c,#9d562e);box-shadow:var(--ui-shadow);z-index:66}
+.v7-home-shell .lh-primary-action small{font-size:var(--ui-text-caption);letter-spacing:.08em}
+.v7-home-shell .lh-primary-action b{font-size:var(--ui-text-subtitle);line-height:1.25}
+.v7-home-shell .lh-primary-action span{font-size:var(--ui-text-small);line-height:1.35;margin-top:3px}
+.v7-home-shell .lh-character{bottom:24%;width:min(51%,230px)}
+
+.v7-home-status{position:absolute;z-index:72;pointer-events:auto;left:max(12px,env(safe-area-inset-left));right:max(12px,env(safe-area-inset-right));top:max(10px,env(safe-area-inset-top));min-height:66px;padding:10px 50px 10px 12px;border:1px solid var(--ui-border);border-radius:var(--ui-radius-md);background:linear-gradient(180deg,rgba(22,16,34,.9),rgba(22,16,34,.72));box-shadow:0 8px 24px rgba(0,0,0,.28);backdrop-filter:blur(10px)}
+.v7-home-status-main{display:flex;align-items:center;gap:8px;min-width:0}
+.v7-home-status-main strong{font-size:var(--ui-text-body);line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.v7-guardian-chip{flex:0 0 auto;padding:3px 7px;border:1px solid rgba(241,207,120,.45);border-radius:999px;color:var(--ui-gold);font-size:var(--ui-text-caption);font-weight:800}
+.v7-home-resources{display:flex;gap:12px;margin-top:7px;font-size:var(--ui-text-small);line-height:1.2;color:var(--ui-ivory)}
+.v7-home-resources span{display:flex;align-items:center;gap:4px;white-space:nowrap}.v7-home-resources b{color:var(--ui-gold);font-size:var(--ui-text-caption)}
+.v7-notification{position:absolute;right:8px;top:10px;width:var(--ui-touch-min);height:var(--ui-touch-min);min-width:var(--ui-touch-min);min-height:var(--ui-touch-min);display:grid;place-items:center;border:0;border-radius:14px;background:rgba(255,255,255,.09);color:var(--ui-ivory)}
+.v7-notification svg{width:22px;height:22px}.v7-notification b{position:absolute;right:1px;top:0;min-width:18px;height:18px;padding:0 4px;display:grid;place-items:center;border-radius:999px;background:#d45e62;color:white;font-size:11px;line-height:1}
+
+.v7-bottom-nav{position:absolute;z-index:74;pointer-events:auto;left:max(6px,env(safe-area-inset-left));right:max(6px,env(safe-area-inset-right));bottom:max(6px,env(safe-area-inset-bottom));height:72px;padding:6px 4px;display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:2px;border:1px solid rgba(241,207,120,.42);border-radius:20px;background:var(--ui-glass-strong);box-shadow:0 10px 28px rgba(0,0,0,.4);backdrop-filter:blur(12px)}
+.v7-bottom-nav button{position:relative;min-width:0;min-height:var(--ui-touch-min);padding:4px 1px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:3px;border:0;border-radius:14px;background:transparent;color:rgba(255,244,210,.72);font:inherit}
+.v7-bottom-nav button>span{width:23px;height:23px}.v7-bottom-nav svg{width:100%;height:100%}.v7-bottom-nav b{font-size:var(--ui-text-caption);line-height:1.05;font-weight:800;white-space:nowrap}
+.v7-bottom-nav button.is-active{background:linear-gradient(180deg,rgba(241,207,120,.22),rgba(217,156,69,.12));color:var(--ui-gold);box-shadow:inset 0 0 0 1px rgba(241,207,120,.35)}
+.v7-bottom-nav button.is-active b{font-weight:900}.v7-bottom-nav button:focus-visible,.v7-category-sheet button:focus-visible,.v7-home-status button:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
+
+.v7-category-backdrop{position:absolute;z-index:90;pointer-events:auto;inset:0;background:rgba(8,6,16,.62);display:flex;align-items:flex-end;padding:80px 8px calc(max(8px,env(safe-area-inset-bottom)) + 74px)}
+.v7-category-sheet{width:100%;max-height:min(72dvh,640px);overflow:auto;color:var(--ui-ink);background:linear-gradient(180deg,#fff8e8,#f8e7c3);border:1px solid #d9b96f;border-radius:var(--ui-radius-lg);box-shadow:0 20px 50px rgba(0,0,0,.48);overscroll-behavior:contain}
+.v7-category-header{position:sticky;top:0;z-index:2;display:grid;grid-template-columns:44px 1fr 44px;gap:10px;align-items:center;padding:14px 12px 12px;background:linear-gradient(180deg,rgba(255,248,232,.99) 80%,rgba(255,248,232,.92));border-bottom:1px solid rgba(151,108,55,.18)}
+.v7-category-icon{width:44px;height:44px;display:grid;place-items:center;border-radius:15px;background:#5b416f;color:#ffe4a0}.v7-category-icon svg{width:27px;height:27px}
+.v7-category-header small{display:block;font-size:var(--ui-text-caption);font-weight:900;letter-spacing:.08em;color:#8a6846}.v7-category-header h2{margin:1px 0 0;font-size:var(--ui-text-title);line-height:1.15}.v7-category-header p{margin:4px 0 0;font-size:var(--ui-text-small);line-height:1.35;color:#735844}
+.v7-category-close{width:var(--ui-touch-min);height:var(--ui-touch-min);min-width:var(--ui-touch-min);min-height:var(--ui-touch-min);border:0;border-radius:14px;background:#efe0c1;color:#5a4030;font-size:26px;line-height:1}
+.v7-category-content,.v7-category-grid{padding:12px;display:grid;gap:10px}.v7-category-grid{grid-template-columns:1fr}
+.v7-category-entry{min-height:var(--ui-control-secondary);width:100%;display:grid;grid-template-columns:40px minmax(0,1fr) 22px;gap:10px;align-items:center;text-align:left;padding:10px 12px;border:1px solid #dfc78f;border-radius:var(--ui-radius-md);background:rgba(255,253,247,.86);color:var(--ui-ink);font:inherit}
+.v7-category-entry-icon{width:40px;height:40px;display:grid;place-items:center;border-radius:13px;background:#f0e2c4;color:#654a79}.v7-category-entry-icon svg{width:24px;height:24px}.v7-category-entry b{display:block;font-size:var(--ui-text-button);line-height:1.25}.v7-category-entry small{display:block;margin-top:3px;font-size:var(--ui-text-small);line-height:1.35;font-weight:500;color:#765e4b}.v7-chevron{width:20px;height:20px;color:#947649}
+.v7-category-summary{min-height:72px;padding:12px 14px;border:1px solid #dcc28b;border-radius:var(--ui-radius-md);background:rgba(239,224,193,.55);display:grid;gap:3px}.v7-category-summary small{font-size:var(--ui-text-caption);font-weight:900;color:#8b6a47}.v7-category-summary b{font-size:var(--ui-text-body)}.v7-category-summary span{font-size:var(--ui-text-small);line-height:1.35;color:#725947;overflow-wrap:anywhere}
+.v7-category-sheet .weekly-planner-card,.v7-category-sheet .lineage-chronicle,.v7-category-sheet .world-chronicle{position:static!important;width:auto!important;max-width:none!important;margin:0!important;transform:none!important}
+.v7-category-sheet .weekly-focus-grid button,.v7-category-sheet .weekly-planner-resolve,.v7-category-sheet .weekly-planner-advance{min-height:var(--ui-touch-min);font-size:var(--ui-text-button)}
+.v7-records-content{padding-bottom:18px}
+
+.seasonal-home-badge{display:none!important}
+
+@media(max-width:390px){
+  .v7-home-status{left:max(8px,env(safe-area-inset-left));right:max(8px,env(safe-area-inset-right));padding-left:10px}
+  .v7-home-status-main strong{font-size:14px}.v7-home-resources{gap:8px;font-size:12px}
+  .v7-bottom-nav{left:max(4px,env(safe-area-inset-left));right:max(4px,env(safe-area-inset-right));height:68px;padding-inline:2px}.v7-bottom-nav b{font-size:11px}
+  .v7-home-shell .lh-primary-action{left:16px;right:16px;bottom:calc(max(86px,env(safe-area-inset-bottom) + 78px));min-height:var(--ui-control-primary)}
+  .v7-home-shell .lh-primary-action b{font-size:16px}.v7-home-shell .lh-primary-action span{font-size:13px}
+  .v7-category-backdrop{padding-left:6px;padding-right:6px;padding-bottom:calc(max(6px,env(safe-area-inset-bottom)) + 70px)}
+}
+
+@media(max-width:360px) and (max-height:660px){
+  .v7-home-status{min-height:60px;padding-top:7px;padding-bottom:7px}.v7-guardian-chip{display:none}
+  .v7-home-shell .lh-character{width:43%;bottom:26%}
+  .v7-home-shell .lh-primary-action span{display:none}.v7-home-shell .lh-primary-action{min-height:var(--ui-control-primary);bottom:calc(max(82px,env(safe-area-inset-bottom) + 76px))}
+  .v7-category-backdrop{padding-top:64px}.v7-category-sheet{max-height:72dvh}
+}
+
+@media(min-width:431px){.v7-home-shell,.v7-category-backdrop{max-width:520px;left:50%;right:auto;width:min(100%,520px);transform:translateX(-50%)}}
+@media(prefers-reduced-motion:reduce){.v7-home-shell *{animation:none!important;transition:none!important;scroll-behavior:auto!important}}

--- a/src/layered-home-v7.css
+++ b/src/layered-home-v7.css
@@ -42,7 +42,21 @@
 .v7-category-sheet .weekly-focus-grid button,.v7-category-sheet .weekly-planner-resolve,.v7-category-sheet .weekly-planner-advance{min-height:var(--ui-touch-min);font-size:var(--ui-text-button)}
 .v7-records-content{padding-bottom:18px}
 
-.seasonal-home-badge{display:none!important}
+.seasonal-home-badge,
+.season-live-entry,
+.sanctuary-entry,
+.raising-home-card,
+.expedition-home-card,
+.yearly-ambition-card,
+.collection-archive-trigger,
+.world-progress-card{display:none!important}
+
+@media(max-width:430px){
+  .season-live-panel button,.sanctuary-panel button,.raising-panel button,.expedition-map button,.expedition-battle button,.expedition-result button,.world-progress-panel button,.collection-archive-panel button,.yearly-ambition-panel button{min-height:var(--ui-touch-min)!important;font-size:var(--ui-text-button)!important}
+  .season-live-panel small,.sanctuary-panel small,.raising-panel small,.expedition-map small,.expedition-battle small,.expedition-result small,.world-progress-panel small,.collection-archive-panel small,.yearly-ambition-panel small{font-size:var(--ui-text-caption)!important;line-height:1.35}
+  .season-live-panel h1,.season-live-panel h2,.sanctuary-panel h1,.sanctuary-panel h2,.raising-panel h1,.raising-panel h2,.expedition-map h1,.expedition-map h2,.expedition-battle h1,.expedition-battle h2,.expedition-result h1,.expedition-result h2,.world-progress-panel h1,.world-progress-panel h2,.collection-archive-panel h1,.collection-archive-panel h2,.yearly-ambition-panel h1,.yearly-ambition-panel h2{font-size:var(--ui-text-title)!important;line-height:1.2}
+  .season-live-panel p,.sanctuary-panel p,.raising-panel p,.expedition-map p,.expedition-battle p,.expedition-result p,.world-progress-panel p,.collection-archive-panel p,.yearly-ambition-panel p{font-size:var(--ui-text-small);line-height:1.5}
+}
 
 @media(max-width:390px){
   .v7-home-status{left:max(8px,env(safe-area-inset-left));right:max(8px,env(safe-area-inset-right));padding-left:10px}

--- a/src/mobile-ui-tokens.css
+++ b/src/mobile-ui-tokens.css
@@ -1,0 +1,30 @@
+:root{
+  --ui-text-caption:12px;
+  --ui-text-small:13px;
+  --ui-text-body:15px;
+  --ui-text-button:15px;
+  --ui-text-subtitle:17px;
+  --ui-text-title:21px;
+  --ui-text-display:24px;
+  --ui-touch-min:44px;
+  --ui-control-secondary:48px;
+  --ui-control-primary:52px;
+  --ui-radius-sm:12px;
+  --ui-radius-md:18px;
+  --ui-radius-lg:24px;
+  --ui-space-1:4px;
+  --ui-space-2:8px;
+  --ui-space-3:12px;
+  --ui-space-4:16px;
+  --ui-space-5:20px;
+  --ui-glass:rgba(20,15,32,.82);
+  --ui-glass-strong:rgba(20,15,32,.94);
+  --ui-parchment:#fff6df;
+  --ui-parchment-soft:#fffaf0;
+  --ui-ink:#473226;
+  --ui-ivory:#fff4d2;
+  --ui-gold:#f1cf78;
+  --ui-gold-strong:#d99c45;
+  --ui-border:rgba(241,207,120,.58);
+  --ui-shadow:0 12px 30px rgba(9,5,18,.36);
+}

--- a/src/v7-external-launchers.test.tsx
+++ b/src/v7-external-launchers.test.tsx
@@ -1,0 +1,43 @@
+import {describe,expect,it} from 'vitest';
+// @ts-ignore -- source contract test runs in Node.
+import {readFileSync} from 'node:fs';
+
+const css=readFileSync(new URL('./layered-home-v7.css',import.meta.url),'utf8');
+const sheet=readFileSync(new URL('./MobileCategorySheet.tsx',import.meta.url),'utf8');
+const shell=readFileSync(new URL('./LayeredHomeV7.tsx',import.meta.url),'utf8');
+
+describe('V7 legacy launcher consolidation',()=>{
+  it('removes all legacy floating launchers from the default home surface',()=>{
+    for(const selector of [
+      '.season-live-entry',
+      '.sanctuary-entry',
+      '.raising-home-card',
+      '.expedition-home-card',
+      '.yearly-ambition-card',
+      '.collection-archive-trigger',
+      '.world-progress-card',
+    ]) expect(css).toContain(selector);
+  });
+
+  it('moves launcher destinations into growth adventure and records categories',()=>{
+    for(const label of [
+      '성장 정체성',
+      '시즌 여정',
+      '별빛 성소',
+      '수호자 원정',
+      '월드 진행',
+      '올해의 야망',
+      '성장 도감',
+    ]) expect(sheet).toContain(label);
+  });
+
+  it('exposes explicit shell callbacks for the migrated destinations',()=>{
+    for(const callback of [
+      'onRaising',
+      'onSanctuary',
+      'onWorldProgress',
+      'onArchive',
+      'onAmbition',
+    ]) expect(shell).toContain(callback);
+  });
+});

--- a/src/v7-mobile-home-architecture.test.tsx
+++ b/src/v7-mobile-home-architecture.test.tsx
@@ -2,30 +2,47 @@ import { describe, expect, it } from 'vitest';
 // @ts-ignore -- Vitest executes this contract in Node; app tsconfig intentionally excludes Node globals.
 import { readFileSync } from 'node:fs';
 
-const source = readFileSync(new URL('./LayeredHome.tsx', import.meta.url), 'utf8');
-const css = readFileSync(new URL('./layered-home.css', import.meta.url), 'utf8');
+const root = readFileSync(new URL('./Root.tsx', import.meta.url), 'utf8');
+const shell = readFileSync(new URL('./LayeredHomeV7.tsx', import.meta.url), 'utf8');
+const categories = readFileSync(new URL('./MobileCategorySheet.tsx', import.meta.url), 'utf8');
+const legacyHome = readFileSync(new URL('./LayeredHome.tsx', import.meta.url), 'utf8');
+const css = readFileSync(new URL('./layered-home-v7.css', import.meta.url), 'utf8');
+const tokens = readFileSync(new URL('./mobile-ui-tokens.css', import.meta.url), 'utf8');
 
 describe('V7 mobile home information architecture', () => {
+  it('switches the real hub entrypoint to the V7 shell', () => {
+    expect(root).toContain("import LayeredHomeV7 from './LayeredHomeV7'");
+    expect(root).toContain('<LayeredHomeV7');
+  });
+
   it('uses six clear semantic bottom categories', () => {
-    for (const label of ['홈', '생활', '성장', '모험', '인연', '기록']) expect(source).toContain(label);
+    for (const label of ['홈', '생활', '성장', '모험', '인연', '기록']) expect(categories).toContain(`label:'${label}'`);
+    expect(shell).toContain('mobileCategories.map');
   });
 
-  it('keeps exactly one authoritative primary action', () => {
-    expect((source.match(/className="lh-primary-action"/g) ?? []).length).toBe(1);
-    expect(source).toContain('hubNextAction(state)');
+  it('keeps exactly one authoritative primary action implementation', () => {
+    expect((legacyHome.match(/className="lh-primary-action"/g) ?? []).length).toBe(1);
+    expect(legacyHome).toContain('hubNextAction(state)');
+    expect(shell).toContain('hubNextAction(state)');
   });
 
-  it('removes legacy always-visible shortcut and promo clusters from the default home', () => {
-    expect(source).not.toContain('className="lh-shortcuts"');
-    expect(source).not.toContain('className="lh-promos"');
-    expect(source).not.toContain('className="lh-goal"');
+  it('hides legacy shortcut, promo, goal, planner and bottom-nav clutter from the visible V7 home', () => {
+    for (const selector of ['.lh-shortcuts','.lh-promos','.lh-goal','.lh-weekly-planner','.lh-bottom-nav']) {
+      expect(css).toContain(selector);
+    }
+    expect(css).toContain('display:none!important');
   });
 
-  it('does not mount the full weekly planner permanently on the home scene', () => {
-    expect(source).not.toContain('className="lh-weekly-planner"');
+  it('moves weekly planning and chronicles behind semantic category disclosure', () => {
+    expect(shell).not.toContain("from './WeeklyPlannerCard'");
+    expect(categories).toContain('<WeeklyPlannerCard');
+    expect(categories).toContain('<LineageChronicle');
+    expect(categories).toContain('<WorldChronicle');
   });
 
   it('reserves readable mobile controls', () => {
-    expect(css).toContain('min-height:52px');
+    expect(tokens).toContain('--ui-control-primary:52px');
+    expect(tokens).toContain('--ui-touch-min:44px');
+    expect(css).toContain('min-height:var(--ui-control-primary)');
   });
 });

--- a/src/v7-mobile-home-architecture.test.tsx
+++ b/src/v7-mobile-home-architecture.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+// @ts-ignore -- Vitest executes this contract in Node; app tsconfig intentionally excludes Node globals.
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('./LayeredHome.tsx', import.meta.url), 'utf8');
+const css = readFileSync(new URL('./layered-home.css', import.meta.url), 'utf8');
+
+describe('V7 mobile home information architecture', () => {
+  it('uses six clear semantic bottom categories', () => {
+    for (const label of ['홈', '생활', '성장', '모험', '인연', '기록']) expect(source).toContain(label);
+  });
+
+  it('keeps exactly one authoritative primary action', () => {
+    expect((source.match(/className="lh-primary-action"/g) ?? []).length).toBe(1);
+    expect(source).toContain('hubNextAction(state)');
+  });
+
+  it('removes legacy always-visible shortcut and promo clusters from the default home', () => {
+    expect(source).not.toContain('className="lh-shortcuts"');
+    expect(source).not.toContain('className="lh-promos"');
+    expect(source).not.toContain('className="lh-goal"');
+  });
+
+  it('does not mount the full weekly planner permanently on the home scene', () => {
+    expect(source).not.toContain('className="lh-weekly-planner"');
+  });
+
+  it('reserves readable mobile controls', () => {
+    expect(css).toContain('min-height:52px');
+  });
+});

--- a/src/v7-mobile-icons.test.tsx
+++ b/src/v7-mobile-icons.test.tsx
@@ -1,23 +1,31 @@
+import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 // @ts-ignore -- Vitest executes source contracts in Node; app tsconfig intentionally excludes Node globals.
 import { readFileSync } from 'node:fs';
+import MobileNavIcon,{type MobileNavIconName} from './MobileNavIcon';
 
-const homeSource = readFileSync(new URL('./LayeredHome.tsx', import.meta.url), 'utf8');
-const css = readFileSync(new URL('./layered-home.css', import.meta.url), 'utf8');
+const css = readFileSync(new URL('./layered-home-v7.css', import.meta.url), 'utf8');
+const tokens = readFileSync(new URL('./mobile-ui-tokens.css', import.meta.url), 'utf8');
+const icons:MobileNavIconName[]=['home','life','growth','adventure','bond','records'];
 
 describe('V7 mobile design system contracts', () => {
   it('imports the shared mobile UI token layer', () => {
     expect(css).toContain("@import './mobile-ui-tokens.css'");
+    for(const token of ['--ui-text-caption:12px','--ui-text-small:13px','--ui-text-body:15px','--ui-text-button:15px','--ui-text-title:21px','--ui-touch-min:44px','--ui-control-primary:52px']) expect(tokens).toContain(token);
   });
 
-  it('uses semantic mobile icon names in the home shell', () => {
-    for (const icon of ['home', 'life', 'growth', 'adventure', 'bond', 'records']) {
-      expect(homeSource).toContain(`'${icon}'`);
+  it('renders all six category icons as consistent currentColor SVGs', () => {
+    for(const icon of icons){
+      const markup=renderToStaticMarkup(<MobileNavIcon name={icon}/>);
+      expect(markup).toContain('viewBox="0 0 24 24"');
+      expect(markup).toContain('stroke="currentColor"');
+      expect(markup).toContain('stroke-width="1.9"');
     }
   });
 
-  it('removes important 8px and 9px home action labels', () => {
-    expect(css).not.toMatch(/\.lh-primary-action[^}]*font-size:(?:8|9)px/);
-    expect(css).toContain('--ui-text-button');
+  it('uses readable tokenized primary and navigation labels', () => {
+    expect(css).toContain('.lh-primary-action b{font-size:var(--ui-text-subtitle)');
+    expect(css).toContain('.v7-bottom-nav b{font-size:var(--ui-text-button)');
+    expect(css).not.toMatch(/\.v7-bottom-nav b\{[^}]*font-size:(?:8|9|10|11|12|13)px/);
   });
 });

--- a/src/v7-mobile-icons.test.tsx
+++ b/src/v7-mobile-icons.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+// @ts-ignore -- Vitest executes source contracts in Node; app tsconfig intentionally excludes Node globals.
+import { readFileSync } from 'node:fs';
+
+const homeSource = readFileSync(new URL('./LayeredHome.tsx', import.meta.url), 'utf8');
+const css = readFileSync(new URL('./layered-home.css', import.meta.url), 'utf8');
+
+describe('V7 mobile design system contracts', () => {
+  it('imports the shared mobile UI token layer', () => {
+    expect(css).toContain("@import './mobile-ui-tokens.css'");
+  });
+
+  it('uses semantic mobile icon names in the home shell', () => {
+    for (const icon of ['home', 'life', 'growth', 'adventure', 'bond', 'records']) {
+      expect(homeSource).toContain(`'${icon}'`);
+    }
+  });
+
+  it('removes important 8px and 9px home action labels', () => {
+    expect(css).not.toMatch(/\.lh-primary-action[^}]*font-size:(?:8|9)px/);
+    expect(css).toContain('--ui-text-button');
+  });
+});


### PR DESCRIPTION
Promote the verified V7 mobile UX integration tree to production.

Tracks #195 and source PR #196.

## Exact release candidate
- integration/v3: `43706e6c25b04786e9aaf4acccfedccb51735867`
- tree: `29ad5ef6b2af615f651badc9e7292956e5e2937b`
- current main baseline: `0166df866e51fae6e320edd5cc76dd5d166b3a57`

## Verified source evidence
- work head: `3a64c6759859bb7b22e3a7cb9b126a2c59cfcbce`
- source PR #196 merged successfully
- CI #1917 SUCCESS
  - 460/460 test files
  - 1793/1793 tests
  - dependency audit: 0 vulnerabilities
  - TypeScript GREEN
  - Vite production build GREEN
- exact-head Vercel preview `dpl_3tk6Kqj8sJasjujx9Nc8r7L46sdP` READY
  - root HTTP 200
  - build errors none
  - preview error/fatal runtime logs none in verification window

## V7 scope
- semantic six-category navigation: 홈 / 생활 / 성장 / 모험 / 인연 / 기록
- custom SVG icon system and shared mobile UI tokens
- simplified home with one authoritative next action
- launcher consolidation into semantic categories
- weekly planner / lineage / world history progressive disclosure
- 360/390/430 mobile readability, safe-area, touch and reduced-motion hardening

No intentional game/save semantic changes. This PR is the final integration-to-main release gate.