### PR TITLE
Release V8 Mobile Router to main

### DIFF
--- a/docs/superpowers/plans/2026-08-26-puppy-maker-v8-mobile-router.md
+++ b/docs/superpowers/plans/2026-08-26-puppy-maker-v8-mobile-router.md
@@ -1,0 +1,194 @@
+# V8 Mobile Router Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace V7’s split sheet/overlay navigation with one mobile navigation authority that keeps six-category browsing persistent, provides predictable feature return paths, and guards only unfinished training/Tactical/choice attempts.
+
+**Architecture:** Add a pure `mobile-router.ts` domain and make `Root` the semantic navigation owner. Reuse existing reducers and feature components, but derive their visibility from the router instead of independent launcher state. A V8 chrome layer provides compact status, six-category navigation, route headers, a single scroll contract, and guarded Back/Home controls. Existing gameplay screens remain reducer-driven in `App`; router state mirrors their semantic origin and active-attempt status.
+
+**Tech Stack:** React 19, TypeScript, CSS, Vitest, Vite.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-puppy-maker-v8-mobile-router-design.md`
+
+## Global Constraints
+- Work only on `work/v8-mobile-router` until release promotion.
+- Preserve save schema and all V3/V4/V5/V6/V7 gameplay semantics.
+- `hubNextAction(state)` remains the authoritative home CTA selector.
+- Navigation state is ephemeral and must not enter save data.
+- Main categories remain exactly `홈 / 생활 / 성장 / 모험 / 인연 / 기록`.
+- Six-category navigation is visible for home/category/ordinary feature/completed-result states.
+- Six-category navigation is hidden only for unfinished training, Tactical battle, choice event, or equivalent active attempt; those states show guarded `뒤로 + 홈` only.
+- Guard copy: `진행 중인 플레이를 종료할까요?` / `지금 나가면 현재 진행 내용이 완료되지 않습니다.` / `계속하기` / `종료하고 이동`.
+- Touch targets >=44px, preferred 48px; no critical actionable text below 14px.
+- Mobile contracts: 360×640, 390×844, 430px class, safe areas, `100dvh`, reduced motion.
+- No force push. No integration/main/production promotion without fresh CI/build evidence.
+
+---
+
+### Task 1: Pure mobile router domain
+
+**Files:**
+- Create: `src/mobile-router.ts`
+- Create: `src/mobile-router.test.ts`
+
+**Interfaces:**
+- Produces `MobileCategoryId`, `MobileFeatureId`, `MobilePlayScreen`, `MobileRoute`, `MobileNavigationState`.
+- Produces `initialMobileNavigationState`, `mobileNavigationReducer`, `isGuardedActiveRoute`, `categoryForFeature`.
+- Actions: `OPEN_CATEGORY`, `OPEN_FEATURE`, `OPEN_PLAY`, `BACK`, `HOME`, `FINISH_FEATURE`, `FINISH_PLAY`, `REPLACE`.
+
+- [ ] Write RED tests for home→category, category→feature, category switch normalization, active-category no-op, feature back, feature finish, category back, finish play, malformed replacement fallback, and guarded active-attempt detection.
+- [ ] Run PR CI and confirm only the new router contract fails because the module does not exist.
+- [ ] Implement a pure reducer with no React/game imports and deterministic normalized stacks.
+- [ ] Re-run targeted/full CI; router tests must be GREEN before UI integration.
+
+### Task 2: V8 chrome and scroll contract
+
+**Files:**
+- Create: `src/MobileRouterChrome.tsx`
+- Create: `src/mobile-router-v8.css`
+- Create: `src/v8-mobile-router-ui.test.tsx`
+- Reuse: `src/MobileHomeStatus.tsx`, `src/MobileNavIcon.tsx`, `src/mobile-ui-tokens.css`
+
+**Interfaces:**
+- `MobileRouterChrome` props include `state`, `navigation`, `onCategory`, `onBack`, `onHome`, `guarded`, `pendingExit`, `onRequestExit`, `onCancelExit`, `onConfirmExit`.
+- Normal states render compact status + six nav.
+- Guarded states render only Back/Home controls and confirmation when requested.
+
+- [ ] Write RED render/source contracts for six nav labels in normal mode, Back/Home-only guarded mode, confirmation copy, and focusable >=44px controls.
+- [ ] Implement the chrome with a single confirmation component.
+- [ ] Implement `.v8-mobile-shell`, `.v8-route-body`, `.v8-bottom-nav`, `.v8-play-guard` using `100dvh`, `min-height:0`, `overflow-y:auto`, `overscroll-behavior:contain`, and safe-area padding.
+- [ ] Add 360/390/430 rules and pressed/focus/reduced-motion states.
+- [ ] Verify targeted tests/build.
+
+### Task 3: Full-page category routing
+
+**Files:**
+- Create: `src/MobileCategoryPage.tsx`
+- Create: `src/v8-mobile-category-page.test.tsx`
+- Modify: `src/LayeredHomeV7.tsx` or replace its route-owning responsibilities with V8 home presentation.
+- Retire runtime use of: `src/MobileCategorySheet.tsx`.
+
+**Interfaces:**
+- Category page receives `category`, `state`, and `onOpenFeature(feature)`.
+- Life: Weekly Planner, schedule, mission, attendance, mail.
+- Growth: raising, ambition, achievements, inventory, season, sanctuary.
+- Adventure: outing, expedition, world.
+- Bond: bond, gifts, stories.
+- Records: lineage, world chronicle, archive.
+
+- [ ] Write RED contracts asserting categories render as pages rather than `.v7-category-backdrop` sheets and all six bottom categories remain reachable.
+- [ ] Implement full-page category content with V7 icon language and 48px entry cards.
+- [ ] Ensure only `.v8-route-body` owns page scrolling; nested chronicle/planner components are made static within that body.
+- [ ] Verify long content cannot cover bottom navigation structurally.
+
+### Task 4: Route legacy home features back to origin categories
+
+**Files:**
+- Modify: `src/LayeredHome.tsx`
+- Modify: `src/layered-home.css`
+- Create: `src/v8-legacy-feature-routing.test.tsx`
+
+**Interfaces:**
+- Add controlled panel props: `controlledPanel?: HomeMenuId|null`, `onControlledPanelClose?:()=>void` while preserving old uncontrolled behavior for tests/compatibility.
+- V8 routes map: mission/attendance/mail→life; quest/bag→growth or bond where invoked; outing→adventure; bond/event→bond.
+
+- [ ] Write RED contracts for controlled panel close callback and origin-category routing.
+- [ ] Implement controlled panel selection without changing claim/gift/outing reducer callbacks.
+- [ ] In V8 mode constrain `.lh-panel-backdrop/.lh-panel` between persistent chrome areas and prevent a hidden close-control trap.
+- [ ] Verify claim actions do not auto-home; close/back returns semantic category.
+
+### Task 5: Make Root overlays router-controlled
+
+**Files:**
+- Modify: `src/Root.tsx`
+- Modify as needed: `src/SeasonLiveOpsOverlay.tsx`, `src/SanctuaryOverlay.tsx`, `src/RaisingIdentityOverlay.tsx`, `src/GuardianExpeditionOverlay.tsx`, `src/WorldProgressOverlay.tsx`, `src/CollectionArchiveOverlay.tsx`, `src/YearlyAmbitionOverlay.tsx`
+- Create: `src/v8-root-feature-routing.test.tsx`
+
+**Interfaces:**
+- Remove independent `seasonLiveOpen`, `sanctuaryOpen`, `raisingOpen`, `worldProgressOpen`, `archiveOpen`, `ambitionOpen` authority where router can derive open state.
+- Route close callbacks dispatch `BACK`/`FINISH_FEATURE` instead of resetting home.
+- Feature open is true exactly when current route maps to that feature.
+
+- [ ] Write RED source/render contracts for route-derived overlay visibility and close destinations.
+- [ ] Add `mobilePage`/controlled mode only where an existing overlay cannot coexist with persistent chrome; do not change game callbacks.
+- [ ] Keep exactly one normal feature visible at a time.
+- [ ] Ensure bottom navigation z/order and content bounds remain usable above ordinary feature presentation.
+- [ ] Verify Growth→season/sanctuary/ambition→Back = Growth; Adventure→world/expedition prestart→Back = Adventure; Records→archive→Back = Records.
+
+### Task 6: Integrate App schedule/training/dialogue/result navigation
+
+**Files:**
+- Modify: `src/Root.tsx`
+- Modify minimally: `src/App.tsx` only if a semantic transition callback is required.
+- Create: `src/v8-play-routing.test.tsx`
+
+**Interfaces:**
+- `gameState.screen==='schedule'`: normal, six nav visible, semantic origin life.
+- `training`: guarded active attempt.
+- `dialogue`: guarded unresolved choice attempt.
+- `result`: normal completed state, six nav visible.
+- Confirmed guarded Home dispatches `navigate('hub')` and router HOME. Confirmed guarded Back dispatches hub and returns to the recorded parent category.
+
+- [ ] Write RED tests/source contracts for normal schedule, guarded training/dialogue, and normal result.
+- [ ] Implement screen-to-route synchronization without persisting navigation state.
+- [ ] Add explicit guarded exit confirmation; cancel must not mutate reducer state or route.
+- [ ] Make category selection from schedule/result navigate App to hub before opening the chosen category.
+- [ ] Preserve normal reducer-driven result completion; when the cycle returns hub, router normalizes home.
+
+### Task 7: Tactical battle active-attempt guard
+
+**Files:**
+- Modify: `src/TacticalExpeditionFlow.tsx`
+- Modify: `src/Root.tsx`
+- Create: `src/v8-tactical-navigation.test.tsx`
+
+**Interfaces:**
+- Add `onBattleStateChange?: (state:{active:boolean;result:boolean})=>void`.
+- Starting a battle emits `{active:true,result:false}`.
+- Resolution emits `{active:false,result:true}` before/with completion callbacks.
+- Retry emits active true again; final exit emits inactive.
+
+- [ ] Write RED tests for battle-state callback transitions.
+- [ ] Implement callback without changing tactical engine/session math.
+- [ ] Root hides six nav only while tactical active=true/result=false and shows guarded Back/Home.
+- [ ] Completed Tactical result restores six nav.
+- [ ] Confirmed guarded exit closes tactical session/expedition and returns Adventure for Back or Home for Home.
+
+### Task 8: Remove V7 routing authority and harden usability
+
+**Files:**
+- Modify: `src/Root.tsx`
+- Modify: `src/LayeredHomeV7.tsx` or replace with `src/MobileHomeV8.tsx`
+- Modify: `src/layered-home-v7.css`
+- Modify: `src/mobile-router-v8.css`
+- Create: `src/v8-mobile-usability-contract.test.tsx`
+
+**Interfaces:**
+- No runtime category state in V7 sheet.
+- No V7 category backdrop covering nav.
+- Root router is the only category/feature navigation authority.
+
+- [ ] Write RED contracts rejecting `.v7-category-backdrop` runtime use and independent launcher booleans.
+- [ ] Remove/retire sheet/backdrop routing from production render.
+- [ ] Normalize status header height/arrangement and ensure date/resources are readable at 360px.
+- [ ] Enforce final-row bottom padding, sticky/visible headers, 44/48px touch targets, and 14px+ critical controls across routed feature overlays.
+- [ ] Add Escape/focus-visible/reduced-motion source contracts.
+
+### Task 9: Full regression and release gate
+
+**Files:**
+- Update PR # for release evidence.
+- Update issue #198 with final evidence.
+
+- [ ] Run targeted V8 suites through CI.
+- [ ] Run full `npm run test`; expected baseline is at least 460 files / 1793 tests with all new V8 tests added.
+- [ ] Run dependency audit; require 0 vulnerabilities.
+- [ ] Run `npm run build`; require TypeScript + Vite success.
+- [ ] Review PR diff for unintended save/game changes.
+- [ ] Merge source PR normally to `integration/v3`; no force push.
+- [ ] Open integration→main release PR and require synthetic merge CI GREEN.
+- [ ] Merge to main with expected-head protection.
+- [ ] Require exact-main push CI GREEN.
+- [ ] Verify exact-main Vercel production deployment is READY.
+- [ ] Smoke canonical production root HTTP 200 and `/api/client-telemetry` HTTP 200 `{"ok":true}`.
+- [ ] Query production error/fatal runtime logs; require no V8 runtime errors before closing #198 completed.

--- a/docs/superpowers/specs/2026-08-26-puppy-maker-v8-mobile-router-design.md
+++ b/docs/superpowers/specs/2026-08-26-puppy-maker-v8-mobile-router-design.md
@@ -1,0 +1,385 @@
+# V8 Mobile Router — Full-screen Navigation & Usability Rewrite
+
+## Status
+Approved direction: **C — full mobile router rewrite**.
+
+## Baseline
+- `integration/v3@43706e6c25b04786e9aaf4acccfedccb51735867`
+- `main@6da538c208d23a40d7a7475854afdbf3c18802ec`
+- shared tree: `29ad5ef6b2af615f651badc9e7292956e5e2937b`
+
+## Goal
+Replace the V7 overlay-heavy mobile navigation model with one predictable, mobile-first navigation authority that keeps status, back behavior, scrolling, touch controls, gameplay exits, and category return paths consistent across the app.
+
+The rewrite must improve usability without changing save, progression, combat, season, lineage, world, NG+, True/Hollow, or reward semantics.
+
+## Why a router rewrite is necessary
+V7 reduced home clutter, but navigation remains split across several authorities:
+- `LayeredHomeV7` owns category state.
+- `LayeredHome` owns legacy home panels.
+- `Root` owns season/sanctuary/raising/expedition/world/archive/ambition overlays.
+- `App` owns gameplay screens such as schedule/training/dialogue/result.
+
+This produces inconsistent return paths and stacking rules. A category sheet can obscure the bottom navigation, legacy panels close directly to home, and full-screen feature overlays have independent open/close state. The user should not have to understand which implementation layer a feature belongs to.
+
+## Design principles
+1. **One navigation authority.** Mobile navigation state lives in a single router model.
+2. **One visible page layer.** Normal navigation uses pages, not stacked full-screen overlays.
+3. **Predictable back.** Back means one semantic step backward.
+4. **Predictable finish.** Feature completion returns to the origin category; complete play cycles return to home unless the flow explicitly continues.
+5. **Persistent controls.** The user must always retain a visible path back or home.
+6. **Content scrolls, controls stay reachable.** Page header and bottom navigation stay stable; only the content region scrolls.
+7. **No gameplay semantics in the router.** The router controls presentation/history only; reducers remain authoritative for game state.
+8. **Mobile first.** 360×640, 390×844, and 430px-class devices are first-class contracts.
+
+## Route model
+Create a dedicated mobile router domain.
+
+```ts
+export type MobileCategoryId =
+  | 'home'
+  | 'life'
+  | 'growth'
+  | 'adventure'
+  | 'bond'
+  | 'records';
+
+export type MobileFeatureId =
+  | 'schedule'
+  | 'mission'
+  | 'attendance'
+  | 'mail'
+  | 'raising'
+  | 'ambition'
+  | 'achievements'
+  | 'inventory'
+  | 'season'
+  | 'sanctuary'
+  | 'outing'
+  | 'expedition'
+  | 'world'
+  | 'bond'
+  | 'gifts'
+  | 'stories'
+  | 'archive'
+  | 'lineage'
+  | 'world_chronicle';
+
+export type MobileRoute =
+  | {kind:'home'}
+  | {kind:'category'; category:Exclude<MobileCategoryId,'home'>}
+  | {kind:'feature'; category:Exclude<MobileCategoryId,'home'>; feature:MobileFeatureId}
+  | {kind:'play'; category:MobileCategoryId; screen:'schedule'|'training'|'dialogue'|'result'};
+
+export type MobileNavigationState = {
+  current: MobileRoute;
+  stack: MobileRoute[];
+};
+```
+
+The exact feature list may only be expanded when an already-existing V7 feature is mapped. V8 does not create unrelated gameplay systems.
+
+## Navigation operations
+The router exposes a small interface:
+
+```ts
+openCategory(category)
+openFeature(category, feature)
+openPlay(category, screen)
+replace(route)
+back()
+home()
+finishFeature()
+finishPlayCycle()
+```
+
+Rules:
+- `openCategory`: category becomes current route and is pushed from home or another category.
+- `openFeature`: remembers the origin category.
+- `back`: returns to the previous semantic route, never an implementation overlay.
+- `finishFeature`: returns to the feature's origin category.
+- `finishPlayCycle`: returns to home and clears transient play history.
+- `home`: clears stack and returns to `{kind:'home'}`.
+- repeated selection of the active bottom-nav category does not duplicate history.
+- switching bottom-nav categories replaces the current category/feature route rather than building a long category stack.
+
+## Bottom navigation behavior
+The six V7 categories remain:
+- 홈
+- 생활
+- 성장
+- 모험
+- 인연
+- 기록
+
+The bottom navigation is visible on home and category pages and remains reachable while category content scrolls.
+
+Feature pages may either keep the bottom bar visible or use a compact home/back footer when screen real estate is constrained; whichever option is used must be consistent per page class and must not allow hidden navigation traps.
+
+Bottom category switching must work in one tap even while another category is open.
+
+## Mobile shell layout
+Replace the V7 backdrop/sheet composition with a full-height shell:
+
+```text
+safe area
+┌─────────────────────────┐
+│ compact status/header   │  sticky/fixed within shell
+├─────────────────────────┤
+│                         │
+│ scrollable page body    │  overflow-y:auto; min-height:0
+│                         │
+├─────────────────────────┤
+│ bottom navigation       │  persistent, safe-area aware
+└─────────────────────────┘
+```
+
+Structural requirements:
+- shell uses `100dvh` when supported.
+- content region uses `min-height:0` and `overflow-y:auto`.
+- body/root must not become the feature scroll container.
+- `overscroll-behavior:contain` prevents accidental background scrolling.
+- header and navigation never disappear below long content.
+- no page requires scrolling back to the top just to close it.
+
+## Status header redesign
+The status window becomes a stable compact component shared by home/category/feature pages.
+
+### Row 1
+- generation
+- year
+- month/week
+- notification affordance
+
+### Row 2
+- gold
+- gems
+- stamina
+- guardian points/rank summary
+
+Requirements:
+- target height about 56–64px excluding safe area.
+- no important value below 13px.
+- primary text 15–16px minimum on 360px-class devices.
+- overflow truncation must preserve the date/time context before decorative labels.
+- notification button minimum touch target 44px.
+
+## Page header
+Category and feature pages use a consistent page header:
+- back button when there is a parent route.
+- page title.
+- optional compact context/subtitle.
+- optional home button for deep feature/play routes.
+
+Back and home controls must be at least 44×44px.
+
+## Category pages
+V7 category content is retained but rendered as full pages rather than bottom sheets.
+
+### 생활
+- Weekly Planner
+- schedule
+- monthly mission
+- attendance
+- mail
+
+### 성장
+- raising identity
+- yearly ambition
+- achievements
+- inventory/abilities
+- season
+- sanctuary
+
+### 모험
+- outing
+- expedition/tactical
+- world progress
+- generational public project summary
+
+### 인연
+- bond
+- gifts
+- stories/events
+
+### 기록
+- lineage
+- world chronicle
+- archive
+- discovery/collection summary
+
+Category entry cards keep the V7 icon language but receive clearer pressed/active feedback and uniform minimum height.
+
+## Feature adaptation strategy
+Do not rewrite game domain logic. Adapt presentation incrementally behind the router.
+
+### Legacy `LayeredHome` panels
+Quest/achievement, bond, bag/inventory, outing, mission, event, attendance, and mail content must be extracted into route-renderable feature components or a shared `MobileLegacyFeaturePage` adapter. They may no longer own a backdrop that returns directly to home.
+
+### Root overlays
+Season, sanctuary, raising, expedition, world progress, archive, and ambition must accept router-controlled page mode. Their existing callback semantics remain unchanged.
+
+During migration, an adapter may render existing inner content inside the V8 page body. The old home launcher and independent open-state authority must be removed once that feature is router-controlled.
+
+## Gameplay routes
+`App` remains authoritative for reducer-driven gameplay state, but navigation presentation must integrate with the V8 router.
+
+### Schedule flow
+`생활 → schedule → training → dialogue/result`
+
+Rules:
+- entering schedule records `life` as the origin category.
+- normal back from schedule before starting returns to 생활.
+- starting training enters play mode.
+- while a training attempt is active, accidental category switching is disabled or guarded; there must always be an explicit exit control.
+- completing the full training/result cycle returns to **home**.
+
+### Expedition/Tactical flow
+`모험 → expedition → tactical/result`
+
+Rules:
+- closing before starting returns to 모험.
+- completing/aborting the active expedition flow exits to 모험 unless the game reducer explicitly ends a global play cycle that should return home.
+- tactical result screen must expose a visible exit control.
+
+## Feature-completion return rules
+Feature completion must preserve spatial memory:
+
+- 성장 → 성장 업적 → reward claim → close/back = 성장
+- 생활 → 출석 → claim → close/back = 생활
+- 생활 → 우편 → claim → close/back = 생활
+- 성장 → 야망 → select → close/back = 성장
+- 성장 → 시즌/성소 → action → close/back = 성장
+- 모험 → 월드 → close/back = 모험
+- 기록 → 도감 → close/back = 기록
+- 인연 → 선물/이야기 → close/back = 인연
+
+No feature action may implicitly reset the route to home unless it represents a complete play cycle or the user taps Home.
+
+## Scroll and viewport contracts
+Every route must satisfy:
+- 360×640
+- 390×844
+- 430px-class width
+- safe-area top and bottom
+- keyboard/focus-visible controls
+- reduced-motion
+
+For long content:
+- scrollable body has bottom padding at least `bottomNavHeight + safeArea + 16px` when bottom nav overlays content.
+- sticky page header remains visible.
+- no fixed CTA can cover the last actionable row.
+- nested full-page scroll containers are prohibited.
+- dialogs used for truly modal confirmation must have their own bounded scroll area and accessible close button.
+
+## Touch feedback
+All main navigation and feature-entry controls:
+- minimum 44px touch target; preferred 48px.
+- visible pressed state using transform/brightness/background, not color alone.
+- active navigation state combines color + fill/background + typography.
+- disabled state is visually distinct and cannot receive accidental click handlers.
+
+## Typography
+Retain V7 token system, but enforce it across routed pages:
+- captions: 12–13px only for non-critical metadata.
+- secondary body: 14px minimum.
+- primary body/button: 15–16px minimum.
+- section title: 17–18px.
+- page title: 21–24px.
+- no critical actionable text at 8–11px.
+
+## Accessibility and focus
+- changing routes moves focus to the new page heading or first meaningful control.
+- `back()` returns focus to the entry that opened the child route when practical.
+- Escape maps to `back()` for feature routes on hardware keyboards.
+- route pages expose meaningful `aria-label`/heading hierarchy.
+- decorative icons remain `aria-hidden`.
+
+## Error and safety behavior
+- unknown/malformed transient route data falls back to home; navigation state is not persisted in the save schema.
+- missing optional callbacks render disabled/unavailable entries rather than throwing.
+- feature completion callbacks run before navigation return so game-state mutations are not lost.
+- rapid repeated category taps cannot duplicate stack entries.
+
+## Data and save compatibility
+V8 adds no persistent gameplay fields.
+
+Do not change:
+- save schema meaning
+- raw stats/gold/gems inheritance rules
+- NG+ semantics
+- lineage semantics
+- True/Hollow activation rules
+- weekly deterministic event semantics
+- combat rewards or progression
+
+Navigation state is ephemeral UI state only.
+
+## Migration sequence
+1. Add pure mobile router domain and tests.
+2. Add V8 shell, page header, persistent nav, and scrolling contract.
+3. Move V7 categories from sheet routes to page routes.
+4. Adapt legacy home features.
+5. Adapt Root overlays into router-controlled pages.
+6. Integrate schedule/training/result return rules.
+7. Integrate expedition/tactical return rules.
+8. Remove V7 sheet/backdrop and independent launcher state that is no longer authoritative.
+9. Run mobile usability regression and full project regression.
+
+## Testing strategy
+### Pure router tests
+Lock:
+- category switching does not duplicate stack.
+- feature back returns to origin category.
+- `finishFeature()` returns to origin category.
+- `finishPlayCycle()` returns home and clears transient stack.
+- malformed route fallback.
+
+### Render/interaction tests
+Lock:
+- six bottom-nav categories remain reachable from category pages.
+- long category content scrolls while header/nav remain structurally persistent.
+- back from achievements returns to growth.
+- close from mail returns to life.
+- archive returns to records.
+- expedition pre-start close returns to adventure.
+- training result completion returns home.
+- no feature backdrop covers the navigation unexpectedly.
+
+### Mobile CSS/source contracts
+Lock:
+- `100dvh` shell.
+- `min-height:0` scroll region.
+- `overflow-y:auto` only on routed content container for page scrolling.
+- safe-area paddings.
+- 44/48px control minimums.
+- 360/390/430 media rules.
+
+### Release regression
+- targeted V8 suites
+- full existing suite (baseline 460 files / 1793 tests)
+- TypeScript
+- production build
+- dependency audit
+- integration PR synthetic merge CI
+- main exact-SHA CI
+- production exact-SHA Vercel READY
+- production root/API smoke
+- production runtime error/fatal log check
+
+## Non-goals
+- redesigning game art.
+- changing game economy or progression.
+- adding desktop-only navigation.
+- replacing React or the current reducer architecture.
+- creating a second saved navigation/history model.
+
+## Completion gate
+V8 is complete only when:
+1. one mobile router owns normal navigation,
+2. home/category/feature/play/result return paths match this spec,
+3. 360/390/430 usability contracts pass,
+4. no legacy overlay can trap the user or force an incorrect home return,
+5. full regression/build/audit are GREEN,
+6. integration/main promotion is complete without force push,
+7. production exact-SHA deployment and runtime smoke are GREEN.

--- a/docs/superpowers/specs/2026-08-26-puppy-maker-v8-mobile-router-design.md
+++ b/docs/superpowers/specs/2026-08-26-puppy-maker-v8-mobile-router-design.md
@@ -9,31 +9,31 @@ Approved direction: **C — full mobile router rewrite**.
 - shared tree: `29ad5ef6b2af615f651badc9e7292956e5e2937b`
 
 ## Goal
-Replace the V7 overlay-heavy mobile navigation model with one predictable, mobile-first navigation authority that keeps status, back behavior, scrolling, touch controls, gameplay exits, and category return paths consistent across the app.
+Replace the V7 overlay-heavy navigation model with one predictable mobile router so status, menus, scrolling, back/home behavior, feature completion, gameplay exit, and result return paths are consistent on 360×640, 390×844, and 430px-class devices.
 
-The rewrite must improve usability without changing save, progression, combat, season, lineage, world, NG+, True/Hollow, or reward semantics.
+V8 changes presentation/navigation only. It must not change save, progression, combat, season, lineage, world, NG+, True/Hollow, reward, weekly-determinism, or inheritance semantics.
 
-## Why a router rewrite is necessary
-V7 reduced home clutter, but navigation remains split across several authorities:
-- `LayeredHomeV7` owns category state.
-- `LayeredHome` owns legacy home panels.
-- `Root` owns season/sanctuary/raising/expedition/world/archive/ambition overlays.
-- `App` owns gameplay screens such as schedule/training/dialogue/result.
+## Why V8 is a router rewrite
+V7 reduced home clutter, but navigation authority is still split across:
+- `LayeredHomeV7` category state,
+- `LayeredHome` legacy panels,
+- `Root` feature overlays,
+- `App` reducer-driven play screens.
 
-This produces inconsistent return paths and stacking rules. A category sheet can obscure the bottom navigation, legacy panels close directly to home, and full-screen feature overlays have independent open/close state. The user should not have to understand which implementation layer a feature belongs to.
+This creates inconsistent stacking and return behavior. V8 replaces those presentation-level authorities with one mobile navigation model while leaving reducers authoritative for gameplay state.
 
 ## Design principles
-1. **One navigation authority.** Mobile navigation state lives in a single router model.
-2. **One visible page layer.** Normal navigation uses pages, not stacked full-screen overlays.
-3. **Predictable back.** Back means one semantic step backward.
-4. **Predictable finish.** Feature completion returns to the origin category; complete play cycles return to home unless the flow explicitly continues.
-5. **Persistent controls.** The user must always retain a visible path back or home.
-6. **Content scrolls, controls stay reachable.** Page header and bottom navigation stay stable; only the content region scrolls.
-7. **No gameplay semantics in the router.** The router controls presentation/history only; reducers remain authoritative for game state.
-8. **Mobile first.** 360×640, 390×844, and 430px-class devices are first-class contracts.
+1. **One navigation authority.** Normal mobile navigation is owned by one router state.
+2. **One visible page layer.** Normal navigation uses pages, not stacked full-screen sheets.
+3. **Predictable back.** Back returns one semantic level.
+4. **Predictable finish.** Ordinary feature completion returns to the origin category. Complete play cycles return to home unless the flow explicitly returns to its category.
+5. **Persistent navigation for browsing.** The six main categories remain visible on home, category, ordinary feature, and completed-result pages.
+6. **Guarded navigation during active play.** While an unfinished training, Tactical battle, minigame, or choice event can be lost, hide the six-category bar and show only persistent `뒤로` and `홈`. Either exit action requires confirmation before discarding the attempt.
+7. **Content scrolls; controls stay reachable.** Only the route body scrolls.
+8. **No gameplay semantics in the router.** Navigation state is ephemeral UI state only.
+9. **Mobile first.** 360×640, 390×844, and 430px-class devices are first-class contracts.
 
 ## Route model
-Create a dedicated mobile router domain.
 
 ```ts
 export type MobileCategoryId =
@@ -65,11 +65,19 @@ export type MobileFeatureId =
   | 'lineage'
   | 'world_chronicle';
 
+export type MobilePlayScreen =
+  | 'schedule'
+  | 'training'
+  | 'dialogue'
+  | 'result'
+  | 'tactical'
+  | 'choice_event';
+
 export type MobileRoute =
   | {kind:'home'}
   | {kind:'category'; category:Exclude<MobileCategoryId,'home'>}
   | {kind:'feature'; category:Exclude<MobileCategoryId,'home'>; feature:MobileFeatureId}
-  | {kind:'play'; category:MobileCategoryId; screen:'schedule'|'training'|'dialogue'|'result'};
+  | {kind:'play'; category:MobileCategoryId; screen:MobilePlayScreen; activeAttempt:boolean};
 
 export type MobileNavigationState = {
   current: MobileRoute;
@@ -77,36 +85,35 @@ export type MobileNavigationState = {
 };
 ```
 
-The exact feature list may only be expanded when an already-existing V7 feature is mapped. V8 does not create unrelated gameplay systems.
+The feature list may expand only to map an already-existing game feature. V8 does not add new gameplay systems.
 
 ## Navigation operations
-The router exposes a small interface:
 
 ```ts
 openCategory(category)
 openFeature(category, feature)
-openPlay(category, screen)
+openPlay(category, screen, activeAttempt)
 replace(route)
 back()
 home()
 finishFeature()
-finishPlayCycle()
+finishPlayCycle(destination?)
 ```
 
-Exact history rules:
+Exact rules:
 - initial state: `current={kind:'home'}`, `stack=[]`.
-- home → category: `stack=[home]`, current becomes that category.
-- category → feature: `stack=[home, category]`, current becomes that feature.
-- bottom-nav category switch from any home/category route: replace the category branch and normalize history to `stack=[home]`; do not accumulate category history.
-- repeated selection of the active category is a no-op.
-- feature → back/finishFeature: return to its category with `stack=[home]`.
-- category → back: return home and clear stack.
-- `home()`: clear stack and return home from anywhere.
-- play routes record their semantic origin, but `finishPlayCycle()` clears transient play history and returns home.
-- malformed or impossible stack/current combinations normalize to home.
+- home → category: current category, history normalized to `[home]`.
+- category → feature: current feature, history normalized to `[home, category]`.
+- switching bottom categories from home/category/ordinary feature/result replaces the category branch instead of creating a long category history.
+- tapping the already-active category is a no-op.
+- feature `back()` / `finishFeature()` returns to its origin category.
+- category `back()` returns home.
+- `home()` clears navigation history and returns home.
+- malformed or impossible route/history combinations normalize to home.
+- active-play `back()` or `home()` never silently exits; it opens the guarded-exit confirmation.
 
-## Bottom navigation behavior
-The six V7 categories remain:
+## Six-category bottom navigation
+The categories remain:
 - 홈
 - 생활
 - 성장
@@ -114,75 +121,100 @@ The six V7 categories remain:
 - 인연
 - 기록
 
-**Home and category pages** always show the six-button bottom navigation. It remains reachable while category content scrolls.
+### Visible during normal use
+The six-button bar is persistent on:
+- home,
+- category pages,
+- ordinary feature pages,
+- completed/result pages where no unfinished attempt can be lost.
 
-**Feature and play pages** do not show the six-button bar. They use a persistent page header with `뒤로` and `홈` controls. This is the single rule for all feature/play pages and preserves vertical space on 360×640 devices.
+It remains reachable while content scrolls. Switching category is one tap and never requires closing the current ordinary feature first.
 
-Bottom category switching must work in one tap while another category page is open.
+### Hidden only during an unfinished active attempt
+The six-button bar is hidden only while leaving could discard unfinished interaction state, specifically:
+- **훈련 진행 중**,
+- **Tactical 전투 진행 중**,
+- **진행 중인 선택 이벤트**,
+- active minigames or equivalent reducer-driven attempts with the same discard risk.
+
+In that mode the UI shows only persistent:
+- `뒤로`
+- `홈`
+
+Both controls are at least 44×44px. Pressing either opens the same explicit confirmation before discarding the unfinished attempt.
+
+Recommended confirmation:
+- title: `진행 중인 플레이를 종료할까요?`
+- body: `지금 나가면 현재 진행 내용이 완료되지 않습니다.`
+- secondary action: `계속하기`
+- destructive/exit action: `종료하고 이동`
+
+For `뒤로`, confirmation returns to the semantic parent after approval. For `홈`, confirmation clears transient navigation and goes home after approval.
+
+No confirmation is shown for ordinary browsing, reward claims, story/archive reading, completed result screens, or other states where nothing unfinished would be lost.
 
 ## Mobile shell layout
-Replace the V7 backdrop/sheet composition with a full-height shell:
 
 ```text
 safe area
 ┌─────────────────────────┐
-│ compact status/header   │  stable within shell
+│ compact status/header   │  persistent
+├─────────────────────────┤
+│ page header (if needed) │  persistent
 ├─────────────────────────┤
 │                         │
-│ scrollable page body    │  overflow-y:auto; min-height:0
+│ scrollable route body   │  min-height:0; overflow-y:auto
 │                         │
 ├─────────────────────────┤
-│ bottom navigation       │  home/category only
+│ 6-category nav OR       │
+│ guarded Back + Home     │  persistent
 └─────────────────────────┘
 ```
 
 Structural requirements:
-- shell uses `100dvh` when supported.
-- content region uses `min-height:0` and `overflow-y:auto`.
-- body/root must not become the feature scroll container.
-- `overscroll-behavior:contain` prevents accidental background scrolling.
-- header and required navigation controls never disappear below long content.
-- no page requires scrolling back to the top just to close it.
+- use `100dvh` where supported,
+- route body uses `min-height:0` and `overflow-y:auto`,
+- body/root is not the feature scroll container,
+- `overscroll-behavior:contain`,
+- safe-area padding top/bottom,
+- no page requires scrolling to the top to escape,
+- fixed controls never cover the final actionable row.
 
 ## Status header redesign
-The status window becomes a stable compact component shared by home/category pages. Feature/play pages use the compact page header and may show a one-line resource summary only when relevant.
+Use a stable compact status component on normal routed pages.
 
 ### Row 1
-- generation
-- year
-- month/week
-- notification affordance
+- generation,
+- year,
+- month/week,
+- notification affordance.
 
 ### Row 2
-- gold
-- gems
-- stamina
-- guardian points/rank summary
+- gold,
+- gems,
+- stamina,
+- guardian summary.
 
 Requirements:
-- target height about 56–64px excluding safe area.
-- no important value below 13px.
-- primary text 15–16px minimum on 360px-class devices.
-- overflow truncation must preserve the date/time context before decorative labels.
-- notification button minimum touch target 44px.
+- about 56–64px excluding safe area,
+- critical values never below 13px,
+- primary text 15–16px minimum on 360px devices,
+- preserve date/time context before decorative labels when truncating,
+- notification touch target minimum 44px.
+
+During active gameplay, the status header may collapse to only gameplay-relevant information if that improves usable space, but guarded `뒤로` and `홈` stay persistent.
 
 ## Page header
-Category and feature/play pages use a consistent page header.
+Category and feature pages use the same header language:
+- back when a parent route exists,
+- page title,
+- optional compact subtitle/context,
+- Home affordance on deep routes where useful.
 
-Category page:
-- page title and optional compact context.
-- bottom nav provides Home/category movement.
-
-Feature/play page:
-- 44×44px or larger Back control.
-- page title.
-- optional compact context/subtitle.
-- 44×44px or larger Home control.
-
-The feature/play header remains visible while its body scrolls.
+For normal browsing, the six-category bar remains at the bottom even when Back/Home is also present at the top.
 
 ## Category pages
-V7 category content is retained but rendered as full pages rather than bottom sheets.
+V7 content becomes full pages rather than bottom sheets.
 
 ### 생활
 - Weekly Planner
@@ -216,183 +248,201 @@ V7 category content is retained but rendered as full pages rather than bottom sh
 - archive
 - discovery/collection summary
 
-Category entry cards keep the V7 icon language but receive clearer pressed/active feedback and uniform minimum height.
+Category cards retain the V7 icon language but use consistent 48px-preferred touch targets and visible pressed feedback.
 
-## Feature adaptation strategy
-Do not rewrite game domain logic. Adapt presentation incrementally behind the router.
+## Feature adaptation
+Do not rewrite game domain logic.
 
 ### Legacy `LayeredHome` panels
-Quest/achievement, bond, bag/inventory, outing, mission, event, attendance, and mail content must be extracted into route-renderable feature components or a shared `MobileLegacyFeaturePage` adapter. They may no longer own a backdrop that returns directly to home.
+Achievement, bond, inventory, outing, mission, event, attendance, and mail content must become route-renderable pages or a shared adapter. They may no longer own a backdrop that always returns directly to home.
 
 ### Root overlays
-Season, sanctuary, raising, expedition, world progress, archive, and ambition must accept router-controlled page mode. Their existing callback semantics remain unchanged.
+Season, sanctuary, raising, expedition, world progress, archive, and ambition must accept router-controlled page mode. Existing callbacks and reducer semantics remain unchanged.
 
-During migration, an adapter may render existing inner content inside the V8 page body. The old home launcher and independent open-state authority must be removed once that feature is router-controlled.
+Independent launcher/open-state authority is removed once each feature is router-controlled.
 
-## Gameplay routes
-`App` remains authoritative for reducer-driven gameplay state, but navigation presentation must integrate with the V8 router.
-
-### Schedule flow
+## Gameplay flows
+### Schedule / training
 `생활 → schedule → training → dialogue/result`
 
 Rules:
-- entering schedule records `life` as the origin category.
-- Back from schedule before starting returns to 생활.
-- Home from schedule returns home without starting training.
-- starting training enters play mode.
-- while a training attempt is active, category navigation is unavailable; persistent Back/Home controls must follow a guarded exit path rather than silently discarding progress.
-- completing the full training/result cycle returns to **home**.
+- entering schedule records `life` as origin.
+- before training starts, six-category navigation is still available because no active attempt is being lost.
+- Back from schedule returns to 생활.
+- starting training sets `activeAttempt=true`, hides the six-category bar, and shows only guarded `뒤로 + 홈`.
+- guarded exit confirms before discarding the attempt.
+- once the attempt reaches a completed result state, `activeAttempt=false`; six-category navigation returns.
+- completing the full training/result cycle through its normal completion action returns to **home**.
 
-### Expedition/Tactical flow
+### Expedition / Tactical
 `모험 → expedition → tactical/result`
 
 Rules:
-- closing before starting returns to 모험.
-- completing/aborting the active expedition flow exits to 모험 unless the game reducer explicitly ends a global play cycle that should return home.
-- tactical result screen must expose persistent exit controls.
+- expedition browsing/preparation keeps six-category navigation visible.
+- closing before battle starts returns to 모험.
+- entering an active Tactical battle sets `activeAttempt=true`, hides the six-category bar, and shows guarded `뒤로 + 홈` only.
+- battle result after resolution is not considered an active attempt; the six-category bar returns.
+- normal expedition completion/abort returns to 모험 unless the reducer explicitly ends a global play cycle whose intended destination is home.
 
-## Feature-completion return rules
-Feature completion must preserve spatial memory:
+### Choice event
+For any choice event where the player must choose before the interaction is complete:
+- entering the unresolved choice state sets `activeAttempt=true`,
+- hide the six-category bar,
+- show guarded `뒤로 + 홈` only,
+- either exit requires confirmation,
+- making the choice resolves the active attempt,
+- after resolution, restore the ordinary navigation appropriate to the destination screen.
 
-- 성장 → 성장 업적 → reward claim → close/back = 성장
-- 생활 → 출석 → claim → close/back = 생활
-- 생활 → 우편 → claim → close/back = 생활
-- 성장 → 야망 → select → close/back = 성장
-- 성장 → 시즌/성소 → action → close/back = 성장
-- 모험 → 월드 → close/back = 모험
-- 기록 → 도감 → close/back = 기록
-- 인연 → 선물/이야기 → close/back = 인연
+## Feature completion return rules
+- 성장 → 성장 업적 → reward claim → back = 성장
+- 생활 → 출석 → claim → back = 생활
+- 생활 → 우편 → claim → back = 생활
+- 성장 → 야망 → select → back = 성장
+- 성장 → 시즌/성소 → action → back = 성장
+- 모험 → 월드 → back = 모험
+- 기록 → 도감 → back = 기록
+- 인연 → 선물/이야기 → back = 인연
 
-No feature action may implicitly reset the route to home unless it represents a complete play cycle or the user taps Home.
+Ordinary feature actions never implicitly reset to home. Users may tap the persistent Home/category navigation whenever no active attempt is in progress.
 
 ## Scroll and viewport contracts
 Every route must satisfy:
-- 360×640
-- 390×844
-- 430px-class width
-- safe-area top and bottom
-- keyboard/focus-visible controls
-- reduced-motion
+- 360×640,
+- 390×844,
+- 430px-class width,
+- top/bottom safe areas,
+- keyboard/focus-visible behavior,
+- reduced motion.
 
-For long content:
-- home/category scroll body has bottom padding at least `bottomNavHeight + safeArea + 16px` when needed.
-- feature/play body leaves space for any persistent header/footer controls.
-- sticky page header remains visible.
-- no fixed CTA can cover the last actionable row.
-- nested full-page scroll containers are prohibited.
-- dialogs used only for truly modal confirmation have their own bounded scroll area and accessible close button.
+Long-content rules:
+- only the route body is the primary page scroll container,
+- headers and bottom controls remain reachable,
+- bottom padding accounts for persistent navigation + safe area,
+- sticky/fixed CTA never covers last content,
+- nested full-page scroll containers are prohibited,
+- true modal confirmation uses a bounded accessible dialog.
 
 ## Touch feedback
-All main navigation and feature-entry controls:
-- minimum 44px touch target; preferred 48px.
-- visible pressed state using transform/brightness/background, not color alone.
-- active navigation state combines color + fill/background + typography.
-- disabled state is visually distinct and cannot receive accidental click handlers.
+All main navigation and feature controls:
+- 44px minimum touch target, 48px preferred,
+- pressed state via transform/brightness/background, not color alone,
+- active nav combines color + background/fill + typography,
+- disabled controls are visibly distinct and inert.
 
 ## Typography
-Retain V7 token system, but enforce it across routed pages:
-- captions: 12–13px only for non-critical metadata.
-- secondary body: 14px minimum.
-- primary body/button: 15–16px minimum.
-- section title: 17–18px.
-- page title: 21–24px.
+Retain V7 tokens and enforce them across V8:
+- metadata captions: 12–13px,
+- secondary body: 14px minimum,
+- primary body/button: 15–16px minimum,
+- section title: 17–18px,
+- page title: 21–24px,
 - no critical actionable text at 8–11px.
 
 ## Accessibility and focus
-- changing routes moves focus to the new page heading or first meaningful control.
-- `back()` returns focus to the entry that opened the child route when practical.
-- Escape maps to `back()` for feature routes on hardware keyboards.
-- route pages expose meaningful `aria-label`/heading hierarchy.
-- decorative icons remain `aria-hidden`.
+- route change moves focus to the new heading or first meaningful control,
+- Back returns focus to the opening control when practical,
+- Escape maps to back on ordinary features,
+- Escape during an active attempt opens guarded-exit confirmation rather than silently exiting,
+- meaningful heading hierarchy and aria labels,
+- decorative icons remain aria-hidden.
 
 ## Error and safety behavior
-- unknown/malformed transient route data falls back to home; navigation state is not persisted in the save schema.
-- missing optional callbacks render disabled/unavailable entries rather than throwing.
-- feature completion callbacks run before navigation return so game-state mutations are not lost.
-- rapid repeated category taps cannot duplicate stack entries.
-- guarded active-play exits must ask for explicit confirmation only when leaving would discard an unfinished attempt; ordinary feature Back/Home actions require no confirmation.
+- malformed transient route data falls back to home,
+- navigation state is not persisted in save data,
+- missing optional callbacks produce disabled/unavailable entries rather than throw,
+- feature callbacks run before navigation return,
+- repeated category taps do not duplicate history,
+- only unfinished active attempts require exit confirmation.
 
-## Data and save compatibility
-V8 adds no persistent gameplay fields.
-
-Do not change:
-- save schema meaning
-- raw stats/gold/gems inheritance rules
-- NG+ semantics
-- lineage semantics
-- True/Hollow activation rules
-- weekly deterministic event semantics
-- combat rewards or progression
-
-Navigation state is ephemeral UI state only.
+## Save and gameplay compatibility
+V8 adds no persistent gameplay fields and must not change:
+- save schema meaning,
+- raw stats/gold/gems inheritance,
+- NG+ semantics,
+- lineage semantics,
+- True/Hollow activation,
+- weekly deterministic events,
+- combat rewards or progression.
 
 ## Migration sequence
-1. Add pure mobile router domain and tests.
-2. Add V8 shell, page header, persistent nav, and scrolling contract.
-3. Move V7 categories from sheet routes to page routes.
-4. Adapt legacy home features.
-5. Adapt Root overlays into router-controlled pages.
-6. Integrate schedule/training/result return rules.
-7. Integrate expedition/tactical return rules.
-8. Remove V7 sheet/backdrop and independent launcher state that is no longer authoritative.
-9. Run mobile usability regression and full project regression.
+1. Pure mobile-router domain + tests.
+2. V8 full-height shell, status header, route body, six-category nav, guarded play controls.
+3. Convert V7 category sheets to full pages.
+4. Convert legacy LayeredHome panels to routed feature pages.
+5. Convert Root overlays to router-controlled page mode.
+6. Integrate schedule/training/result active-attempt rules.
+7. Integrate expedition/Tactical active-attempt rules.
+8. Integrate unresolved choice-event active-attempt rules.
+9. Remove V7 sheet/backdrop and obsolete independent launcher/open-state authorities.
+10. Run full mobile and project regression.
 
 ## Testing strategy
-### Pure router tests
+### Router unit tests
 Lock:
-- home/category/feature stack normalization.
-- category switching does not duplicate stack.
-- feature back returns to origin category.
-- `finishFeature()` returns to origin category.
-- `finishPlayCycle()` returns home and clears transient stack.
-- malformed route fallback.
+- normalized home/category/feature histories,
+- category switches do not accumulate stack,
+- feature back returns origin category,
+- finishFeature returns origin category,
+- normal finishPlayCycle destination,
+- malformed route fallback,
+- activeAttempt exit requires guard.
 
-### Render/interaction tests
+### Interaction tests
 Lock:
-- six bottom-nav categories remain reachable from every category page.
-- feature pages show persistent Back/Home instead of the six-button bar.
-- long category content scrolls while header/nav remain structurally persistent.
-- back from achievements returns to growth.
-- close from mail returns to life.
-- archive returns to records.
-- expedition pre-start close returns to adventure.
-- training result completion returns home.
-- no feature backdrop covers the navigation unexpectedly.
+- six bottom categories reachable from home/category/ordinary feature/result,
+- category switch from an open ordinary feature works in one tap,
+- achievements back → growth,
+- mail back → life,
+- archive back → records,
+- expedition pre-start close → adventure,
+- active training hides six-category nav,
+- active Tactical hides six-category nav,
+- unresolved choice event hides six-category nav,
+- active play shows only Back/Home exit controls,
+- Back/Home during active play opens confirmation,
+- cancel confirmation resumes the same play state,
+- confirm Back exits to semantic parent,
+- confirm Home exits home,
+- resolved choice/completed result restores six-category nav,
+- normal completed training cycle returns home.
 
 ### Mobile CSS/source contracts
 Lock:
-- `100dvh` shell.
-- `min-height:0` scroll region.
-- `overflow-y:auto` only on routed content container for page scrolling.
-- safe-area paddings.
-- 44/48px control minimums.
-- 360/390/430 media rules.
+- `100dvh`,
+- `min-height:0`,
+- route-body `overflow-y:auto`,
+- `overscroll-behavior:contain`,
+- safe-area padding,
+- 44/48px touch targets,
+- 360/390/430 rules,
+- no legacy full-screen backdrop can cover persistent normal navigation.
 
 ### Release regression
-- targeted V8 suites
-- full existing suite (baseline 460 files / 1793 tests)
-- TypeScript
-- production build
-- dependency audit
-- integration PR synthetic merge CI
-- main exact-SHA CI
-- production exact-SHA Vercel READY
-- production root/API smoke
-- production runtime error/fatal log check
+- targeted V8 suites,
+- full existing suite (baseline 460 files / 1793 tests),
+- TypeScript,
+- production build,
+- dependency audit,
+- integration PR synthetic merge CI,
+- main exact-SHA CI,
+- production exact-SHA Vercel READY,
+- production root/API smoke,
+- production runtime error/fatal log check.
 
 ## Non-goals
-- redesigning game art.
-- changing game economy or progression.
-- adding desktop-only navigation.
-- replacing React or the current reducer architecture.
-- creating a second saved navigation/history model.
+- redesigning game art,
+- changing game economy or progression,
+- adding desktop-only navigation,
+- replacing React or the reducer architecture,
+- persisting navigation/history in save data.
 
 ## Completion gate
 V8 is complete only when:
 1. one mobile router owns normal navigation,
-2. home/category/feature/play/result return paths match this spec,
-3. 360/390/430 usability contracts pass,
-4. no legacy overlay can trap the user or force an incorrect home return,
-5. full regression/build/audit are GREEN,
-6. integration/main promotion is complete without force push,
-7. production exact-SHA deployment and runtime smoke are GREEN.
+2. home/category/feature/play/result paths match this spec,
+3. active training/Tactical/choice events use guarded Back/Home only,
+4. 360/390/430 usability contracts pass,
+5. no legacy overlay can trap the user or force an incorrect home return,
+6. full regression/build/audit are GREEN,
+7. integration/main promotion is complete without force push,
+8. production exact-SHA deployment and runtime smoke are GREEN.

--- a/docs/superpowers/specs/2026-08-26-puppy-maker-v8-mobile-router-design.md
+++ b/docs/superpowers/specs/2026-08-26-puppy-maker-v8-mobile-router-design.md
@@ -93,15 +93,17 @@ finishFeature()
 finishPlayCycle()
 ```
 
-Rules:
-- `openCategory`: category becomes current route and is pushed from home or another category.
-- `openFeature`: remembers the origin category.
-- `back`: returns to the previous semantic route, never an implementation overlay.
-- `finishFeature`: returns to the feature's origin category.
-- `finishPlayCycle`: returns to home and clears transient play history.
-- `home`: clears stack and returns to `{kind:'home'}`.
-- repeated selection of the active bottom-nav category does not duplicate history.
-- switching bottom-nav categories replaces the current category/feature route rather than building a long category stack.
+Exact history rules:
+- initial state: `current={kind:'home'}`, `stack=[]`.
+- home → category: `stack=[home]`, current becomes that category.
+- category → feature: `stack=[home, category]`, current becomes that feature.
+- bottom-nav category switch from any home/category route: replace the category branch and normalize history to `stack=[home]`; do not accumulate category history.
+- repeated selection of the active category is a no-op.
+- feature → back/finishFeature: return to its category with `stack=[home]`.
+- category → back: return home and clear stack.
+- `home()`: clear stack and return home from anywhere.
+- play routes record their semantic origin, but `finishPlayCycle()` clears transient play history and returns home.
+- malformed or impossible stack/current combinations normalize to home.
 
 ## Bottom navigation behavior
 The six V7 categories remain:
@@ -112,11 +114,11 @@ The six V7 categories remain:
 - 인연
 - 기록
 
-The bottom navigation is visible on home and category pages and remains reachable while category content scrolls.
+**Home and category pages** always show the six-button bottom navigation. It remains reachable while category content scrolls.
 
-Feature pages may either keep the bottom bar visible or use a compact home/back footer when screen real estate is constrained; whichever option is used must be consistent per page class and must not allow hidden navigation traps.
+**Feature and play pages** do not show the six-button bar. They use a persistent page header with `뒤로` and `홈` controls. This is the single rule for all feature/play pages and preserves vertical space on 360×640 devices.
 
-Bottom category switching must work in one tap even while another category is open.
+Bottom category switching must work in one tap while another category page is open.
 
 ## Mobile shell layout
 Replace the V7 backdrop/sheet composition with a full-height shell:
@@ -124,13 +126,13 @@ Replace the V7 backdrop/sheet composition with a full-height shell:
 ```text
 safe area
 ┌─────────────────────────┐
-│ compact status/header   │  sticky/fixed within shell
+│ compact status/header   │  stable within shell
 ├─────────────────────────┤
 │                         │
 │ scrollable page body    │  overflow-y:auto; min-height:0
 │                         │
 ├─────────────────────────┤
-│ bottom navigation       │  persistent, safe-area aware
+│ bottom navigation       │  home/category only
 └─────────────────────────┘
 ```
 
@@ -139,11 +141,11 @@ Structural requirements:
 - content region uses `min-height:0` and `overflow-y:auto`.
 - body/root must not become the feature scroll container.
 - `overscroll-behavior:contain` prevents accidental background scrolling.
-- header and navigation never disappear below long content.
+- header and required navigation controls never disappear below long content.
 - no page requires scrolling back to the top just to close it.
 
 ## Status header redesign
-The status window becomes a stable compact component shared by home/category/feature pages.
+The status window becomes a stable compact component shared by home/category pages. Feature/play pages use the compact page header and may show a one-line resource summary only when relevant.
 
 ### Row 1
 - generation
@@ -165,13 +167,19 @@ Requirements:
 - notification button minimum touch target 44px.
 
 ## Page header
-Category and feature pages use a consistent page header:
-- back button when there is a parent route.
+Category and feature/play pages use a consistent page header.
+
+Category page:
+- page title and optional compact context.
+- bottom nav provides Home/category movement.
+
+Feature/play page:
+- 44×44px or larger Back control.
 - page title.
 - optional compact context/subtitle.
-- optional home button for deep feature/play routes.
+- 44×44px or larger Home control.
 
-Back and home controls must be at least 44×44px.
+The feature/play header remains visible while its body scrolls.
 
 ## Category pages
 V7 category content is retained but rendered as full pages rather than bottom sheets.
@@ -229,9 +237,10 @@ During migration, an adapter may render existing inner content inside the V8 pag
 
 Rules:
 - entering schedule records `life` as the origin category.
-- normal back from schedule before starting returns to 생활.
+- Back from schedule before starting returns to 생활.
+- Home from schedule returns home without starting training.
 - starting training enters play mode.
-- while a training attempt is active, accidental category switching is disabled or guarded; there must always be an explicit exit control.
+- while a training attempt is active, category navigation is unavailable; persistent Back/Home controls must follow a guarded exit path rather than silently discarding progress.
 - completing the full training/result cycle returns to **home**.
 
 ### Expedition/Tactical flow
@@ -240,7 +249,7 @@ Rules:
 Rules:
 - closing before starting returns to 모험.
 - completing/aborting the active expedition flow exits to 모험 unless the game reducer explicitly ends a global play cycle that should return home.
-- tactical result screen must expose a visible exit control.
+- tactical result screen must expose persistent exit controls.
 
 ## Feature-completion return rules
 Feature completion must preserve spatial memory:
@@ -266,11 +275,12 @@ Every route must satisfy:
 - reduced-motion
 
 For long content:
-- scrollable body has bottom padding at least `bottomNavHeight + safeArea + 16px` when bottom nav overlays content.
+- home/category scroll body has bottom padding at least `bottomNavHeight + safeArea + 16px` when needed.
+- feature/play body leaves space for any persistent header/footer controls.
 - sticky page header remains visible.
 - no fixed CTA can cover the last actionable row.
 - nested full-page scroll containers are prohibited.
-- dialogs used for truly modal confirmation must have their own bounded scroll area and accessible close button.
+- dialogs used only for truly modal confirmation have their own bounded scroll area and accessible close button.
 
 ## Touch feedback
 All main navigation and feature-entry controls:
@@ -300,6 +310,7 @@ Retain V7 token system, but enforce it across routed pages:
 - missing optional callbacks render disabled/unavailable entries rather than throwing.
 - feature completion callbacks run before navigation return so game-state mutations are not lost.
 - rapid repeated category taps cannot duplicate stack entries.
+- guarded active-play exits must ask for explicit confirmation only when leaving would discard an unfinished attempt; ordinary feature Back/Home actions require no confirmation.
 
 ## Data and save compatibility
 V8 adds no persistent gameplay fields.
@@ -329,6 +340,7 @@ Navigation state is ephemeral UI state only.
 ## Testing strategy
 ### Pure router tests
 Lock:
+- home/category/feature stack normalization.
 - category switching does not duplicate stack.
 - feature back returns to origin category.
 - `finishFeature()` returns to origin category.
@@ -337,7 +349,8 @@ Lock:
 
 ### Render/interaction tests
 Lock:
-- six bottom-nav categories remain reachable from category pages.
+- six bottom-nav categories remain reachable from every category page.
+- feature pages show persistent Back/Home instead of the six-button bar.
 - long category content scrolls while header/nav remain structurally persistent.
 - back from achievements returns to growth.
 - close from mail returns to life.

--- a/src/LayeredHome.tsx
+++ b/src/LayeredHome.tsx
@@ -112,9 +112,11 @@ type LayeredHomeProps = {
   onExpedition?: () => void;
   onSeason?: () => void;
   onMenuReady?: (openMenu: (id: HomeMenuId) => void) => void;
+  onMenuNavigate?: (id: HomeMenuId) => void;
+  onWeeklyPlannerNavigate?: () => void;
 };
 
-export default function LayeredHome({ state, onSchedule, onClaimAchievement, onOuting, onGift, onAttendance, onMail, onMonthlyFocus, onWeeklyFocus, onCompleteWeek, onAdvanceWeek, onExpedition, onSeason, onMenuReady }: LayeredHomeProps) {
+export default function LayeredHome({ state, onSchedule, onClaimAchievement, onOuting, onGift, onAttendance, onMail, onMonthlyFocus, onWeeklyFocus, onCompleteWeek, onAdvanceWeek, onExpedition, onSeason, onMenuReady, onMenuNavigate, onWeeklyPlannerNavigate }: LayeredHomeProps) {
   const [petted, setPetted] = useState(false);
   const [activeNav, setActiveNav] = useState(-1);
   const [activePanel, setActivePanel] = useState<HomeMenuId | null>(null);
@@ -164,12 +166,16 @@ export default function LayeredHome({ state, onSchedule, onClaimAchievement, onO
   const openMenu = useCallback((id: HomeMenuId, index?: number) => {
     if (typeof index === 'number') setActiveNav(index);
     else setActiveNav(-1);
+    if (onMenuNavigate) {
+      onMenuNavigate(id);
+      return;
+    }
     if (id === 'schedule') return onSchedule();
     const activeElement = document.activeElement;
     panelLauncherRef.current = activeElement instanceof HTMLElement && activeElement !== document.body ? activeElement : null;
     if (id === 'bond') setPetted(true);
     setActivePanel(id);
-  }, [onSchedule]);
+  }, [onMenuNavigate, onSchedule]);
 
   const closePanel = useCallback(() => {
     setActivePanel(null);
@@ -182,7 +188,7 @@ export default function LayeredHome({ state, onSchedule, onClaimAchievement, onO
       case 'mail': return openMenu('mail');
       case 'attendance': return openMenu('attendance');
       case 'achievement': return openMenu('quest', 2);
-      case 'weekly_planner': return plannerRef.current?.querySelector<HTMLButtonElement>('button:not(:disabled)')?.focus();
+      case 'weekly_planner': return onWeeklyPlannerNavigate ? onWeeklyPlannerNavigate() : plannerRef.current?.querySelector<HTMLButtonElement>('button:not(:disabled)')?.focus();
       case 'advance_week': return onAdvanceWeek?.();
       case 'schedule': return onSchedule();
       case 'outing': return openMenu('outing');

--- a/src/MobileCategoryPage.tsx
+++ b/src/MobileCategoryPage.tsx
@@ -1,0 +1,119 @@
+import type {GameState} from './game';
+import {publicProjectDefinitions} from './generational-world';
+import LineageChronicle from './LineageChronicle';
+import MobileNavIcon,{type MobileNavIconName} from './MobileNavIcon';
+import WeeklyPlannerCard from './WeeklyPlannerCard';
+import WorldChronicle from './WorldChronicle';
+import type {MobileContentCategory,MobileFeatureId} from './mobile-router';
+import type {WeeklyFocusId} from './weekly-life';
+
+type Props={
+  category:MobileContentCategory;
+  state:GameState;
+  onOpenFeature:(feature:MobileFeatureId)=>void;
+  onWeeklyFocus?:(focus:WeeklyFocusId)=>void;
+  onCompleteWeek?:()=>void;
+  onAdvanceWeek?:()=>void;
+};
+
+type CategoryMeta={label:string;eyebrow:string;description:string;icon:MobileNavIconName};
+
+const meta:Record<MobileContentCategory,CategoryMeta>={
+  life:{label:'생활',eyebrow:'LIVING',description:'이번 주와 이번 달의 일상을 정리해요.',icon:'life'},
+  growth:{label:'성장',eyebrow:'GROWTH',description:'훈련과 성과, 장기 성장을 확인해요.',icon:'growth'},
+  adventure:{label:'모험',eyebrow:'ADVENTURE',description:'밖으로 나가 탐험하고 전투해요.',icon:'adventure'},
+  bond:{label:'인연',eyebrow:'BONDS',description:'루나와 친구들의 관계와 이야기를 만나요.',icon:'bond'},
+  records:{label:'기록',eyebrow:'CHRONICLE',description:'세대와 세계에 남긴 흔적을 돌아봐요.',icon:'records'},
+};
+
+function Entry({icon,title,description,feature,onOpenFeature}:{
+  icon:MobileNavIconName;
+  title:string;
+  description:string;
+  feature:MobileFeatureId;
+  onOpenFeature:(feature:MobileFeatureId)=>void;
+}){
+  return <button type="button" className="v8-category-entry" onClick={()=>onOpenFeature(feature)}>
+    <span className="v8-category-entry-icon"><MobileNavIcon name={icon}/></span>
+    <span className="v8-category-entry-copy"><b>{title}</b><small>{description}</small></span>
+    <MobileNavIcon name="chevron" className="v8-category-chevron"/>
+  </button>;
+}
+
+function SectionTitle({children}:{children:string}){
+  return <h2 className="v8-section-title">{children}</h2>;
+}
+
+export default function MobileCategoryPage({category,state,onOpenFeature,onWeeklyFocus,onCompleteWeek,onAdvanceWeek}:Props){
+  const info=meta[category];
+  const activeProject=state.generationalWorld.activeProject;
+  const activeProjectLabel=activeProject?publicProjectDefinitions[activeProject].label:null;
+
+  return <section className="v8-category-page" aria-labelledby={`v8-category-${category}`}>
+    <header className="v8-category-header">
+      <span className="v8-category-icon"><MobileNavIcon name={info.icon}/></span>
+      <div>
+        <small>{info.eyebrow}</small>
+        <h1 id={`v8-category-${category}`}>{info.label}</h1>
+        <p>{info.description}</p>
+      </div>
+    </header>
+
+    {category==='life'&&<div className="v8-category-content">
+      <SectionTitle>이번 주 계획</SectionTitle>
+      <WeeklyPlannerCard
+        state={state}
+        onSelectFocus={focus=>onWeeklyFocus?.(focus)}
+        onComplete={()=>onCompleteWeek?.()}
+        onAdvance={()=>onAdvanceWeek?.()}
+        showChronicles={false}
+      />
+      <div className="v8-category-grid">
+        <Entry icon="life" title="스케줄" description="훈련과 하루 일정을 선택해요." feature="schedule" onOpenFeature={onOpenFeature}/>
+        <Entry icon="life" title="이번 달 목표" description="월간 집중과 미션을 확인해요." feature="mission" onOpenFeature={onOpenFeature}/>
+        <Entry icon="bell" title="출석 보상" description="이번 달 출석 보상을 받아요." feature="attendance" onOpenFeature={onOpenFeature}/>
+        <Entry icon="records" title="우편함" description="도착한 편지와 보상을 확인해요." feature="mail" onOpenFeature={onOpenFeature}/>
+      </div>
+    </div>}
+
+    {category==='growth'&&<div className="v8-category-grid">
+      <Entry icon="growth" title="성장 정체성" description="Calling, Trait, 관계 장면과 루나의 성장 방향을 확인해요." feature="raising" onOpenFeature={onOpenFeature}/>
+      <Entry icon="growth" title="올해의 야망" description="한 해 동안 집중할 성장 목표와 현재 진행률을 봐요." feature="ambition" onOpenFeature={onOpenFeature}/>
+      <Entry icon="growth" title="성장 업적" description="성장 목표와 받을 보상을 확인해요." feature="achievements" onOpenFeature={onOpenFeature}/>
+      <Entry icon="growth" title="능력과 보유품" description="숙련도와 성장에 필요한 보유품을 살펴봐요." feature="inventory" onOpenFeature={onOpenFeature}/>
+      <Entry icon="records" title="시즌 여정" description="시즌 점수, 보상, Legacy 성장을 확인해요." feature="season" onOpenFeature={onOpenFeature}/>
+      <Entry icon="records" title="별빛 성소" description="시설, 전문화, Masterwork와 천상 성장을 관리해요." feature="sanctuary" onOpenFeature={onOpenFeature}/>
+    </div>}
+
+    {category==='adventure'&&<div className="v8-category-content">
+      <div className="v8-category-grid">
+        <Entry icon="adventure" title="외출" description="마을과 주변 지역에서 새로운 일을 찾아요." feature="outing" onOpenFeature={onOpenFeature}/>
+        <Entry icon="adventure" title="수호자 원정" description="Expedition과 Tactical 전투에 도전해요." feature="expedition" onOpenFeature={onOpenFeature}/>
+        <Entry icon="adventure" title="월드 진행" description="지역 명성, 월간 월드 이벤트와 의뢰를 확인해요." feature="world" onOpenFeature={onOpenFeature}/>
+      </div>
+      <div className="v8-category-summary" aria-label="세계 프로젝트">
+        <small>WORLD</small><b>세계 프로젝트</b>
+        <span>{activeProjectLabel?`진행 중 · ${activeProjectLabel} ${state.generationalWorld.projectProgress}%`:'진행 중인 장기 프로젝트가 없어요.'}</span>
+      </div>
+    </div>}
+
+    {category==='bond'&&<div className="v8-category-grid">
+      <Entry icon="bond" title="루나와 교감" description="관계와 선물, 교감 기록을 확인해요." feature="bond" onOpenFeature={onOpenFeature}/>
+      <Entry icon="bond" title="선물" description="보유한 선물을 확인하고 마음을 전해요." feature="gifts" onOpenFeature={onOpenFeature}/>
+      <Entry icon="records" title="이야기" description="열린 캐릭터 이야기와 이벤트를 다시 봐요." feature="stories" onOpenFeature={onOpenFeature}/>
+    </div>}
+
+    {category==='records'&&<div className="v8-category-content v8-records-content">
+      <section className="v8-embedded-section" aria-label="가문 연대기">
+        <SectionTitle>가문 연대기</SectionTitle>
+        <LineageChronicle state={state}/>
+      </section>
+      <section className="v8-embedded-section" aria-label="세계 연대기">
+        <SectionTitle>세계 연대기</SectionTitle>
+        <WorldChronicle generation={state.lineage.generation} world={state.generationalWorld}/>
+      </section>
+      <Entry icon="records" title="성장 도감" description="성장, 원정, 유산과 연간 수호 기록을 한곳에서 봐요." feature="archive" onOpenFeature={onOpenFeature}/>
+      <div className="v8-category-summary"><small>COLLECTION</small><b>발견과 기억</b><span>발견물 {state.discoveries.length}개 · 세대 {state.lineage.generation}</span></div>
+    </div>}
+  </section>;
+}

--- a/src/MobileLegacyFeaturePage.tsx
+++ b/src/MobileLegacyFeaturePage.tsx
@@ -1,0 +1,159 @@
+import {
+  discoveryIds,explorationLevel,explorationXpForNextLevel,giftDefinitions,giftItemIds,outingDefinitions,outingLocationIds,
+  type DiscoveryId,type ExplorationEventId,type GiftItemId,type OutingLocationId,
+} from './adventure';
+import {attendanceKey,attendanceReward} from './attendance';
+import {talentDefinitions} from './advanced-talents';
+import {careerTitleDefinitions} from './career-records';
+import {
+  achievementDefinitions,collectionProgress,currentAdvancedTalents,currentAvailableMail,currentCareerTitles,currentGuardianStatus,
+  currentStoryChapters,eligibleAchievements,masteryLevel,relationshipRank,type AchievementId,type GameState,type MailRewardId,
+} from './game';
+import {guardianRankDefinitions} from './guardian-rank';
+import {mailDefinitions} from './mail-rewards';
+import {monthlyFocusDefinitions} from './monthly-focus';
+import {monthlyMissionDefinitions} from './monthly-missions';
+import type {MobileFeatureId} from './mobile-router';
+import {storyChapterDefinitions} from './story-chapters';
+
+type Props={
+  feature:MobileFeatureId;
+  state:GameState;
+  onClaimAchievement:(achievement:AchievementId)=>void;
+  onOuting:(location:OutingLocationId)=>void;
+  onGift:(item:GiftItemId)=>void;
+  onAttendance:()=>void;
+  onMail:(mail:MailRewardId)=>void;
+  onMonthlyFocus:(focus:GameState['monthlyFocus'])=>void;
+};
+
+const relationshipLabels={acquaintance:'낯선 사이',familiar:'익숙한 사이',friend:'친구',close_friend:'가까운 친구',precious:'소중한 사람'} as const;
+const explorationEventLabels:Record<ExplorationEventId,string>={
+  glowing_tracks:'빛나는 발자국을 따라가 50G를 발견했어요.',ancient_tree:'오래된 나무의 선물로 별빛 쿠키를 얻었어요.',
+  street_performance:'마을 공연을 도와 50G를 받았어요.',wand_repair:'마법 지팡이를 고쳐주고 여우 부적을 받았어요.',
+  silver_fish:'은빛 물고기가 숨겨둔 50G를 발견했어요.',quiet_breeze:'고요한 바람 속에서 허브티를 발견했어요.',
+};
+const discoveryLabels:Record<DiscoveryId,string>={
+  moon_feather:'달빛 깃털',star_mushroom:'별무늬 버섯',tiny_bell:'작은 마법 종',old_spellbook:'낡은 주문서',
+  glass_shell:'유리빛 조개',wind_crystal:'바람 결정',
+};
+
+const featureMeta:Partial<Record<MobileFeatureId,{eyebrow:string;title:string;description:string}>>={
+  achievements:{eyebrow:'ACHIEVEMENTS',title:'성장 업적',description:'달성한 성장 목표와 보상을 확인해요.'},
+  mission:{eyebrow:'MONTHLY CHALLENGES',title:'이번 달 도전',description:'월간 집중과 도전 진행도를 확인해요.'},
+  attendance:{eyebrow:'MONTHLY CHECK-IN',title:'월간 출석',description:'이번 달 출석 보상을 확인해요.'},
+  mail:{eyebrow:'MILESTONE MAIL',title:'우편함',description:'도착한 편지와 보상을 확인해요.'},
+  inventory:{eyebrow:'INVENTORY',title:'능력과 보유품',description:'보유한 선물과 성장 기록을 함께 확인해요.'},
+  gifts:{eyebrow:'GIFTS',title:'선물',description:'보유한 선물을 루나에게 건네요.'},
+  outing:{eyebrow:'ADVENTURE',title:'외출',description:'마을과 주변 지역으로 나가 탐험해요.'},
+  bond:{eyebrow:'BOND & COLLECTION',title:'루나와의 교감',description:'관계와 장기 성장 기록을 확인해요.'},
+  stories:{eyebrow:'STORY ARCHIVE',title:'루나 이야기',description:'열린 캐릭터 이야기와 이벤트를 다시 봐요.'},
+};
+
+function Row({marker,title,description,status,disabled=false,onClick}:{marker:string|number;title:string;description?:string;status?:string;disabled?:boolean;onClick?:()=>void}){
+  return <button type="button" className="v8-feature-row" disabled={disabled} onClick={onClick}>
+    <span className="v8-feature-marker">{marker}</span>
+    <span className="v8-feature-copy"><b>{title}</b>{description&&<small>{description}</small>}</span>
+    {status&&<i>{status}</i>}
+  </button>;
+}
+
+export default function MobileLegacyFeaturePage({feature,state,onClaimAchievement,onOuting,onGift,onAttendance,onMail,onMonthlyFocus}:Props){
+  const info=featureMeta[feature]??{eyebrow:'FEATURE',title:'기능',description:'선택한 기능을 확인해요.'};
+  const eligible=new Set(eligibleAchievements(state));
+  const availableMail=new Set(currentAvailableMail(state));
+  const attendanceId=attendanceKey(state.year,state.month);
+  const attendanceClaimed=state.claimedAttendanceMonths.includes(attendanceId);
+  const attendance=attendanceReward(state.year,state.month);
+  const storyOpen=new Set([...currentStoryChapters(state),...state.expeditionStoryEntries]);
+  const collection=collectionProgress(state);
+  const guardian=currentGuardianStatus(state);
+  const guardianDefinition=guardianRankDefinitions.find(item=>item.id===guardian.rank)??guardianRankDefinitions[0];
+  const rank=relationshipRank(state.stats.affection);
+  const talents=currentAdvancedTalents(state);
+  const titles=currentCareerTitles(state);
+  const currentTitle=careerTitleDefinitions.find(item=>item.id===titles[titles.length-1]);
+  const talentLabels=talents.map(id=>talentDefinitions.find(item=>item.id===id)?.label).filter(Boolean);
+  const highestMastery=Math.max(...Object.values(state.mastery).map(entry=>masteryLevel(entry.xp)));
+
+  return <section className="v8-feature-page" aria-labelledby={`v8-feature-${feature}`}>
+    <header className="v8-feature-heading">
+      <small>{info.eyebrow}</small><h1 id={`v8-feature-${feature}`}>{info.title}</h1><p>{info.description}</p>
+    </header>
+    <div className="v8-feature-list">
+      {feature==='achievements'&&achievementDefinitions.map((item,index)=>{
+        const claimed=state.claimedAchievements.includes(item.id);
+        const canClaim=eligible.has(item.id)&&!claimed;
+        const reward=item.reward.gold?`${item.reward.gold}G`:`보석 ${item.reward.gems}`;
+        return <Row key={item.id} marker={claimed?'✓':canClaim?'!':index+1} title={item.title} description={`${item.description} · ${reward}`} status={claimed?'완료':canClaim?'받기':'진행중'} disabled={!canClaim} onClick={()=>canClaim&&onClaimAchievement(item.id)}/>;
+      })}
+
+      {feature==='attendance'&&<>
+        <Row marker={attendanceClaimed?'✓':'!'} title={`${state.year}년차 ${state.month}월 출석 보상`} description={`기본 150G${attendance.gems>0?` · 분기 보너스 보석 ${attendance.gems}개`:' · 다음 분기월에는 보석 보너스'}`} status={attendanceClaimed?'수령 완료':'받기'} disabled={attendanceClaimed} onClick={()=>!attendanceClaimed&&onAttendance()}/>
+        <Row marker="◆" title="누적 출석 기록" description="월이 바뀌어도 이전 수령 기록은 유지돼요." status={`${state.claimedAttendanceMonths.length}개월`} disabled/>
+      </>}
+
+      {feature==='mail'&&mailDefinitions.map((mail,index)=>{
+        const unlocked=availableMail.has(mail.id);
+        const claimed=state.claimedMailRewards.includes(mail.id);
+        const reward=[mail.reward.gold?`${mail.reward.gold}G`:'',mail.reward.gems?`보석 ${mail.reward.gems}`:''].filter(Boolean).join(' · ');
+        return <Row key={mail.id} marker={claimed?'✓':unlocked?'!':index+1} title={mail.title} description={unlocked?`${mail.message} · ${reward}`:'진행 조건을 달성하면 편지가 도착해요.'} status={claimed?'수령 완료':unlocked?'받기':'잠김'} disabled={!unlocked||claimed} onClick={()=>unlocked&&!claimed&&onMail(mail.id)}/>;
+      })}
+
+      {feature==='mission'&&<>
+        {monthlyFocusDefinitions.map((focus,index)=>{
+          const selected=state.monthlyFocus===focus.id;
+          return <Row key={focus.id} marker={selected?'✓':index+1} title={focus.label} description={focus.description} status={selected?'선택됨':'선택'} onClick={()=>onMonthlyFocus(focus.id)}/>;
+        })}
+        <Row marker="🔥" title="연속 성장" description="3개월마다 보석 3개 추가 보상" status={`${state.growthStreak}개월`} disabled/>
+        {monthlyMissionDefinitions.map((item,index)=>{
+          const value=state.monthlyCounters[item.counter];
+          const completed=state.rewardedMonthlyMissions.includes(item.id);
+          const reward=item.reward.gold?`${item.reward.gold}G`:`보석 ${item.reward.gems}`;
+          return <Row key={item.id} marker={completed?'✓':index+1} title={item.title} description={`${Math.min(value,item.target)} / ${item.target} · 보상 ${reward}`} status={completed?'보상 완료':'진행중'} disabled/>;
+        })}
+      </>}
+
+      {(feature==='inventory'||feature==='gifts')&&<>
+        {feature==='inventory'&&<div className="v8-feature-summary"><b>현재 성장 기록</b><span>최고 숙련 Lv.{highestMastery} · 기억 {collection.memories}개 · 기술 {collection.skills}개</span></div>}
+        {giftItemIds.map((id,index)=>{
+          const item=giftDefinitions[id];
+          const quantity=state.inventory[id];
+          return <Row key={id} marker={index+1} title={item.name} description={item.description} status={quantity>0?`선물하기 · ${quantity}개`:'없음'} disabled={quantity<=0} onClick={()=>quantity>0&&onGift(id)}/>;
+        })}
+      </>}
+
+      {feature==='stories'&&storyChapterDefinitions.map((chapter,index)=>{
+        const opened=storyOpen.has(chapter.id);
+        const reward=chapter.rewardGems>0?` · 보상 보석 ${chapter.rewardGems}`:'';
+        return <Row key={chapter.id} marker={opened?'✓':index+1} title={chapter.title} description={`${opened?chapter.summary:chapter.unlockHint}${reward}`} status={opened?'열림':'잠김'} disabled/>;
+      })}
+
+      {feature==='bond'&&<>
+        <Row marker="★" title="수호 등급" description={guardian.next?`다음 ${guardianRankDefinitions.find(item=>item.id===guardian.next?.rank)?.label??''}까지 ${guardian.next.threshold-guardian.points}점`:'최고 등급 달성'} status={guardianDefinition.label} disabled/>
+        <Row marker="◆" title="커리어 칭호" description={titles.length?`${titles.length}개 해금 · ${currentTitle?.description??''}`:'장기 플레이 기록으로 새로운 칭호가 열려요.'} status={currentTitle?.label??'도전 중'} disabled/>
+        <Row marker="✦" title="고급 훈련 재능" description={talentLabels.length?talentLabels.join(' · '):'숙련 Lv.3부터 계열별 재능이 열려요.'} status={`${talents.length} / ${talentDefinitions.length}`} disabled/>
+        <Row marker="↗" title="커리어 기록" description={`훈련 ${state.careerRecords.trainings}회 · S등급 ${state.careerRecords.sGrades}회 · 외출 ${state.careerRecords.outings}회 · 선물 ${state.careerRecords.gifts}회`} status={`BEST ${state.careerRecords.bestScore}`} disabled/>
+        <Row marker="♥" title="현재 관계" status={relationshipLabels[rank]} disabled/>
+        <Row marker="1" title="호감도" status={`${state.stats.affection} / 100`} disabled/>
+        <Row marker="2" title="수집한 기억" status={`${collection.memories}개`} disabled/>
+        <Row marker="3" title="해금한 기술" status={`${collection.skills}개`} disabled/>
+        <Row marker="4" title="외출 기억" status={`${state.visitedOutings.length} / ${outingLocationIds.length}`} disabled/>
+        <Row marker="5" title="숨겨진 발견물" status={`${state.discoveries.length} / ${discoveryIds.length}`} disabled/>
+        <Row marker="6" title="최고 숙련도" status={`Lv.${highestMastery}`} disabled/>
+      </>}
+
+      {feature==='outing'&&<>
+        {state.lastExploration&&<Row marker="★" title={`${outingDefinitions[state.lastExploration.location].name} 탐험 기록`} description={state.lastExploration.discovery?`숨겨진 발견 · ${discoveryLabels[state.lastExploration.discovery]}`:state.lastExploration.event?explorationEventLabels[state.lastExploration.event]:'이번에는 특별한 일 없이 평화롭게 다녀왔어요.'} status={state.lastExploration.discovery?'발견!':state.lastExploration.event?'사건':'기록'} disabled/>}
+        {outingLocationIds.map((id,index)=>{
+          const location=outingDefinitions[id];
+          const visited=state.visitedOutings.includes(id);
+          const xp=state.explorationXp[id];
+          const level=explorationLevel(xp);
+          const nextXp=explorationXpForNextLevel(xp);
+          return <Row key={id} marker={visited?'✓':index+1} title={location.name} description={`탐험 Lv.${level} · ${nextXp===null?'MAX':`${xp} / ${nextXp} XP`} · ${location.description}`} status={visited?'탐험':'출발'} onClick={()=>onOuting(id)}/>;
+        })}
+      </>}
+    </div>
+  </section>;
+}

--- a/src/MobileRouterChrome.tsx
+++ b/src/MobileRouterChrome.tsx
@@ -4,6 +4,7 @@ import MobileHomeStatus from './MobileHomeStatus';
 import MobileNavIcon,{type MobileNavIconName} from './MobileNavIcon';
 import type {MobileCategoryId,MobileNavigationState} from './mobile-router';
 import './mobile-router-v8.css';
+import './mobile-legacy-feature-v8.css';
 
 type PendingExit='back'|'home'|null;
 

--- a/src/MobileRouterChrome.tsx
+++ b/src/MobileRouterChrome.tsx
@@ -39,11 +39,21 @@ function activeCategory(navigation:MobileNavigationState):MobileCategoryId{
 }
 
 export default function MobileRouterChrome({
-  state,navigation,guarded,pendingExit,onCategory,onHome,onRequestExit,onCancelExit,onConfirmExit,
+  state,navigation,guarded,pendingExit,onCategory,onBack,onHome,onRequestExit,onCancelExit,onConfirmExit,
   notificationCount=0,onNotifications=()=>undefined,children,
 }:Props){
+  const route=navigation.current;
   const active=activeCategory(navigation);
-  return <div className={`v8-mobile-shell${guarded?' is-guarded':''}`}>
+  const appPlay=route.kind==='play'&&route.screen!=='tactical'&&route.screen!=='choice_event';
+  const ordinaryRoute=route.kind==='category'||route.kind==='feature';
+  const shellClass=[
+    'v8-mobile-shell',
+    guarded?'is-guarded':'',
+    route.kind==='home'?'is-home':'',
+    appPlay?'is-app-play':'',
+  ].filter(Boolean).join(' ');
+
+  return <div className={shellClass}>
     {!guarded&&<MobileHomeStatus
       state={state}
       notificationCount={notificationCount}
@@ -60,7 +70,12 @@ export default function MobileRouterChrome({
       </button>
     </nav>}
 
-    <div className="v8-route-body">{children}</div>
+    <div className="v8-route-body">
+      {ordinaryRoute&&<button type="button" className="v8-route-back" onClick={onBack} aria-label="이전 화면으로 돌아가기">
+        <span aria-hidden="true">‹</span><b>이전</b>
+      </button>}
+      {children}
+    </div>
 
     {!guarded&&<nav className="v8-bottom-nav" aria-label="주요 메뉴">
       {categories.map(item=><button

--- a/src/MobileRouterChrome.tsx
+++ b/src/MobileRouterChrome.tsx
@@ -1,0 +1,92 @@
+import type {ReactNode} from 'react';
+import type {GameState} from './game';
+import MobileHomeStatus from './MobileHomeStatus';
+import MobileNavIcon,{type MobileNavIconName} from './MobileNavIcon';
+import type {MobileCategoryId,MobileNavigationState} from './mobile-router';
+import './mobile-router-v8.css';
+
+type PendingExit='back'|'home'|null;
+
+type Props={
+  state:GameState;
+  navigation:MobileNavigationState;
+  guarded:boolean;
+  pendingExit:PendingExit;
+  onCategory:(category:MobileCategoryId)=>void;
+  onBack:()=>void;
+  onHome:()=>void;
+  onRequestExit:(target:Exclude<PendingExit,null>)=>void;
+  onCancelExit:()=>void;
+  onConfirmExit:()=>void;
+  notificationCount?:number;
+  onNotifications?:()=>void;
+  children:ReactNode;
+};
+
+const categories:Array<{id:MobileCategoryId;label:string;icon:MobileNavIconName}>=[
+  {id:'home',label:'홈',icon:'home'},
+  {id:'life',label:'생활',icon:'life'},
+  {id:'growth',label:'성장',icon:'growth'},
+  {id:'adventure',label:'모험',icon:'adventure'},
+  {id:'bond',label:'인연',icon:'bond'},
+  {id:'records',label:'기록',icon:'records'},
+];
+
+function activeCategory(navigation:MobileNavigationState):MobileCategoryId{
+  const route=navigation.current;
+  if(route.kind==='home')return 'home';
+  return route.category;
+}
+
+export default function MobileRouterChrome({
+  state,navigation,guarded,pendingExit,onCategory,onBack,onHome,onRequestExit,onCancelExit,onConfirmExit,
+  notificationCount=0,onNotifications=()=>undefined,children,
+}:Props){
+  const active=activeCategory(navigation);
+  return <div className={`v8-mobile-shell${guarded?' is-guarded':''}`}>
+    {!guarded&&<MobileHomeStatus
+      state={state}
+      notificationCount={notificationCount}
+      onNotifications={onNotifications}
+    />}
+
+    {guarded&&<header className="v8-play-header" aria-label="진행 중인 플레이 이동">
+      <button type="button" className="v8-play-back" onClick={()=>onRequestExit('back')} aria-label="진행을 종료하고 뒤로가기">
+        <span aria-hidden="true">‹</span><b>뒤로</b>
+      </button>
+      <strong>진행 중</strong>
+      <button type="button" className="v8-play-home" onClick={()=>onRequestExit('home')} aria-label="진행을 종료하고 홈으로 이동">
+        <MobileNavIcon name="home"/><b>홈</b>
+      </button>
+    </header>}
+
+    <div className="v8-route-body">{children}</div>
+
+    {guarded?<nav className="v8-play-guard" aria-label="진행 중인 플레이 제어">
+      <button type="button" onClick={()=>onRequestExit('back')}><span aria-hidden="true">‹</span><b>뒤로</b></button>
+      <button type="button" onClick={()=>onRequestExit('home')}><MobileNavIcon name="home"/><b>홈</b></button>
+    </nav>:<nav className="v8-bottom-nav" aria-label="주요 메뉴">
+      {categories.map(item=><button
+        key={item.id}
+        type="button"
+        className={active===item.id?'is-active':''}
+        aria-current={active===item.id?'page':undefined}
+        aria-pressed={active===item.id}
+        onClick={()=>item.id==='home'?onHome():onCategory(item.id)}
+      >
+        <span><MobileNavIcon name={item.icon}/></span><b>{item.label}</b>
+      </button>)}
+    </nav>}
+
+    {guarded&&pendingExit&&<div className="v8-exit-confirm-backdrop" role="presentation">
+      <section className="v8-exit-confirm" role="alertdialog" aria-modal="true" aria-labelledby="v8-exit-title" aria-describedby="v8-exit-copy">
+        <h2 id="v8-exit-title">진행 중인 플레이를 종료할까요?</h2>
+        <p id="v8-exit-copy">지금 나가면 현재 진행 내용이 완료되지 않습니다.</p>
+        <div className="v8-exit-actions">
+          <button type="button" className="is-safe" onClick={onCancelExit}>계속하기</button>
+          <button type="button" className="is-danger" onClick={onConfirmExit}>종료하고 이동</button>
+        </div>
+      </section>
+    </div>}
+  </div>;
+}

--- a/src/MobileRouterChrome.tsx
+++ b/src/MobileRouterChrome.tsx
@@ -39,7 +39,7 @@ function activeCategory(navigation:MobileNavigationState):MobileCategoryId{
 }
 
 export default function MobileRouterChrome({
-  state,navigation,guarded,pendingExit,onCategory,onBack,onHome,onRequestExit,onCancelExit,onConfirmExit,
+  state,navigation,guarded,pendingExit,onCategory,onHome,onRequestExit,onCancelExit,onConfirmExit,
   notificationCount=0,onNotifications=()=>undefined,children,
 }:Props){
   const active=activeCategory(navigation);
@@ -50,7 +50,7 @@ export default function MobileRouterChrome({
       onNotifications={onNotifications}
     />}
 
-    {guarded&&<header className="v8-play-header" aria-label="진행 중인 플레이 이동">
+    {guarded&&<nav className="v8-play-guard" aria-label="진행 중인 플레이 제어">
       <button type="button" className="v8-play-back" onClick={()=>onRequestExit('back')} aria-label="진행을 종료하고 뒤로가기">
         <span aria-hidden="true">‹</span><b>뒤로</b>
       </button>
@@ -58,14 +58,11 @@ export default function MobileRouterChrome({
       <button type="button" className="v8-play-home" onClick={()=>onRequestExit('home')} aria-label="진행을 종료하고 홈으로 이동">
         <MobileNavIcon name="home"/><b>홈</b>
       </button>
-    </header>}
+    </nav>}
 
     <div className="v8-route-body">{children}</div>
 
-    {guarded?<nav className="v8-play-guard" aria-label="진행 중인 플레이 제어">
-      <button type="button" onClick={()=>onRequestExit('back')}><span aria-hidden="true">‹</span><b>뒤로</b></button>
-      <button type="button" onClick={()=>onRequestExit('home')}><MobileNavIcon name="home"/><b>홈</b></button>
-    </nav>:<nav className="v8-bottom-nav" aria-label="주요 메뉴">
+    {!guarded&&<nav className="v8-bottom-nav" aria-label="주요 메뉴">
       {categories.map(item=><button
         key={item.id}
         type="button"

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,14 +1,18 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import type { GiftItemId, OutingLocationId } from './adventure';
+import { attendanceKey } from './attendance';
 import App from './App';
 import CollectionArchiveOverlay from './CollectionArchiveOverlay';
 import GuardianExpeditionOverlay from './GuardianExpeditionOverlay';
-import LayeredHomeV7 from './LayeredHomeV7';
+import LayeredHome from './LayeredHome';
+import MobileCategoryPage from './MobileCategoryPage';
+import MobileLegacyFeaturePage from './MobileLegacyFeaturePage';
+import MobileRouterChrome from './MobileRouterChrome';
 import RaisingIdentityOverlay from './RaisingIdentityOverlay';
 import SanctuaryOverlay from './SanctuaryOverlay';
 import SeasonalHomeBadge from './SeasonalHomeBadge';
 import SeasonLiveOpsOverlay from './SeasonLiveOpsOverlay';
-import TacticalExpeditionFlow from './TacticalExpeditionFlow';
+import TacticalExpeditionFlow, { type TacticalPhase } from './TacticalExpeditionFlow';
 import WorldProgressOverlay from './WorldProgressOverlay';
 import YearEndCeremonyOverlay from './YearEndCeremonyOverlay';
 import YearlyAmbitionOverlay from './YearlyAmbitionOverlay';
@@ -18,6 +22,8 @@ import type { BattleResult } from './tactical-battle';
 import type { CompanionId } from './tactical-companions';
 import type { TacticalEncounterId } from './tactical-encounters';
 import {
+  currentAvailableMail,
+  eligibleAchievements,
   initialState,
   type AchievementId,
   type ExpeditionActionCounts,
@@ -32,6 +38,14 @@ import {
   type YearlyAmbitionId,
 } from './game';
 import type { HomeMenuId } from './home-panels';
+import {
+  categoryForFeature,
+  initialMobileNavigationState,
+  isGuardedActiveRoute,
+  mobileNavigationReducer,
+  type MobileContentCategory,
+  type MobileFeatureId,
+} from './mobile-router';
 import type { SanctuaryMasterworkId } from './sanctuary-masterworks';
 import type { SanctuarySpecializationId } from './sanctuary-specializations';
 import type { SanctuaryFacilityId } from './starlight-sanctuary';
@@ -53,8 +67,28 @@ import './raising-identity.css';
 import './sanctuary.css';
 import './astral-rift.css';
 
+const homeMenuFeatures:Record<HomeMenuId,MobileFeatureId>={
+  schedule:'schedule',bag:'inventory',quest:'achievements',outing:'outing',bond:'bond',
+  attendance:'attendance',event:'stories',mail:'mail',mission:'mission',
+};
+
+const legacyPageFeatures = new Set<MobileFeatureId>([
+  'mission','attendance','mail','achievements','inventory','outing','bond','gifts','stories',
+]);
+
+const appScreenRoutes:Partial<Record<Screen,{category:'life';screen:'schedule'|'training'|'dialogue'|'result'}>>={
+  schedule:{category:'life',screen:'schedule'},
+  training:{category:'life',screen:'training'},
+  dialogue:{category:'life',screen:'dialogue'},
+  result:{category:'life',screen:'result'},
+};
+
 export default function Root() {
   const [gameState, setGameState] = useState<GameState>(initialState);
+  const [navigation, dispatchNavigation] = useReducer(mobileNavigationReducer, initialMobileNavigationState);
+  const [pendingExit, setPendingExit] = useState<'back'|'home'|null>(null);
+  const leavingAppScreenRef = useRef(false);
+
   const [navigate, setNavigate] = useState<((screen: Screen) => void) | null>(null);
   const [claimAchievement, setClaimAchievement] = useState<((achievement: AchievementId) => void) | null>(null);
   const [goOuting, setGoOuting] = useState<((location: OutingLocationId) => void) | null>(null);
@@ -72,7 +106,6 @@ export default function Root() {
   const [buildSanctuaryMasterwork, setBuildSanctuaryMasterwork] = useState<((masterwork: SanctuaryMasterworkId) => void) | null>(null);
   const [clearAstralRift, setClearAstralRift] = useState<((riftId: AstralRiftId, intensity: AstralRiftIntensity) => void) | null>(null);
   const [purchaseAstralRiftRelic, setPurchaseAstralRiftRelic] = useState<((relicId: AstralRiftRelicId) => void) | null>(null);
-  const [openHomeMenu, setOpenHomeMenu] = useState<((id: HomeMenuId) => void) | null>(null);
   const [finishExpedition, setFinishExpedition] = useState<((stageId: ExpeditionStageId, score: number, fatigueDelta: number, stressDelta: number, actionKinds: ExpeditionActionCounts) => void) | null>(null);
   const [equipExpedition, setEquipExpedition] = useState<((relic: ExpeditionRelicId) => void) | null>(null);
   const [unequipExpedition, setUnequipExpedition] = useState<((relic: ExpeditionRelicId) => void) | null>(null);
@@ -83,32 +116,24 @@ export default function Root() {
   const [selectWeeklyFocus, setSelectWeeklyFocus] = useState<((focus:WeeklyFocusId)=>void)|null>(null);
   const [completeWeeklyFocus, setCompleteWeeklyFocus] = useState<(()=>void)|null>(null);
   const [advanceWeek, setAdvanceWeek] = useState<(()=>void)|null>(null);
-  const [expeditionOpen, setExpeditionOpen] = useState(false);
-  const [raisingOpen, setRaisingOpen] = useState(false);
-  const [seasonLiveOpen, setSeasonLiveOpen] = useState(false);
-  const [sanctuaryOpen, setSanctuaryOpen] = useState(false);
-  const [worldProgressOpen, setWorldProgressOpen] = useState(false);
-  const [archiveOpen, setArchiveOpen] = useState(false);
-  const [ambitionOpen, setAmbitionOpen] = useState(false);
 
-  const captureNavigate = useCallback((nextNavigate: (screen: Screen) => void) => setNavigate(() => nextNavigate), []);
-  const captureClaimAchievement = useCallback((nextClaim: (achievement: AchievementId) => void) => setClaimAchievement(() => nextClaim), []);
-  const captureOuting = useCallback((nextOuting: (location: OutingLocationId) => void) => setGoOuting(() => nextOuting), []);
-  const captureGift = useCallback((nextGift: (item: GiftItemId) => void) => setGiveGift(() => nextGift), []);
-  const captureAttendance = useCallback((nextClaim: () => void) => setClaimAttendance(() => nextClaim), []);
-  const captureMail = useCallback((nextClaim: (mail: MailRewardId) => void) => setClaimMail(() => nextClaim), []);
-  const captureMonthlyFocus = useCallback((nextSetFocus: (focus: GameState['monthlyFocus']) => void) => setSetMonthlyFocus(() => nextSetFocus), []);
-  const captureYearlyAmbition = useCallback((nextSetAmbition: (ambition: YearlyAmbitionId) => void) => setSetYearlyAmbition(() => nextSetAmbition), []);
-  const captureGuardianCalling = useCallback((nextSetCalling: (calling: GuardianCallingId) => void) => setSetGuardianCalling(() => nextSetCalling), []);
-  const captureGrowthTrait = useCallback((nextPurchaseTrait: (trait: GrowthTraitId) => void) => setPurchaseGrowthTrait(() => nextPurchaseTrait), []);
-  const captureSeasonPurchase = useCallback((nextPurchase: (offer: SeasonShopOfferId) => void) => setPurchaseSeasonOffer(() => nextPurchase), []);
-  const captureSeasonLegacyUnlock = useCallback((nextUnlock: (nodeId: SeasonLegacyNodeId) => void) => setUnlockSeasonLegacyNode(() => nextUnlock), []);
-  const captureSanctuaryUpgrade = useCallback((nextUpgrade: (facility: SanctuaryFacilityId) => void) => setUpgradeSanctuary(() => nextUpgrade), []);
-  const captureSanctuarySpecialization = useCallback((nextSelect: (specialization: SanctuarySpecializationId) => void) => setSelectSanctuarySpecialization(() => nextSelect), []);
-  const captureSanctuaryMasterwork = useCallback((nextBuild: (masterwork: SanctuaryMasterworkId) => void) => setBuildSanctuaryMasterwork(() => nextBuild), []);
-  const captureAstralRiftClear = useCallback((nextClear: (riftId: AstralRiftId, intensity: AstralRiftIntensity) => void) => setClearAstralRift(() => nextClear), []);
-  const captureAstralRiftRelic = useCallback((nextPurchase: (relicId: AstralRiftRelicId) => void) => setPurchaseAstralRiftRelic(() => nextPurchase), []);
-  const captureHomeMenu = useCallback((nextOpenMenu: (id: HomeMenuId) => void) => setOpenHomeMenu(() => nextOpenMenu), []);
+  const captureNavigate = useCallback((next: (screen: Screen) => void) => setNavigate(() => next), []);
+  const captureClaimAchievement = useCallback((next: (achievement: AchievementId) => void) => setClaimAchievement(() => next), []);
+  const captureOuting = useCallback((next: (location: OutingLocationId) => void) => setGoOuting(() => next), []);
+  const captureGift = useCallback((next: (item: GiftItemId) => void) => setGiveGift(() => next), []);
+  const captureAttendance = useCallback((next: () => void) => setClaimAttendance(() => next), []);
+  const captureMail = useCallback((next: (mail: MailRewardId) => void) => setClaimMail(() => next), []);
+  const captureMonthlyFocus = useCallback((next: (focus: GameState['monthlyFocus']) => void) => setSetMonthlyFocus(() => next), []);
+  const captureYearlyAmbition = useCallback((next: (ambition: YearlyAmbitionId) => void) => setSetYearlyAmbition(() => next), []);
+  const captureGuardianCalling = useCallback((next: (calling: GuardianCallingId) => void) => setSetGuardianCalling(() => next), []);
+  const captureGrowthTrait = useCallback((next: (trait: GrowthTraitId) => void) => setPurchaseGrowthTrait(() => next), []);
+  const captureSeasonPurchase = useCallback((next: (offer: SeasonShopOfferId) => void) => setPurchaseSeasonOffer(() => next), []);
+  const captureSeasonLegacyUnlock = useCallback((next: (nodeId: SeasonLegacyNodeId) => void) => setUnlockSeasonLegacyNode(() => next), []);
+  const captureSanctuaryUpgrade = useCallback((next: (facility: SanctuaryFacilityId) => void) => setUpgradeSanctuary(() => next), []);
+  const captureSanctuarySpecialization = useCallback((next: (specialization: SanctuarySpecializationId) => void) => setSelectSanctuarySpecialization(() => next), []);
+  const captureSanctuaryMasterwork = useCallback((next: (masterwork: SanctuaryMasterworkId) => void) => setBuildSanctuaryMasterwork(() => next), []);
+  const captureAstralRiftClear = useCallback((next: (riftId: AstralRiftId, intensity: AstralRiftIntensity) => void) => setClearAstralRift(() => next), []);
+  const captureAstralRiftRelic = useCallback((next: (relicId: AstralRiftRelicId) => void) => setPurchaseAstralRiftRelic(() => next), []);
   const captureExpeditionFinish = useCallback((next: (stageId: ExpeditionStageId, score: number, fatigueDelta: number, stressDelta: number, actionKinds: ExpeditionActionCounts) => void) => setFinishExpedition(() => next), []);
   const captureExpeditionEquip = useCallback((next: (relic: ExpeditionRelicId) => void) => setEquipExpedition(() => next), []);
   const captureExpeditionUnequip = useCallback((next: (relic: ExpeditionRelicId) => void) => setUnequipExpedition(() => next), []);
@@ -120,7 +145,39 @@ export default function Root() {
   const captureWeeklyComplete = useCallback((next:()=>void)=>setCompleteWeeklyFocus(() => next),[]);
   const captureWeeklyAdvance = useCallback((next:()=>void)=>setAdvanceWeek(() => next),[]);
 
-  const openSchedule = useCallback(() => navigate?.('schedule'), [navigate]);
+  const leaveAppScreen = useCallback(() => {
+    if (gameState.screen === 'hub') return;
+    leavingAppScreenRef.current = true;
+    navigate?.('hub');
+  }, [gameState.screen, navigate]);
+
+  const openCategory = useCallback((category:MobileContentCategory) => {
+    leaveAppScreen();
+    dispatchNavigation({type:'OPEN_CATEGORY',category});
+  },[leaveAppScreen]);
+
+  const openFeature = useCallback((feature:MobileFeatureId) => {
+    const category=categoryForFeature[feature];
+    if(feature==='schedule'){
+      navigate?.('schedule');
+      dispatchNavigation({type:'OPEN_PLAY',category:'life',screen:'schedule'});
+      return;
+    }
+    dispatchNavigation({type:'OPEN_FEATURE',category,feature});
+  },[navigate]);
+
+  const handleBack = useCallback(() => {
+    const current=navigation.current;
+    if(current.kind==='play'&&current.screen!=='tactical'&&current.screen!=='choice_event')leaveAppScreen();
+    dispatchNavigation({type:'BACK'});
+  },[navigation.current,leaveAppScreen]);
+
+  const handleHome = useCallback(() => {
+    leaveAppScreen();
+    dispatchNavigation({type:'HOME'});
+  },[leaveAppScreen]);
+
+  const handleHomeMenuNavigate = useCallback((id:HomeMenuId)=>openFeature(homeMenuFeatures[id]),[openFeature]);
   const handleClaimAchievement = useCallback((achievement: AchievementId) => claimAchievement?.(achievement), [claimAchievement]);
   const handleOuting = useCallback((location: OutingLocationId) => goOuting?.(location), [goOuting]);
   const handleGift = useCallback((item: GiftItemId) => giveGift?.(item), [giveGift]);
@@ -128,8 +185,6 @@ export default function Root() {
   const handleMail = useCallback((mail: MailRewardId) => claimMail?.(mail), [claimMail]);
   const handleMonthlyFocus = useCallback((focus: GameState['monthlyFocus']) => setMonthlyFocus?.(focus), [setMonthlyFocus]);
   const handleYearlyAmbition = useCallback((ambition: YearlyAmbitionId) => setYearlyAmbition?.(ambition), [setYearlyAmbition]);
-  const handleArchiveNavigate = useCallback((id: HomeMenuId) => openHomeMenu?.(id), [openHomeMenu]);
-  const handleOpenExpedition = useCallback(() => setExpeditionOpen(true), []);
   const handleSeasonPurchase = useCallback((offer: SeasonShopOfferId) => purchaseSeasonOffer?.(offer), [purchaseSeasonOffer]);
   const handleSeasonLegacyUnlock = useCallback((nodeId: SeasonLegacyNodeId) => unlockSeasonLegacyNode?.(nodeId), [unlockSeasonLegacyNode]);
   const handleSanctuaryUpgrade = useCallback((facility: SanctuaryFacilityId) => upgradeSanctuary?.(facility), [upgradeSanctuary]);
@@ -141,41 +196,113 @@ export default function Root() {
   const handleCompleteWeek = useCallback(()=>completeWeeklyFocus?.(),[completeWeeklyFocus]);
   const handleAdvanceWeek = useCallback(()=>advanceWeek?.(),[advanceWeek]);
 
-  return <>
-    <App
-      onStateChange={setGameState}
-      onNavigateReady={captureNavigate}
-      onClaimAchievementReady={captureClaimAchievement}
-      onOutingReady={captureOuting}
-      onGiftReady={captureGift}
-      onAttendanceReady={captureAttendance}
-      onMailReady={captureMail}
-      onMonthlyFocusReady={captureMonthlyFocus}
-      onYearlyAmbitionReady={captureYearlyAmbition}
-      onExpeditionFinishReady={captureExpeditionFinish}
-      onExpeditionEquipReady={captureExpeditionEquip}
-      onExpeditionUnequipReady={captureExpeditionUnequip}
-      onExpeditionCraftReady={captureExpeditionCraft}
-      onGuardianCallingReady={captureGuardianCalling}
-      onGrowthTraitReady={captureGrowthTrait}
-      onSeasonPurchaseReady={captureSeasonPurchase}
-      onSeasonLegacyUnlockReady={captureSeasonLegacyUnlock}
-      onSanctuaryUpgradeReady={captureSanctuaryUpgrade}
-      onSanctuarySpecializationReady={captureSanctuarySpecialization}
-      onSanctuaryMasterworkReady={captureSanctuaryMasterwork}
-      onAstralRiftClearReady={captureAstralRiftClear}
-      onAstralRiftRelicReady={captureAstralRiftRelic}
-      onTacticalPartyReady={captureTacticalParty}
-      onTacticalPreferencesReady={captureTacticalPreferences}
-      onTacticalCompleteReady={captureTacticalComplete}
-      onWeeklyFocusReady={captureWeeklyFocus}
-      onWeeklyCompleteReady={captureWeeklyComplete}
-      onWeeklyAdvanceReady={captureWeeklyAdvance}
+  const notificationCount=useMemo(()=>{
+    const mail=new Set(currentAvailableMail(gameState));
+    const unclaimedMail=[...mail].filter(id=>!gameState.claimedMailRewards.includes(id)).length;
+    const attendance=gameState.claimedAttendanceMonths.includes(attendanceKey(gameState.year,gameState.month))?0:1;
+    const eligible=new Set(eligibleAchievements(gameState));
+    const achievements=[...eligible].filter(id=>!gameState.claimedAchievements.includes(id)).length;
+    return unclaimedMail+attendance+achievements;
+  },[gameState]);
+
+  const openNotifications=useCallback(()=>{
+    const mail=new Set(currentAvailableMail(gameState));
+    if([...mail].some(id=>!gameState.claimedMailRewards.includes(id)))return openFeature('mail');
+    if(!gameState.claimedAttendanceMonths.includes(attendanceKey(gameState.year,gameState.month)))return openFeature('attendance');
+    const eligible=new Set(eligibleAchievements(gameState));
+    if([...eligible].some(id=>!gameState.claimedAchievements.includes(id)))return openFeature('achievements');
+    openCategory('life');
+  },[gameState,openFeature,openCategory]);
+
+  const handleTacticalPhase=useCallback((phase:TacticalPhase)=>{
+    if(phase==='active')dispatchNavigation({type:'OPEN_PLAY',category:'adventure',screen:'tactical'});
+    else if(phase==='result')dispatchNavigation({type:'OPEN_FEATURE',category:'adventure',feature:'expedition'});
+    else if(navigation.current.kind==='play'&&navigation.current.screen==='tactical')dispatchNavigation({type:'OPEN_FEATURE',category:'adventure',feature:'expedition'});
+  },[navigation.current]);
+
+  useEffect(()=>{
+    if(leavingAppScreenRef.current){
+      if(gameState.screen==='hub')leavingAppScreenRef.current=false;
+      return;
+    }
+    const route=appScreenRoutes[gameState.screen];
+    if(route){
+      const current=navigation.current;
+      if(current.kind!=='play'||current.screen!==route.screen){
+        dispatchNavigation({type:'OPEN_PLAY',category:route.category,screen:route.screen});
+      }
+      return;
+    }
+    if(gameState.screen==='hub'&&navigation.current.kind==='play'&&navigation.current.screen!=='tactical'&&navigation.current.screen!=='choice_event'){
+      dispatchNavigation({type:'HOME'});
+    }
+  },[gameState.screen,navigation.current]);
+
+  const guarded=isGuardedActiveRoute(navigation.current);
+  const normalAppPlay=gameState.screen==='schedule'||gameState.screen==='result';
+  const guardedAppPlay=gameState.screen==='training'||gameState.screen==='dialogue';
+
+  const confirmExit=useCallback(()=>{
+    const target=pendingExit;
+    setPendingExit(null);
+    if(target==='home')handleHome();
+    else if(target==='back')handleBack();
+  },[pendingExit,handleHome,handleBack]);
+
+  const renderExpedition = (state:GameState) => <>
+    <GuardianExpeditionOverlay
+      state={state}
+      open
+      onOpen={()=>undefined}
+      onClose={handleBack}
+      onFinish={(stageId, score, fatigueDelta, stressDelta, actionKinds) => finishExpedition?.(stageId, score, fatigueDelta, stressDelta, actionKinds)}
+      onEquip={relic => equipExpedition?.(relic)}
+      onUnequip={relic => unequipExpedition?.(relic)}
+      onCraft={recipe => craftExpedition?.(recipe)}
     />
-    {gameState.screen === 'hub' && <>
-      <LayeredHomeV7
-        state={gameState}
-        onSchedule={openSchedule}
+    {setTacticalParty && setTacticalPreferences && completeTacticalBattle && finishExpedition && <TacticalExpeditionFlow
+      state={state}
+      expeditionOpen
+      onSetParty={setTacticalParty}
+      onSetPreferences={setTacticalPreferences}
+      onComplete={completeTacticalBattle}
+      onExpeditionFinish={finishExpedition}
+      onExitToHome={()=>{
+        navigate?.('hub');
+        dispatchNavigation({type:'OPEN_CATEGORY',category:'adventure'});
+      }}
+      onPhaseChange={handleTacticalPhase}
+    />}
+  </>;
+
+  const renderFeature = (state:GameState,feature:MobileFeatureId) => {
+    if(legacyPageFeatures.has(feature))return <MobileLegacyFeaturePage
+      feature={feature}
+      state={state}
+      onClaimAchievement={handleClaimAchievement}
+      onOuting={handleOuting}
+      onGift={handleGift}
+      onAttendance={handleAttendance}
+      onMail={handleMail}
+      onMonthlyFocus={handleMonthlyFocus}
+    />;
+    if(feature==='raising')return <RaisingIdentityOverlay state={state} open onOpen={()=>undefined} onClose={handleBack} onCalling={calling=>setGuardianCalling?.(calling)} onTrait={trait=>purchaseGrowthTrait?.(trait)}/>;
+    if(feature==='ambition')return <YearlyAmbitionOverlay state={state} onSelect={handleYearlyAmbition} open onOpenChange={open=>{if(!open)handleBack();}}/>;
+    if(feature==='season')return <SeasonLiveOpsOverlay state={state} open onOpen={()=>undefined} onClose={handleBack} onPurchase={handleSeasonPurchase} onLegacyUnlock={handleSeasonLegacyUnlock}/>;
+    if(feature==='sanctuary')return <SanctuaryOverlay state={state} open onOpen={()=>undefined} onClose={handleBack} onUpgrade={handleSanctuaryUpgrade} onSpecialization={handleSanctuarySpecialization} onMasterwork={handleSanctuaryMasterwork} onAstralRiftClear={handleAstralRiftClear} onAstralRiftRelic={handleAstralRiftRelic} onConvergenceClear={()=>undefined} onGuardianBoon={()=>undefined}/>;
+    if(feature==='world')return <WorldProgressOverlay state={state} open onOpenChange={open=>{if(!open)handleBack();}}/>;
+    if(feature==='archive')return <CollectionArchiveOverlay state={state} onNavigate={handleHomeMenuNavigate} onExpedition={()=>openFeature('expedition')} open onOpenChange={open=>{if(!open)handleBack();}}/>;
+    if(feature==='expedition')return renderExpedition(state);
+    if(feature==='lineage'||feature==='world_chronicle')return <MobileCategoryPage category="records" state={state} onOpenFeature={openFeature} onWeeklyFocus={handleWeeklyFocus} onCompleteWeek={handleCompleteWeek} onAdvanceWeek={handleAdvanceWeek}/>;
+    return null;
+  };
+
+  const renderRoute = (state:GameState) => {
+    const route=navigation.current;
+    if(route.kind==='home')return <>
+      <LayeredHome
+        state={state}
+        onSchedule={()=>openFeature('schedule')}
         onClaimAchievement={handleClaimAchievement}
         onOuting={handleOuting}
         onGift={handleGift}
@@ -185,68 +312,68 @@ export default function Root() {
         onWeeklyFocus={handleWeeklyFocus}
         onCompleteWeek={handleCompleteWeek}
         onAdvanceWeek={handleAdvanceWeek}
-        onExpedition={handleOpenExpedition}
-        onSeason={() => setSeasonLiveOpen(true)}
-        onRaising={() => setRaisingOpen(true)}
-        onSanctuary={() => setSanctuaryOpen(true)}
-        onWorldProgress={() => setWorldProgressOpen(true)}
-        onArchive={() => setArchiveOpen(true)}
-        onAmbition={() => setAmbitionOpen(true)}
-        onMenuReady={captureHomeMenu}
+        onExpedition={()=>openFeature('expedition')}
+        onSeason={()=>openFeature('season')}
+        onMenuNavigate={handleHomeMenuNavigate}
+        onWeeklyPlannerNavigate={()=>openCategory('life')}
       />
-      <SeasonalHomeBadge month={gameState.month} stamps={gameState.seasonStamps} />
-      <SeasonLiveOpsOverlay
-        state={gameState}
-        open={seasonLiveOpen}
-        onOpen={() => setSeasonLiveOpen(true)}
-        onClose={() => setSeasonLiveOpen(false)}
-        onPurchase={handleSeasonPurchase}
-        onLegacyUnlock={handleSeasonLegacyUnlock}
+      <SeasonalHomeBadge month={state.month} stamps={state.seasonStamps}/>
+      <YearEndCeremonyOverlay state={state}/>
+    </>;
+    if(route.kind==='category')return <MobileCategoryPage category={route.category} state={state} onOpenFeature={openFeature} onWeeklyFocus={handleWeeklyFocus} onCompleteWeek={handleCompleteWeek} onAdvanceWeek={handleAdvanceWeek}/>;
+    if(route.kind==='feature')return renderFeature(state,route.feature);
+    if(route.screen==='tactical')return renderExpedition(state);
+    return null;
+  };
+
+  return <>
+    <div className={`v8-app-host${normalAppPlay?' is-normal-play':''}${guardedAppPlay?' is-guarded-play':''}`}>
+      <App
+        onStateChange={setGameState}
+        onNavigateReady={captureNavigate}
+        onClaimAchievementReady={captureClaimAchievement}
+        onOutingReady={captureOuting}
+        onGiftReady={captureGift}
+        onAttendanceReady={captureAttendance}
+        onMailReady={captureMail}
+        onMonthlyFocusReady={captureMonthlyFocus}
+        onYearlyAmbitionReady={captureYearlyAmbition}
+        onExpeditionFinishReady={captureExpeditionFinish}
+        onExpeditionEquipReady={captureExpeditionEquip}
+        onExpeditionUnequipReady={captureExpeditionUnequip}
+        onExpeditionCraftReady={captureExpeditionCraft}
+        onGuardianCallingReady={captureGuardianCalling}
+        onGrowthTraitReady={captureGrowthTrait}
+        onSeasonPurchaseReady={captureSeasonPurchase}
+        onSeasonLegacyUnlockReady={captureSeasonLegacyUnlock}
+        onSanctuaryUpgradeReady={captureSanctuaryUpgrade}
+        onSanctuarySpecializationReady={captureSanctuarySpecialization}
+        onSanctuaryMasterworkReady={captureSanctuaryMasterwork}
+        onAstralRiftClearReady={captureAstralRiftClear}
+        onAstralRiftRelicReady={captureAstralRiftRelic}
+        onTacticalPartyReady={captureTacticalParty}
+        onTacticalPreferencesReady={captureTacticalPreferences}
+        onTacticalCompleteReady={captureTacticalComplete}
+        onWeeklyFocusReady={captureWeeklyFocus}
+        onWeeklyCompleteReady={captureWeeklyComplete}
+        onWeeklyAdvanceReady={captureWeeklyAdvance}
       />
-      <SanctuaryOverlay
-        state={gameState}
-        open={sanctuaryOpen}
-        onOpen={() => setSanctuaryOpen(true)}
-        onClose={() => setSanctuaryOpen(false)}
-        onUpgrade={handleSanctuaryUpgrade}
-        onSpecialization={handleSanctuarySpecialization}
-        onMasterwork={handleSanctuaryMasterwork}
-        onAstralRiftClear={handleAstralRiftClear}
-        onAstralRiftRelic={handleAstralRiftRelic}
-        onConvergenceClear={() => undefined}
-        onGuardianBoon={() => undefined}
-      />
-      <YearlyAmbitionOverlay state={gameState} onSelect={handleYearlyAmbition} open={ambitionOpen} onOpenChange={setAmbitionOpen} />
-      <CollectionArchiveOverlay state={gameState} onNavigate={handleArchiveNavigate} onExpedition={handleOpenExpedition} open={archiveOpen} onOpenChange={setArchiveOpen} />
-      <WorldProgressOverlay state={gameState} open={worldProgressOpen} onOpenChange={setWorldProgressOpen} />
-      <YearEndCeremonyOverlay state={gameState} />
-      <RaisingIdentityOverlay
-        state={gameState}
-        open={raisingOpen}
-        onOpen={() => setRaisingOpen(true)}
-        onClose={() => setRaisingOpen(false)}
-        onCalling={calling => setGuardianCalling?.(calling)}
-        onTrait={trait => purchaseGrowthTrait?.(trait)}
-      />
-      <GuardianExpeditionOverlay
-        state={gameState}
-        open={expeditionOpen}
-        onOpen={handleOpenExpedition}
-        onClose={() => setExpeditionOpen(false)}
-        onFinish={(stageId, score, fatigueDelta, stressDelta, actionKinds) => finishExpedition?.(stageId, score, fatigueDelta, stressDelta, actionKinds)}
-        onEquip={relic => equipExpedition?.(relic)}
-        onUnequip={relic => unequipExpedition?.(relic)}
-        onCraft={recipe => craftExpedition?.(recipe)}
-      />
-      {setTacticalParty && setTacticalPreferences && completeTacticalBattle && finishExpedition && <TacticalExpeditionFlow
-        state={gameState}
-        expeditionOpen={expeditionOpen}
-        onSetParty={setTacticalParty}
-        onSetPreferences={setTacticalPreferences}
-        onComplete={completeTacticalBattle}
-        onExpeditionFinish={finishExpedition}
-        onExitToHome={() => setExpeditionOpen(false)}
-      />}
-    </>}
+    </div>
+    <MobileRouterChrome
+      state={gameState}
+      navigation={navigation}
+      guarded={guarded}
+      pendingExit={pendingExit}
+      onCategory={category=>category==='home'?handleHome():openCategory(category)}
+      onBack={handleBack}
+      onHome={handleHome}
+      onRequestExit={setPendingExit}
+      onCancelExit={()=>setPendingExit(null)}
+      onConfirmExit={confirmExit}
+      notificationCount={notificationCount}
+      onNotifications={openNotifications}
+    >
+      {renderRoute(gameState)}
+    </MobileRouterChrome>
   </>;
 }

--- a/src/TacticalExpeditionFlow.tsx
+++ b/src/TacticalExpeditionFlow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import TacticalBattleScreen from './TacticalBattleScreen';
 import type { BattleResult, BattleSession } from './tactical-battle';
 import { COMPANIONS, type CompanionId } from './tactical-companions';
@@ -47,6 +47,7 @@ export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,
   const [party,setParty] = useState<[CompanionId,CompanionId]>(()=>tacticalPartyForGame(state));
   const [auto,setAuto] = useState(state.tacticalAutoBattle);
   const [speed,setSpeed] = useState<1|2>(state.tacticalBattleSpeed);
+  const onPhaseChangeRef = useRef(onPhaseChange);
   const stageId = (nextExpeditionStage(state.expeditionRecords) ?? 'forest_path') as ExpeditionStageId;
   const stage = useMemo(()=>expeditionStageDefinitions.find(item=>item.id===stageId)!,[stageId]);
   const bondLevels = useMemo(()=>({
@@ -57,8 +58,12 @@ export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,
   }),[state.tacticalCompanionBonds]);
 
   useEffect(()=>{
-    if(expeditionOpen&&!open)onPhaseChange?.('setup');
-  },[expeditionOpen,open,onPhaseChange]);
+    onPhaseChangeRef.current=onPhaseChange;
+  },[onPhaseChange]);
+
+  useEffect(()=>{
+    if(expeditionOpen&&!open)onPhaseChangeRef.current?.('setup');
+  },[expeditionOpen,open]);
 
   if (!expeditionOpen) return null;
 

--- a/src/TacticalExpeditionFlow.tsx
+++ b/src/TacticalExpeditionFlow.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import TacticalBattleScreen from './TacticalBattleScreen';
 import type { BattleResult, BattleSession } from './tactical-battle';
 import { COMPANIONS, type CompanionId } from './tactical-companions';
@@ -14,6 +14,8 @@ import {
 } from './tactical-launcher';
 import './tactical-expedition-flow.css';
 
+export type TacticalPhase='setup'|'active'|'result';
+
 export type TacticalExpeditionFlowProps = {
   state:GameState;
   expeditionOpen:boolean;
@@ -22,6 +24,7 @@ export type TacticalExpeditionFlowProps = {
   onComplete:(encounterId:TacticalEncounterId,result:BattleResult,rounds:number,survivingAllies:number,damageTaken:number,companions:[CompanionId,CompanionId])=>void;
   onExpeditionFinish:(stageId:ExpeditionStageId,score:number,fatigueDelta:number,stressDelta:number,actionKinds:ExpeditionActionCounts)=>void;
   onExitToHome:()=>void;
+  onPhaseChange?:(phase:TacticalPhase)=>void;
 };
 
 const companionLabels:Record<CompanionId,string> = { bear:'곰 · 탱커',owl:'올빼미 · 지원',wolf:'늑대 · 딜러',cat:'고양이 · 교란' };
@@ -38,7 +41,7 @@ export function closeTacticalFlow(clearSession:()=>void,closeBattle:()=>void,onE
   onExitToHome();
 }
 
-export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,onSetPreferences,onComplete,onExpeditionFinish,onExitToHome}:TacticalExpeditionFlowProps) {
+export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,onSetPreferences,onComplete,onExpeditionFinish,onExitToHome,onPhaseChange}:TacticalExpeditionFlowProps) {
   const [open,setOpen] = useState(false);
   const [session,setSession] = useState<BattleSession|null>(null);
   const [party,setParty] = useState<[CompanionId,CompanionId]>(()=>tacticalPartyForGame(state));
@@ -53,6 +56,10 @@ export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,
     cat:state.tacticalCompanionBonds.cat.level,
   }),[state.tacticalCompanionBonds]);
 
+  useEffect(()=>{
+    if(expeditionOpen&&!open)onPhaseChange?.('setup');
+  },[expeditionOpen,open,onPhaseChange]);
+
   if (!expeditionOpen) return null;
 
   const chooseCompanion = (id:CompanionId) => {
@@ -60,10 +67,13 @@ export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,
     setParty(([first,second])=>[second,id]);
   };
 
+  const createSession = (seedOffset=0) => createTacticalBattleFromGame({...state,selectedTacticalCompanions:party},stageId,seedFor(state,stageId)+seedOffset);
+
   const start = () => {
     onSetParty(party);
-    setSession(createTacticalBattleFromGame({...state,selectedTacticalCompanions:party},stageId,seedFor(state,stageId)));
+    setSession(createSession());
     setOpen(true);
+    onPhaseChange?.('active');
   };
 
   const toggleAuto = () => {
@@ -79,10 +89,21 @@ export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,
 
   const complete = (result:BattleResult,finalSession:BattleSession) => {
     const metrics = tacticalCompletionMetrics(finalSession);
+    onPhaseChange?.('result');
     onComplete(tacticalEncounterForExpeditionStage(stageId),result,metrics.rounds,metrics.survivingAllies,metrics.damageTaken,party);
     const actionKinds:ExpeditionActionCounts = { attack:metrics.rounds,dodge:0,charge:0 };
     const expeditionScore = tacticalExpeditionFinishScore(stage.target,result);
     onExpeditionFinish(stageId,expeditionScore,result==='victory'?2:6,result==='victory'?1:5,actionKinds);
+  };
+
+  const retry = () => {
+    setSession(createSession(1));
+    onPhaseChange?.('active');
+  };
+
+  const exit = () => {
+    onPhaseChange?.('setup');
+    closeTacticalFlow(()=>setSession(null),()=>setOpen(false),onExitToHome);
   };
 
   if (open && session) {
@@ -96,8 +117,8 @@ export default function TacticalExpeditionFlow({state,expeditionOpen,onSetParty,
         onToggleAuto={toggleAuto}
         onToggleSpeed={toggleSpeed}
         onComplete={complete}
-        onRetry={()=>setSession(createTacticalBattleFromGame({...state,selectedTacticalCompanions:party},stageId,seedFor(state,stageId)+1))}
-        onExit={()=>closeTacticalFlow(()=>setSession(null),()=>setOpen(false),onExitToHome)}
+        onRetry={retry}
+        onExit={exit}
       />
     </div>;
   }

--- a/src/mobile-legacy-feature-v8.css
+++ b/src/mobile-legacy-feature-v8.css
@@ -1,0 +1,16 @@
+.v8-feature-page{width:100%;max-width:520px;margin:0 auto;padding:0 0 16px;display:grid;gap:12px;color:#493326}
+.v8-feature-heading{position:sticky;top:52px;z-index:3;padding:13px 14px;border:1px solid #d9b96f;border-radius:18px;background:linear-gradient(180deg,rgba(255,248,232,.99),rgba(248,231,195,.97));box-shadow:0 8px 20px rgba(0,0,0,.18)}
+.v8-feature-heading>small{display:block;font-size:12px;line-height:1.2;font-weight:900;letter-spacing:.08em;color:#8a6846}
+.v8-feature-heading h1{margin:2px 0 0;font-size:22px;line-height:1.2;color:#493326}
+.v8-feature-heading p{margin:5px 0 0;font-size:14px;line-height:1.45;color:#735844;overflow-wrap:anywhere}
+.v8-feature-list{display:grid;gap:9px}
+.v8-feature-row{width:100%;min-height:58px;display:grid;grid-template-columns:38px minmax(0,1fr) auto;gap:10px;align-items:center;padding:10px 12px;border:1px solid #dfc78f;border-radius:15px;background:rgba(255,253,247,.97);color:#493326;text-align:left;font:inherit;touch-action:manipulation}
+.v8-feature-row:not(:disabled){cursor:pointer;box-shadow:0 4px 10px rgba(57,35,21,.08)}
+.v8-feature-row:disabled{opacity:.76}
+.v8-feature-row:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
+.v8-feature-marker{width:38px;height:38px;display:grid;place-items:center;border-radius:12px;background:#f0e2c4;color:#654a79;font-size:15px;font-weight:900}
+.v8-feature-copy{min-width:0}.v8-feature-copy b{display:block;font-size:15px;line-height:1.3;overflow-wrap:anywhere}.v8-feature-copy small{display:block;margin-top:3px;font-size:14px;line-height:1.4;font-weight:500;color:#765e4b;overflow-wrap:anywhere}
+.v8-feature-row>i{max-width:92px;font-style:normal;font-size:13px;line-height:1.25;font-weight:900;color:#745a39;text-align:right;overflow-wrap:anywhere}
+.v8-feature-summary{padding:12px 14px;border:1px solid #dcc28b;border-radius:16px;background:rgba(239,224,193,.92);display:grid;gap:4px}.v8-feature-summary b{font-size:16px}.v8-feature-summary span{font-size:14px;line-height:1.4;color:#725947;overflow-wrap:anywhere}
+@media(max-width:390px){.v8-feature-heading{top:50px;padding:11px 12px}.v8-feature-heading h1{font-size:20px}.v8-feature-row{grid-template-columns:36px minmax(0,1fr);gap:8px;min-height:56px;padding:9px 10px}.v8-feature-marker{width:36px;height:36px}.v8-feature-row>i{grid-column:2;justify-self:start;max-width:none;text-align:left;font-size:13px}.v8-feature-copy b{font-size:15px}.v8-feature-copy small{font-size:14px}}
+@media(prefers-reduced-motion:reduce){.v8-feature-page *{animation:none!important;transition:none!important}}

--- a/src/mobile-router-v8.css
+++ b/src/mobile-router-v8.css
@@ -1,5 +1,11 @@
 @import './mobile-ui-tokens.css';
 
+.v8-app-host{position:absolute;inset:0;z-index:1;overflow:hidden}
+.v8-app-host.is-normal-play{top:calc(74px + env(safe-area-inset-top));bottom:calc(60px + env(safe-area-inset-bottom))}
+.v8-app-host.is-guarded-play{top:calc(62px + env(safe-area-inset-top));bottom:0}
+.v8-app-host.is-normal-play .page,.v8-app-host.is-guarded-play .page{width:100%;height:100%;min-height:100%;padding:0;background:transparent}
+.v8-app-host.is-normal-play .game-shell,.v8-app-host.is-guarded-play .game-shell{width:100%;height:100%;max-width:none;max-height:none;border-radius:0;box-shadow:none}
+
 .v8-mobile-shell{
   position:absolute;inset:0;z-index:100;
   width:100%;height:100vh;height:100dvh;
@@ -7,6 +13,9 @@
   overflow:hidden;background:#171126;color:var(--ui-ivory);
   font-family:'Noto Sans KR',sans-serif;isolation:isolate;
 }
+.v8-mobile-shell.is-app-play{background:transparent;pointer-events:none}
+.v8-mobile-shell.is-app-play>.v7-home-status,.v8-mobile-shell.is-app-play>.v8-bottom-nav,.v8-mobile-shell.is-app-play>.v8-play-guard,.v8-mobile-shell.is-app-play>.v8-exit-confirm-backdrop{pointer-events:auto}
+.v8-mobile-shell.is-app-play>.v8-route-body{pointer-events:none;background:transparent}
 .v8-mobile-shell>.v7-home-status{
   position:relative;inset:auto;z-index:4;min-height:60px;margin:max(8px,env(safe-area-inset-top)) 10px 6px;
   padding:9px 50px 9px 12px;
@@ -16,6 +25,8 @@
   -webkit-overflow-scrolling:touch;scrollbar-gutter:stable;
   padding:8px 12px 16px;
 }
+.v8-route-back{position:sticky;top:0;z-index:12;min-width:76px;min-height:44px;margin:0 0 8px;padding:7px 12px;border:1px solid rgba(241,207,120,.5);border-radius:14px;background:rgba(32,22,49,.94);color:#fff2c7;font:inherit;font-size:14px;font-weight:850;display:flex;align-items:center;justify-content:center;gap:5px;box-shadow:0 5px 14px rgba(0,0,0,.2);backdrop-filter:blur(10px)}
+.v8-route-back span{font-size:25px;line-height:.75}.v8-route-back:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
 .v8-bottom-nav{
   position:relative;z-index:6;display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:3px;
   padding:6px max(6px,env(safe-area-inset-left)) calc(6px + env(safe-area-inset-bottom)) max(6px,env(safe-area-inset-right));
@@ -32,7 +43,7 @@
 .v8-bottom-nav button>span{width:23px;height:23px}.v8-bottom-nav svg{width:100%;height:100%}
 .v8-bottom-nav b{font-size:13px;line-height:1.05;font-weight:800;white-space:nowrap}
 .v8-bottom-nav button.is-active{background:linear-gradient(180deg,rgba(241,207,120,.24),rgba(217,156,69,.12));color:var(--ui-gold);box-shadow:inset 0 0 0 1px rgba(241,207,120,.35)}
-.v8-bottom-nav button:active,.v8-play-guard button:active,.v8-exit-actions button:active,.v8-category-entry:active{transform:translateY(1px);filter:brightness(.92)}
+.v8-bottom-nav button:active,.v8-play-guard button:active,.v8-exit-actions button:active,.v8-category-entry:active,.v8-route-back:active{transform:translateY(1px);filter:brightness(.92)}
 .v8-bottom-nav button:focus-visible,.v8-play-guard button:focus-visible,.v8-exit-actions button:focus-visible,.v8-category-entry:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
 
 .v8-play-guard{
@@ -64,6 +75,21 @@
 .v8-category-page .weekly-focus-grid button,.v8-category-page .weekly-planner-resolve,.v8-category-page .weekly-planner-advance{min-height:var(--ui-touch-min);font-size:15px}
 .v8-records-content{padding-bottom:4px}
 
+.v8-mobile-shell.is-home .v8-route-body{padding:0;overflow:hidden;scrollbar-gutter:auto}
+.v8-mobile-shell.is-home .layered-home .lh-level,
+.v8-mobile-shell.is-home .layered-home .lh-currency,
+.v8-mobile-shell.is-home .layered-home .lh-weather,
+.v8-mobile-shell.is-home .layered-home .lh-shortcuts,
+.v8-mobile-shell.is-home .layered-home .lh-goal,
+.v8-mobile-shell.is-home .layered-home .lh-promos,
+.v8-mobile-shell.is-home .layered-home .lh-weekly-planner,
+.v8-mobile-shell.is-home .layered-home .run-guidance-card,
+.v8-mobile-shell.is-home .layered-home .lh-bottom-nav{display:none!important}
+.v8-mobile-shell.is-home .layered-home .lh-character{width:min(58%,310px);bottom:25%}
+.v8-mobile-shell.is-home .layered-home .lh-primary-action{left:16%;right:16%;bottom:28.5%;min-height:64px}
+.v8-mobile-shell.is-home .layered-home .lh-primary-action small{font-size:11px}.v8-mobile-shell.is-home .layered-home .lh-primary-action b{font-size:clamp(17px,4.4vw,22px)}.v8-mobile-shell.is-home .layered-home .lh-primary-action span{font-size:13px}
+.v8-mobile-shell.is-home .layered-home .lh-dialogue{left:5%;right:5%;bottom:8%;height:14%}.v8-mobile-shell.is-home .layered-home .lh-dialogue p{font-size:clamp(13px,3.2vw,16px)}
+
 @media(max-width:430px){
   .v8-route-body{padding-inline:10px}.v8-bottom-nav b{font-size:13px}.v8-mobile-shell>.v7-home-status{margin-inline:8px}
   .v8-category-header h1{font-size:21px}.v8-category-entry{min-height:62px}
@@ -74,12 +100,18 @@
   .v8-play-guard{grid-template-columns:minmax(76px,1fr) auto minmax(76px,1fr);padding-inline:7px}.v8-play-guard button{padding-inline:7px}
   .v8-category-header{grid-template-columns:44px minmax(0,1fr);padding:10px}.v8-category-icon{width:44px;height:44px}.v8-category-header h1{font-size:20px}.v8-category-header p{font-size:14px}
   .v8-category-entry{grid-template-columns:42px minmax(0,1fr) 20px;padding-inline:10px}.v8-category-entry-icon{width:42px;height:42px}.v8-category-entry-copy b{font-size:15px}.v8-category-entry-copy small{font-size:14px}
+  .v8-mobile-shell.is-home .layered-home .lh-primary-action{left:12%;right:12%}.v8-mobile-shell.is-home .layered-home .lh-dialogue{left:3%;right:3%}
 }
 @media(max-width:360px){
   .v8-mobile-shell>.v7-home-status{min-height:56px}.v8-route-body{padding-inline:6px}
   .v8-bottom-nav{gap:1px}.v8-bottom-nav button>span{width:21px;height:21px}.v8-bottom-nav b{font-size:12px}
   .v8-exit-confirm{padding:17px}.v8-exit-actions{grid-template-columns:1fr}
   .v8-category-header{top:-6px}.v8-category-header p{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}.v8-category-entry{min-height:60px;gap:8px}.v8-category-entry-copy small{line-height:1.35}
+  .v8-mobile-shell.is-home .layered-home .lh-primary-action span{font-size:12px}
+}
+@media(max-height:650px){
+  .v8-app-host.is-normal-play{top:64px;bottom:54px}.v8-app-host.is-guarded-play{top:56px}
+  .v8-mobile-shell.is-home .layered-home .lh-character{width:48%;bottom:24%}.v8-mobile-shell.is-home .layered-home .lh-primary-action{bottom:30%;min-height:54px}.v8-mobile-shell.is-home .layered-home .lh-dialogue{bottom:7%;height:15%}
 }
 @media(prefers-reduced-motion:reduce){
   .v8-mobile-shell *{animation:none!important;transition:none!important;scroll-behavior:auto!important}

--- a/src/mobile-router-v8.css
+++ b/src/mobile-router-v8.css
@@ -16,14 +16,13 @@
   -webkit-overflow-scrolling:touch;scrollbar-gutter:stable;
   padding:8px 12px 16px;
 }
-.v8-bottom-nav,.v8-play-guard{
-  position:relative;z-index:6;display:grid;gap:3px;
+.v8-bottom-nav{
+  position:relative;z-index:6;display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:3px;
   padding:6px max(6px,env(safe-area-inset-left)) calc(6px + env(safe-area-inset-bottom)) max(6px,env(safe-area-inset-right));
   border-top:1px solid rgba(241,207,120,.38);background:rgba(20,14,32,.96);box-shadow:0 -8px 24px rgba(0,0,0,.28);
   backdrop-filter:blur(12px);
 }
-.v8-bottom-nav{grid-template-columns:repeat(6,minmax(0,1fr))}
-.v8-bottom-nav button,.v8-play-guard button,.v8-play-header button,.v8-exit-actions button{
+.v8-bottom-nav button,.v8-play-guard button,.v8-exit-actions button{
   min-width:44px;min-height:var(--ui-touch-min);border:0;border-radius:14px;font:inherit;touch-action:manipulation;
 }
 .v8-bottom-nav button{
@@ -33,22 +32,17 @@
 .v8-bottom-nav button>span{width:23px;height:23px}.v8-bottom-nav svg{width:100%;height:100%}
 .v8-bottom-nav b{font-size:13px;line-height:1.05;font-weight:800;white-space:nowrap}
 .v8-bottom-nav button.is-active{background:linear-gradient(180deg,rgba(241,207,120,.24),rgba(217,156,69,.12));color:var(--ui-gold);box-shadow:inset 0 0 0 1px rgba(241,207,120,.35)}
-.v8-bottom-nav button:active,.v8-play-guard button:active,.v8-play-header button:active,.v8-exit-actions button:active{transform:translateY(1px);filter:brightness(.92)}
-.v8-bottom-nav button:focus-visible,.v8-play-guard button:focus-visible,.v8-play-header button:focus-visible,.v8-exit-actions button:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
+.v8-bottom-nav button:active,.v8-play-guard button:active,.v8-exit-actions button:active{transform:translateY(1px);filter:brightness(.92)}
+.v8-bottom-nav button:focus-visible,.v8-play-guard button:focus-visible,.v8-exit-actions button:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
 
-.v8-play-header{
+.v8-play-guard{
   position:relative;z-index:6;min-height:60px;display:grid;grid-template-columns:minmax(84px,1fr) auto minmax(84px,1fr);align-items:center;gap:8px;
-  padding:max(8px,env(safe-area-inset-top)) 10px 7px;background:rgba(20,14,32,.96);border-bottom:1px solid rgba(241,207,120,.38);
+  padding:max(8px,env(safe-area-inset-top)) 10px 7px;background:rgba(20,14,32,.96);border-bottom:1px solid rgba(241,207,120,.38);box-shadow:0 8px 24px rgba(0,0,0,.24);
 }
-.v8-play-header>strong{font-size:16px;text-align:center;color:var(--ui-gold)}
-.v8-play-header button{display:flex;align-items:center;justify-content:center;gap:5px;padding:6px 10px;background:rgba(255,255,255,.08);color:var(--ui-ivory)}
-.v8-play-header .v8-play-home{justify-self:end}.v8-play-header .v8-play-back{justify-self:start}
-.v8-play-header svg{width:20px;height:20px}.v8-play-header b{font-size:15px}
-.v8-play-header .v8-play-back span{font-size:28px;line-height:.7}
-
-.v8-play-guard{grid-template-columns:1fr 1fr}
-.v8-play-guard button{display:flex;align-items:center;justify-content:center;gap:7px;padding:8px 12px;background:rgba(255,255,255,.08);color:var(--ui-ivory);font-size:15px;font-weight:850}
-.v8-play-guard svg{width:21px;height:21px}.v8-play-guard span{font-size:28px;line-height:.7}
+.v8-play-guard>strong{font-size:16px;text-align:center;color:var(--ui-gold)}
+.v8-play-guard button{display:flex;align-items:center;justify-content:center;gap:5px;padding:6px 10px;background:rgba(255,255,255,.08);color:var(--ui-ivory);font-size:15px;font-weight:850}
+.v8-play-guard .v8-play-home{justify-self:end}.v8-play-guard .v8-play-back{justify-self:start}
+.v8-play-guard svg{width:20px;height:20px}.v8-play-guard .v8-play-back span{font-size:28px;line-height:.7}
 
 .v8-exit-confirm-backdrop{position:absolute;inset:0;z-index:20;display:grid;place-items:center;padding:20px;background:rgba(5,4,10,.72);backdrop-filter:blur(5px)}
 .v8-exit-confirm{width:min(100%,360px);padding:20px;border:1px solid rgba(241,207,120,.55);border-radius:22px;background:linear-gradient(180deg,#fff7e5,#f2dfba);color:#493326;box-shadow:0 24px 60px rgba(0,0,0,.52)}
@@ -61,7 +55,7 @@
 @media(max-width:390px){
   .v8-mobile-shell>.v7-home-status{min-height:58px;margin-top:max(6px,env(safe-area-inset-top));padding-left:10px}
   .v8-route-body{padding-inline:8px}.v8-bottom-nav{padding-inline:3px}.v8-bottom-nav button{min-height:48px}.v8-bottom-nav b{font-size:12px}
-  .v8-play-header{grid-template-columns:minmax(76px,1fr) auto minmax(76px,1fr);padding-inline:7px}.v8-play-header button{padding-inline:7px}
+  .v8-play-guard{grid-template-columns:minmax(76px,1fr) auto minmax(76px,1fr);padding-inline:7px}.v8-play-guard button{padding-inline:7px}
 }
 @media(max-width:360px){
   .v8-mobile-shell>.v7-home-status{min-height:56px}.v8-route-body{padding-inline:6px}

--- a/src/mobile-router-v8.css
+++ b/src/mobile-router-v8.css
@@ -1,0 +1,73 @@
+@import './mobile-ui-tokens.css';
+
+.v8-mobile-shell{
+  position:absolute;inset:0;z-index:100;
+  width:100%;height:100vh;height:100dvh;
+  display:grid;grid-template-rows:auto minmax(0,1fr) auto;
+  overflow:hidden;background:#171126;color:var(--ui-ivory);
+  font-family:'Noto Sans KR',sans-serif;isolation:isolate;
+}
+.v8-mobile-shell>.v7-home-status{
+  position:relative;inset:auto;z-index:4;min-height:60px;margin:max(8px,env(safe-area-inset-top)) 10px 6px;
+  padding:9px 50px 9px 12px;
+}
+.v8-route-body{
+  position:relative;z-index:1;min-height:0;overflow-y:auto;overscroll-behavior:contain;
+  -webkit-overflow-scrolling:touch;scrollbar-gutter:stable;
+  padding:8px 12px 16px;
+}
+.v8-bottom-nav,.v8-play-guard{
+  position:relative;z-index:6;display:grid;gap:3px;
+  padding:6px max(6px,env(safe-area-inset-left)) calc(6px + env(safe-area-inset-bottom)) max(6px,env(safe-area-inset-right));
+  border-top:1px solid rgba(241,207,120,.38);background:rgba(20,14,32,.96);box-shadow:0 -8px 24px rgba(0,0,0,.28);
+  backdrop-filter:blur(12px);
+}
+.v8-bottom-nav{grid-template-columns:repeat(6,minmax(0,1fr))}
+.v8-bottom-nav button,.v8-play-guard button,.v8-play-header button,.v8-exit-actions button{
+  min-width:44px;min-height:var(--ui-touch-min);border:0;border-radius:14px;font:inherit;touch-action:manipulation;
+}
+.v8-bottom-nav button{
+  padding:5px 1px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:3px;
+  background:transparent;color:rgba(255,244,210,.7);
+}
+.v8-bottom-nav button>span{width:23px;height:23px}.v8-bottom-nav svg{width:100%;height:100%}
+.v8-bottom-nav b{font-size:13px;line-height:1.05;font-weight:800;white-space:nowrap}
+.v8-bottom-nav button.is-active{background:linear-gradient(180deg,rgba(241,207,120,.24),rgba(217,156,69,.12));color:var(--ui-gold);box-shadow:inset 0 0 0 1px rgba(241,207,120,.35)}
+.v8-bottom-nav button:active,.v8-play-guard button:active,.v8-play-header button:active,.v8-exit-actions button:active{transform:translateY(1px);filter:brightness(.92)}
+.v8-bottom-nav button:focus-visible,.v8-play-guard button:focus-visible,.v8-play-header button:focus-visible,.v8-exit-actions button:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
+
+.v8-play-header{
+  position:relative;z-index:6;min-height:60px;display:grid;grid-template-columns:minmax(84px,1fr) auto minmax(84px,1fr);align-items:center;gap:8px;
+  padding:max(8px,env(safe-area-inset-top)) 10px 7px;background:rgba(20,14,32,.96);border-bottom:1px solid rgba(241,207,120,.38);
+}
+.v8-play-header>strong{font-size:16px;text-align:center;color:var(--ui-gold)}
+.v8-play-header button{display:flex;align-items:center;justify-content:center;gap:5px;padding:6px 10px;background:rgba(255,255,255,.08);color:var(--ui-ivory)}
+.v8-play-header .v8-play-home{justify-self:end}.v8-play-header .v8-play-back{justify-self:start}
+.v8-play-header svg{width:20px;height:20px}.v8-play-header b{font-size:15px}
+.v8-play-header .v8-play-back span{font-size:28px;line-height:.7}
+
+.v8-play-guard{grid-template-columns:1fr 1fr}
+.v8-play-guard button{display:flex;align-items:center;justify-content:center;gap:7px;padding:8px 12px;background:rgba(255,255,255,.08);color:var(--ui-ivory);font-size:15px;font-weight:850}
+.v8-play-guard svg{width:21px;height:21px}.v8-play-guard span{font-size:28px;line-height:.7}
+
+.v8-exit-confirm-backdrop{position:absolute;inset:0;z-index:20;display:grid;place-items:center;padding:20px;background:rgba(5,4,10,.72);backdrop-filter:blur(5px)}
+.v8-exit-confirm{width:min(100%,360px);padding:20px;border:1px solid rgba(241,207,120,.55);border-radius:22px;background:linear-gradient(180deg,#fff7e5,#f2dfba);color:#493326;box-shadow:0 24px 60px rgba(0,0,0,.52)}
+.v8-exit-confirm h2{margin:0;font-size:21px;line-height:1.25}.v8-exit-confirm p{margin:9px 0 17px;font-size:15px;line-height:1.5;color:#725947}
+.v8-exit-actions{display:grid;grid-template-columns:1fr 1fr;gap:8px}.v8-exit-actions button{padding:10px 12px;font-size:15px;font-weight:900}.v8-exit-actions .is-safe{background:#ead9b5;color:#503a2b}.v8-exit-actions .is-danger{background:#8e3e43;color:#fff}
+
+@media(max-width:430px){
+  .v8-route-body{padding-inline:10px}.v8-bottom-nav b{font-size:13px}.v8-mobile-shell>.v7-home-status{margin-inline:8px}
+}
+@media(max-width:390px){
+  .v8-mobile-shell>.v7-home-status{min-height:58px;margin-top:max(6px,env(safe-area-inset-top));padding-left:10px}
+  .v8-route-body{padding-inline:8px}.v8-bottom-nav{padding-inline:3px}.v8-bottom-nav button{min-height:48px}.v8-bottom-nav b{font-size:12px}
+  .v8-play-header{grid-template-columns:minmax(76px,1fr) auto minmax(76px,1fr);padding-inline:7px}.v8-play-header button{padding-inline:7px}
+}
+@media(max-width:360px){
+  .v8-mobile-shell>.v7-home-status{min-height:56px}.v8-route-body{padding-inline:6px}
+  .v8-bottom-nav{gap:1px}.v8-bottom-nav button>span{width:21px;height:21px}.v8-bottom-nav b{font-size:12px}
+  .v8-exit-confirm{padding:17px}.v8-exit-actions{grid-template-columns:1fr}
+}
+@media(prefers-reduced-motion:reduce){
+  .v8-mobile-shell *{animation:none!important;transition:none!important;scroll-behavior:auto!important}
+}

--- a/src/mobile-router-v8.css
+++ b/src/mobile-router-v8.css
@@ -32,8 +32,8 @@
 .v8-bottom-nav button>span{width:23px;height:23px}.v8-bottom-nav svg{width:100%;height:100%}
 .v8-bottom-nav b{font-size:13px;line-height:1.05;font-weight:800;white-space:nowrap}
 .v8-bottom-nav button.is-active{background:linear-gradient(180deg,rgba(241,207,120,.24),rgba(217,156,69,.12));color:var(--ui-gold);box-shadow:inset 0 0 0 1px rgba(241,207,120,.35)}
-.v8-bottom-nav button:active,.v8-play-guard button:active,.v8-exit-actions button:active{transform:translateY(1px);filter:brightness(.92)}
-.v8-bottom-nav button:focus-visible,.v8-play-guard button:focus-visible,.v8-exit-actions button:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
+.v8-bottom-nav button:active,.v8-play-guard button:active,.v8-exit-actions button:active,.v8-category-entry:active{transform:translateY(1px);filter:brightness(.92)}
+.v8-bottom-nav button:focus-visible,.v8-play-guard button:focus-visible,.v8-exit-actions button:focus-visible,.v8-category-entry:focus-visible{outline:3px solid #ffe29a;outline-offset:2px}
 
 .v8-play-guard{
   position:relative;z-index:6;min-height:60px;display:grid;grid-template-columns:minmax(84px,1fr) auto minmax(84px,1fr);align-items:center;gap:8px;
@@ -49,18 +49,37 @@
 .v8-exit-confirm h2{margin:0;font-size:21px;line-height:1.25}.v8-exit-confirm p{margin:9px 0 17px;font-size:15px;line-height:1.5;color:#725947}
 .v8-exit-actions{display:grid;grid-template-columns:1fr 1fr;gap:8px}.v8-exit-actions button{padding:10px 12px;font-size:15px;font-weight:900}.v8-exit-actions .is-safe{background:#ead9b5;color:#503a2b}.v8-exit-actions .is-danger{background:#8e3e43;color:#fff}
 
+.v8-category-page{width:100%;max-width:520px;margin:0 auto;padding:0 0 12px;display:grid;gap:12px;color:#493326}
+.v8-category-header{position:sticky;top:-8px;z-index:3;display:grid;grid-template-columns:48px minmax(0,1fr);gap:11px;align-items:center;padding:12px;border:1px solid #d9b96f;border-radius:18px;background:linear-gradient(180deg,rgba(255,248,232,.99),rgba(248,231,195,.97));box-shadow:0 8px 20px rgba(0,0,0,.22)}
+.v8-category-icon{width:48px;height:48px;display:grid;place-items:center;border-radius:15px;background:#5b416f;color:#ffe4a0}.v8-category-icon svg{width:28px;height:28px}
+.v8-category-header small{display:block;font-size:12px;font-weight:900;letter-spacing:.09em;color:#8a6846}.v8-category-header h1{margin:1px 0 0;font-size:22px;line-height:1.15;color:#493326}.v8-category-header p{margin:4px 0 0;font-size:14px;line-height:1.4;color:#735844}
+.v8-category-content,.v8-category-grid{display:grid;gap:10px}.v8-category-grid{grid-template-columns:1fr}
+.v8-category-entry{width:100%;min-height:64px;display:grid;grid-template-columns:44px minmax(0,1fr) 22px;gap:10px;align-items:center;padding:10px 12px;border:1px solid #dfc78f;border-radius:16px;background:rgba(255,253,247,.96);color:#493326;text-align:left;font:inherit;box-shadow:0 4px 10px rgba(57,35,21,.08);touch-action:manipulation}
+.v8-category-entry-icon{width:44px;height:44px;display:grid;place-items:center;border-radius:13px;background:#f0e2c4;color:#654a79}.v8-category-entry-icon svg{width:25px;height:25px}.v8-category-entry-copy{min-width:0}.v8-category-entry-copy b{display:block;font-size:16px;line-height:1.25}.v8-category-entry-copy small{display:block;margin-top:3px;font-size:14px;line-height:1.4;font-weight:500;color:#765e4b;overflow-wrap:anywhere}.v8-category-chevron{width:20px;height:20px;color:#947649}
+.v8-category-summary{min-height:76px;padding:12px 14px;border:1px solid #dcc28b;border-radius:16px;background:rgba(239,224,193,.9);display:grid;gap:3px}.v8-category-summary small{font-size:12px;font-weight:900;color:#8b6a47}.v8-category-summary b{font-size:16px}.v8-category-summary span{font-size:14px;line-height:1.4;color:#725947;overflow-wrap:anywhere}
+.v8-section-title{margin:2px 0 0;padding:0 2px;font-size:18px;line-height:1.3;color:#fff0bd;text-shadow:0 2px 5px rgba(0,0,0,.45)}
+.v8-embedded-section{display:grid;gap:8px;min-width:0}
+.v8-category-page .weekly-planner-card,.v8-category-page .lineage-chronicle,.v8-category-page .world-chronicle{position:static!important;inset:auto!important;width:auto!important;max-width:none!important;margin:0!important;transform:none!important}
+.v8-category-page .weekly-planner-card{box-sizing:border-box}
+.v8-category-page .weekly-focus-grid button,.v8-category-page .weekly-planner-resolve,.v8-category-page .weekly-planner-advance{min-height:var(--ui-touch-min);font-size:15px}
+.v8-records-content{padding-bottom:4px}
+
 @media(max-width:430px){
   .v8-route-body{padding-inline:10px}.v8-bottom-nav b{font-size:13px}.v8-mobile-shell>.v7-home-status{margin-inline:8px}
+  .v8-category-header h1{font-size:21px}.v8-category-entry{min-height:62px}
 }
 @media(max-width:390px){
   .v8-mobile-shell>.v7-home-status{min-height:58px;margin-top:max(6px,env(safe-area-inset-top));padding-left:10px}
   .v8-route-body{padding-inline:8px}.v8-bottom-nav{padding-inline:3px}.v8-bottom-nav button{min-height:48px}.v8-bottom-nav b{font-size:12px}
   .v8-play-guard{grid-template-columns:minmax(76px,1fr) auto minmax(76px,1fr);padding-inline:7px}.v8-play-guard button{padding-inline:7px}
+  .v8-category-header{grid-template-columns:44px minmax(0,1fr);padding:10px}.v8-category-icon{width:44px;height:44px}.v8-category-header h1{font-size:20px}.v8-category-header p{font-size:14px}
+  .v8-category-entry{grid-template-columns:42px minmax(0,1fr) 20px;padding-inline:10px}.v8-category-entry-icon{width:42px;height:42px}.v8-category-entry-copy b{font-size:15px}.v8-category-entry-copy small{font-size:14px}
 }
 @media(max-width:360px){
   .v8-mobile-shell>.v7-home-status{min-height:56px}.v8-route-body{padding-inline:6px}
   .v8-bottom-nav{gap:1px}.v8-bottom-nav button>span{width:21px;height:21px}.v8-bottom-nav b{font-size:12px}
   .v8-exit-confirm{padding:17px}.v8-exit-actions{grid-template-columns:1fr}
+  .v8-category-header{top:-6px}.v8-category-header p{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}.v8-category-entry{min-height:60px;gap:8px}.v8-category-entry-copy small{line-height:1.35}
 }
 @media(prefers-reduced-motion:reduce){
   .v8-mobile-shell *{animation:none!important;transition:none!important;scroll-behavior:auto!important}

--- a/src/mobile-router.test.ts
+++ b/src/mobile-router.test.ts
@@ -1,0 +1,69 @@
+import {describe,expect,it} from 'vitest';
+import {
+  initialMobileNavigationState,
+  isGuardedActiveRoute,
+  mobileNavigationReducer,
+  type MobileNavigationState,
+} from './mobile-router';
+
+describe('V8 mobile router',()=>{
+  it('opens a category from home with normalized home history',()=>{
+    const next=mobileNavigationReducer(initialMobileNavigationState,{type:'OPEN_CATEGORY',category:'growth'});
+    expect(next).toEqual({current:{kind:'category',category:'growth'},stack:[{kind:'home'}]});
+  });
+
+  it('opens a feature and returns it to its origin category',()=>{
+    const category=mobileNavigationReducer(initialMobileNavigationState,{type:'OPEN_CATEGORY',category:'growth'});
+    const feature=mobileNavigationReducer(category,{type:'OPEN_FEATURE',category:'growth',feature:'achievements'});
+    expect(feature).toEqual({
+      current:{kind:'feature',category:'growth',feature:'achievements'},
+      stack:[{kind:'home'},{kind:'category',category:'growth'}],
+    });
+    expect(mobileNavigationReducer(feature,{type:'BACK'})).toEqual({
+      current:{kind:'category',category:'growth'},
+      stack:[{kind:'home'}],
+    });
+    expect(mobileNavigationReducer(feature,{type:'FINISH_FEATURE'})).toEqual({
+      current:{kind:'category',category:'growth'},
+      stack:[{kind:'home'}],
+    });
+  });
+
+  it('switches categories without building a long category stack',()=>{
+    const life=mobileNavigationReducer(initialMobileNavigationState,{type:'OPEN_CATEGORY',category:'life'});
+    const adventure=mobileNavigationReducer(life,{type:'OPEN_CATEGORY',category:'adventure'});
+    expect(adventure).toEqual({current:{kind:'category',category:'adventure'},stack:[{kind:'home'}]});
+    expect(mobileNavigationReducer(adventure,{type:'OPEN_CATEGORY',category:'adventure'})).toBe(adventure);
+  });
+
+  it('backs from a category to home and HOME always clears history',()=>{
+    const records=mobileNavigationReducer(initialMobileNavigationState,{type:'OPEN_CATEGORY',category:'records'});
+    expect(mobileNavigationReducer(records,{type:'BACK'})).toEqual(initialMobileNavigationState);
+    const archive=mobileNavigationReducer(records,{type:'OPEN_FEATURE',category:'records',feature:'archive'});
+    expect(mobileNavigationReducer(archive,{type:'HOME'})).toEqual(initialMobileNavigationState);
+  });
+
+  it('tracks a play origin and FINISH_PLAY normalizes to home',()=>{
+    const play=mobileNavigationReducer(initialMobileNavigationState,{type:'OPEN_PLAY',category:'life',screen:'training'});
+    expect(play.current).toEqual({kind:'play',category:'life',screen:'training'});
+    expect(play.stack).toEqual([{kind:'home'},{kind:'category',category:'life'}]);
+    expect(mobileNavigationReducer(play,{type:'FINISH_PLAY'})).toEqual(initialMobileNavigationState);
+  });
+
+  it('falls back to home for malformed replacement data',()=>{
+    const dirty={
+      current:{kind:'category',category:'growth'},
+      stack:[{kind:'home'}],
+    } satisfies MobileNavigationState;
+    expect(mobileNavigationReducer(dirty,{type:'REPLACE',route:{kind:'feature',category:'unknown',feature:'archive'}})).toEqual(initialMobileNavigationState);
+    expect(mobileNavigationReducer(dirty,{type:'REPLACE',route:null})).toEqual(initialMobileNavigationState);
+  });
+
+  it('guards only unfinished training and unresolved dialogue play routes',()=>{
+    expect(isGuardedActiveRoute({kind:'play',category:'life',screen:'training'})).toBe(true);
+    expect(isGuardedActiveRoute({kind:'play',category:'life',screen:'dialogue'})).toBe(true);
+    expect(isGuardedActiveRoute({kind:'play',category:'life',screen:'schedule'})).toBe(false);
+    expect(isGuardedActiveRoute({kind:'play',category:'life',screen:'result'})).toBe(false);
+    expect(isGuardedActiveRoute({kind:'category',category:'life'})).toBe(false);
+  });
+});

--- a/src/mobile-router.ts
+++ b/src/mobile-router.ts
@@ -1,0 +1,132 @@
+export type MobileCategoryId='home'|'life'|'growth'|'adventure'|'bond'|'records';
+export type MobileContentCategory=Exclude<MobileCategoryId,'home'>;
+
+export type MobileFeatureId=
+  |'schedule'
+  |'mission'
+  |'attendance'
+  |'mail'
+  |'raising'
+  |'ambition'
+  |'achievements'
+  |'inventory'
+  |'season'
+  |'sanctuary'
+  |'outing'
+  |'expedition'
+  |'world'
+  |'bond'
+  |'gifts'
+  |'stories'
+  |'archive'
+  |'lineage'
+  |'world_chronicle';
+
+export type MobilePlayScreen='schedule'|'training'|'dialogue'|'result'|'tactical'|'choice_event';
+
+export type MobileRoute=
+  |{kind:'home'}
+  |{kind:'category';category:MobileContentCategory}
+  |{kind:'feature';category:MobileContentCategory;feature:MobileFeatureId}
+  |{kind:'play';category:MobileCategoryId;screen:MobilePlayScreen};
+
+export type MobileNavigationState={current:MobileRoute;stack:MobileRoute[]};
+
+export type MobileNavigationAction=
+  |{type:'OPEN_CATEGORY';category:MobileContentCategory}
+  |{type:'OPEN_FEATURE';category:MobileContentCategory;feature:MobileFeatureId}
+  |{type:'OPEN_PLAY';category:MobileCategoryId;screen:MobilePlayScreen}
+  |{type:'BACK'}
+  |{type:'HOME'}
+  |{type:'FINISH_FEATURE'}
+  |{type:'FINISH_PLAY'}
+  |{type:'REPLACE';route:unknown};
+
+const categories:readonly MobileContentCategory[]=['life','growth','adventure','bond','records'];
+const features:readonly MobileFeatureId[]=[
+  'schedule','mission','attendance','mail','raising','ambition','achievements','inventory','season','sanctuary',
+  'outing','expedition','world','bond','gifts','stories','archive','lineage','world_chronicle',
+];
+const playScreens:readonly MobilePlayScreen[]=['schedule','training','dialogue','result','tactical','choice_event'];
+const homeRoute:MobileRoute={kind:'home'};
+
+export const initialMobileNavigationState:MobileNavigationState={current:homeRoute,stack:[]};
+
+export const categoryForFeature:Record<MobileFeatureId,MobileContentCategory>={
+  schedule:'life',mission:'life',attendance:'life',mail:'life',
+  raising:'growth',ambition:'growth',achievements:'growth',inventory:'growth',season:'growth',sanctuary:'growth',
+  outing:'adventure',expedition:'adventure',world:'adventure',
+  bond:'bond',gifts:'bond',stories:'bond',
+  archive:'records',lineage:'records',world_chronicle:'records',
+};
+
+function isRecord(value:unknown):value is Record<string,unknown>{
+  return Boolean(value)&&typeof value==='object'&&!Array.isArray(value);
+}
+function isCategory(value:unknown):value is MobileContentCategory{
+  return typeof value==='string'&&categories.includes(value as MobileContentCategory);
+}
+function isMobileCategory(value:unknown):value is MobileCategoryId{
+  return value==='home'||isCategory(value);
+}
+function isFeature(value:unknown):value is MobileFeatureId{
+  return typeof value==='string'&&features.includes(value as MobileFeatureId);
+}
+function isPlayScreen(value:unknown):value is MobilePlayScreen{
+  return typeof value==='string'&&playScreens.includes(value as MobilePlayScreen);
+}
+export function isMobileRoute(value:unknown):value is MobileRoute{
+  if(!isRecord(value)||typeof value.kind!=='string')return false;
+  if(value.kind==='home')return true;
+  if(value.kind==='category')return isCategory(value.category);
+  if(value.kind==='feature')return isCategory(value.category)&&isFeature(value.feature)&&categoryForFeature[value.feature]===value.category;
+  if(value.kind==='play')return isMobileCategory(value.category)&&isPlayScreen(value.screen);
+  return false;
+}
+
+function categoryState(category:MobileContentCategory):MobileNavigationState{
+  return {current:{kind:'category',category},stack:[homeRoute]};
+}
+function featureState(category:MobileContentCategory,feature:MobileFeatureId):MobileNavigationState{
+  if(categoryForFeature[feature]!==category)return initialMobileNavigationState;
+  return {current:{kind:'feature',category,feature},stack:[homeRoute,{kind:'category',category}]};
+}
+function playState(category:MobileCategoryId,screen:MobilePlayScreen):MobileNavigationState{
+  return {
+    current:{kind:'play',category,screen},
+    stack:category==='home'?[homeRoute]:[homeRoute,{kind:'category',category}],
+  };
+}
+
+export function isGuardedActiveRoute(route:MobileRoute):boolean{
+  return route.kind==='play'&&(['training','dialogue','tactical','choice_event'] as readonly MobilePlayScreen[]).includes(route.screen);
+}
+
+export function mobileNavigationReducer(state:MobileNavigationState,action:MobileNavigationAction):MobileNavigationState{
+  switch(action.type){
+    case 'OPEN_CATEGORY':
+      if(state.current.kind==='category'&&state.current.category===action.category)return state;
+      return categoryState(action.category);
+    case 'OPEN_FEATURE':
+      return featureState(action.category,action.feature);
+    case 'OPEN_PLAY':
+      return playState(action.category,action.screen);
+    case 'BACK':
+      if(state.current.kind==='home')return state;
+      if(state.current.kind==='category')return initialMobileNavigationState;
+      if(state.current.kind==='feature')return categoryState(state.current.category);
+      if(state.current.kind==='play'&&state.current.category!=='home')return categoryState(state.current.category);
+      return initialMobileNavigationState;
+    case 'HOME':
+    case 'FINISH_PLAY':
+      return initialMobileNavigationState;
+    case 'FINISH_FEATURE':
+      return state.current.kind==='feature'?categoryState(state.current.category):state;
+    case 'REPLACE':
+      if(!isMobileRoute(action.route))return initialMobileNavigationState;
+      if(action.route.kind==='home')return initialMobileNavigationState;
+      if(action.route.kind==='category')return categoryState(action.route.category);
+      if(action.route.kind==='feature')return featureState(action.route.category,action.route.feature);
+      return playState(action.route.category,action.route.screen);
+  }
+}

--- a/src/v7-mobile-home-architecture.test.tsx
+++ b/src/v7-mobile-home-architecture.test.tsx
@@ -9,10 +9,12 @@ const legacyHome = readFileSync(new URL('./LayeredHome.tsx', import.meta.url), '
 const css = readFileSync(new URL('./layered-home-v7.css', import.meta.url), 'utf8');
 const tokens = readFileSync(new URL('./mobile-ui-tokens.css', import.meta.url), 'utf8');
 
-describe('V7 mobile home information architecture', () => {
-  it('switches the real hub entrypoint to the V7 shell', () => {
-    expect(root).toContain("import LayeredHomeV7 from './LayeredHomeV7'");
-    expect(root).toContain('<LayeredHomeV7');
+describe('V7 mobile home information architecture compatibility', () => {
+  it('keeps the V7 home principles while the V8 router owns the real entrypoint', () => {
+    expect(root).toContain("import MobileRouterChrome from './MobileRouterChrome'");
+    expect(root).toContain("import MobileCategoryPage from './MobileCategoryPage'");
+    expect(root).toContain('<MobileRouterChrome');
+    expect(root).not.toContain('<LayeredHomeV7');
   });
 
   it('uses six clear semantic bottom categories', () => {

--- a/src/v8-legacy-feature-routing.test.tsx
+++ b/src/v8-legacy-feature-routing.test.tsx
@@ -1,0 +1,45 @@
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe,expect,it,vi} from 'vitest';
+import {initialState} from './game';
+import MobileLegacyFeaturePage from './MobileLegacyFeaturePage';
+import type {MobileFeatureId} from './mobile-router';
+
+function render(feature:MobileFeatureId){
+  return renderToStaticMarkup(<MobileLegacyFeaturePage
+    feature={feature}
+    state={initialState}
+    onClaimAchievement={vi.fn()}
+    onOuting={vi.fn()}
+    onGift={vi.fn()}
+    onAttendance={vi.fn()}
+    onMail={vi.fn()}
+    onMonthlyFocus={vi.fn()}
+  />);
+}
+
+describe('V8 routed legacy features',()=>{
+  it('renders achievements as a page with no home-reset backdrop',()=>{
+    const html=render('achievements');
+    expect(html).toContain('성장 업적');
+    expect(html).toContain('v8-feature-page');
+    expect(html).not.toContain('lh-panel-backdrop');
+    expect(html).not.toContain('aria-label="홈으로 돌아가기"');
+  });
+
+  it('renders attendance, mail and mission as ordinary routed pages',()=>{
+    expect(render('attendance')).toContain('월간 출석');
+    expect(render('mail')).toContain('우편함');
+    expect(render('mission')).toContain('이번 달 도전');
+  });
+
+  it('renders inventory, outing, bond and stories without modal trapping',()=>{
+    expect(render('inventory')).toContain('능력과 보유품');
+    expect(render('gifts')).toContain('선물');
+    expect(render('outing')).toContain('외출');
+    expect(render('bond')).toContain('루나와의 교감');
+    expect(render('stories')).toContain('루나 이야기');
+    for(const feature of ['inventory','gifts','outing','bond','stories'] as const){
+      expect(render(feature)).not.toContain('role="dialog"');
+    }
+  });
+});

--- a/src/v8-mobile-category-page.test.tsx
+++ b/src/v8-mobile-category-page.test.tsx
@@ -1,0 +1,46 @@
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe,expect,it,vi} from 'vitest';
+import {initialState} from './game';
+import MobileCategoryPage from './MobileCategoryPage';
+import type {MobileContentCategory} from './mobile-router';
+
+function render(category:MobileContentCategory){
+  return renderToStaticMarkup(<MobileCategoryPage
+    category={category}
+    state={initialState}
+    onOpenFeature={vi.fn()}
+    onWeeklyFocus={vi.fn()}
+    onCompleteWeek={vi.fn()}
+    onAdvanceWeek={vi.fn()}
+  />);
+}
+
+describe('V8 full-page categories',()=>{
+  it('renders categories as route pages rather than backdrop sheets',()=>{
+    const html=render('life');
+    expect(html).toContain('v8-category-page');
+    expect(html).toContain('v8-category-header');
+    expect(html).not.toContain('v7-category-backdrop');
+    expect(html).not.toContain('role="dialog"');
+  });
+
+  it('maps life features and weekly planner into the 생활 page',()=>{
+    const html=render('life');
+    for(const label of ['이번 주 계획','스케줄','이번 달 목표','출석 보상','우편함'])expect(html).toContain(label);
+  });
+
+  it('maps growth and adventure features into clear pages',()=>{
+    const growth=render('growth');
+    for(const label of ['성장 정체성','올해의 야망','성장 업적','능력과 보유품','시즌 여정','별빛 성소'])expect(growth).toContain(label);
+    const adventure=render('adventure');
+    for(const label of ['외출','수호자 원정','월드 진행','세계 프로젝트'])expect(adventure).toContain(label);
+  });
+
+  it('maps bond and records content without nested full-screen sheets',()=>{
+    const bond=render('bond');
+    for(const label of ['루나와 교감','선물','이야기'])expect(bond).toContain(label);
+    const records=render('records');
+    for(const label of ['가문 연대기','세계 연대기','성장 도감','발견과 기억'])expect(records).toContain(label);
+    expect(records).not.toContain('v7-category-sheet');
+  });
+});

--- a/src/v8-mobile-router-ui.test.tsx
+++ b/src/v8-mobile-router-ui.test.tsx
@@ -1,0 +1,68 @@
+import {readFileSync} from 'node:fs';
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe,expect,it,vi} from 'vitest';
+import {initialState} from './game';
+import MobileRouterChrome from './MobileRouterChrome';
+import type {MobileNavigationState} from './mobile-router';
+
+const growthNavigation:MobileNavigationState={
+  current:{kind:'category',category:'growth'},
+  stack:[{kind:'home'}],
+};
+const guardedNavigation:MobileNavigationState={
+  current:{kind:'play',category:'life',screen:'training'},
+  stack:[{kind:'home'},{kind:'category',category:'life'}],
+};
+
+function render(navigation:MobileNavigationState,guarded=false,pendingExit:null|'back'|'home'=null){
+  return renderToStaticMarkup(<MobileRouterChrome
+    state={initialState}
+    navigation={navigation}
+    guarded={guarded}
+    pendingExit={pendingExit}
+    onCategory={vi.fn()}
+    onBack={vi.fn()}
+    onHome={vi.fn()}
+    onRequestExit={vi.fn()}
+    onCancelExit={vi.fn()}
+    onConfirmExit={vi.fn()}
+  ><main>content</main></MobileRouterChrome>);
+}
+
+describe('V8 mobile router chrome',()=>{
+  it('keeps all six navigation categories visible in ordinary states',()=>{
+    const html=render(growthNavigation);
+    for(const label of ['홈','생활','성장','모험','인연','기록'])expect(html).toContain(`>${label}<`);
+    expect(html).toContain('v8-bottom-nav');
+    expect(html).not.toContain('v8-play-guard');
+  });
+
+  it('shows only Back and Home navigation while an attempt is guarded',()=>{
+    const html=render(guardedNavigation,true);
+    expect(html).toContain('v8-play-guard');
+    expect(html).toContain('>뒤로<');
+    expect(html).toContain('>홈<');
+    expect(html).not.toContain('v8-bottom-nav');
+    expect(html).not.toContain('>생활<');
+  });
+
+  it('uses the approved confirmation copy before leaving guarded play',()=>{
+    const html=render(guardedNavigation,true,'home');
+    expect(html).toContain('진행 중인 플레이를 종료할까요?');
+    expect(html).toContain('지금 나가면 현재 진행 내용이 완료되지 않습니다.');
+    expect(html).toContain('계속하기');
+    expect(html).toContain('종료하고 이동');
+  });
+
+  it('locks one scroll body and mobile viewport/accessibility CSS contracts',()=>{
+    const css=readFileSync(new URL('./mobile-router-v8.css',import.meta.url),'utf8');
+    expect(css).toMatch(/\.v8-mobile-shell[^}]*100dvh/s);
+    expect(css).toMatch(/\.v8-route-body[^}]*min-height:\s*0[^}]*overflow-y:\s*auto[^}]*overscroll-behavior:\s*contain/s);
+    expect(css).toContain('env(safe-area-inset-bottom)');
+    expect(css).toContain('min-height:var(--ui-touch-min)');
+    expect(css).toContain('@media(max-width:430px)');
+    expect(css).toContain('@media(max-width:390px)');
+    expect(css).toContain('@media(max-width:360px)');
+    expect(css).toContain('@media(prefers-reduced-motion:reduce)');
+  });
+});

--- a/src/v8-mobile-router-ui.test.tsx
+++ b/src/v8-mobile-router-ui.test.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore -- Vitest executes this contract in Node; app tsconfig intentionally excludes Node globals.
 import {readFileSync} from 'node:fs';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {describe,expect,it,vi} from 'vitest';

--- a/src/v8-root-router-integration.test.tsx
+++ b/src/v8-root-router-integration.test.tsx
@@ -1,0 +1,44 @@
+// @ts-ignore -- Vitest executes source-contract checks in Node; app tsconfig excludes Node globals.
+import {readFileSync} from 'node:fs';
+import {describe,expect,it} from 'vitest';
+
+const root=readFileSync(new URL('./Root.tsx',import.meta.url),'utf8');
+const home=readFileSync(new URL('./LayeredHome.tsx',import.meta.url),'utf8');
+const tactical=readFileSync(new URL('./TacticalExpeditionFlow.tsx',import.meta.url),'utf8');
+
+describe('V8 root router integration',()=>{
+  it('makes the V8 router the single mobile navigation authority',()=>{
+    expect(root).toContain("from './MobileRouterChrome'");
+    expect(root).toContain("from './MobileCategoryPage'");
+    expect(root).toContain("from './MobileLegacyFeaturePage'");
+    expect(root).toContain('mobileNavigationReducer');
+    expect(root).toContain('initialMobileNavigationState');
+    expect(root).toContain('isGuardedActiveRoute');
+    expect(root).toContain('<MobileRouterChrome');
+    expect(root).not.toContain('<LayeredHomeV7');
+  });
+
+  it('removes legacy independent overlay open-state authority',()=>{
+    for(const legacyState of ['seasonLiveOpen','sanctuaryOpen','raisingOpen','expeditionOpen','worldProgressOpen','archiveOpen','ambitionOpen']){
+      expect(root).not.toContain(legacyState);
+    }
+  });
+
+  it('routes App schedule, training, dialogue and result screens through V8 play routes',()=>{
+    for(const screen of ['schedule','training','dialogue','result']){
+      expect(root).toContain(`screen:'${screen}'`);
+    }
+    expect(root).toContain("navigate?.('hub')");
+  });
+
+  it('delegates legacy home menu requests to router features instead of opening internal panels',()=>{
+    expect(home).toContain('onMenuNavigate');
+    expect(home).toContain('onWeeklyPlannerNavigate');
+  });
+
+  it('reports Tactical setup, active and result phases to the router',()=>{
+    expect(tactical).toContain('onPhaseChange');
+    expect(tactical).toContain("onPhaseChange?.('active')");
+    expect(tactical).toContain("onPhaseChange?.('result')");
+  });
+});

--- a/src/v8-root-router-integration.test.tsx
+++ b/src/v8-root-router-integration.test.tsx
@@ -20,8 +20,11 @@ describe('V8 root router integration',()=>{
 
   it('removes legacy independent overlay open-state authority',()=>{
     for(const legacyState of ['seasonLiveOpen','sanctuaryOpen','raisingOpen','expeditionOpen','worldProgressOpen','archiveOpen','ambitionOpen']){
-      expect(root).not.toContain(legacyState);
+      const setter=`set${legacyState[0].toUpperCase()}${legacyState.slice(1)}`;
+      expect(root).not.toContain(`const [${legacyState},`);
+      expect(root).not.toContain(setter);
     }
+    expect(root).toContain('mobileNavigationReducer');
   });
 
   it('routes App schedule, training, dialogue and result screens through V8 play routes',()=>{
@@ -36,9 +39,10 @@ describe('V8 root router integration',()=>{
     expect(home).toContain('onWeeklyPlannerNavigate');
   });
 
-  it('reports Tactical setup, active and result phases to the router',()=>{
+  it('reports Tactical setup, active and result phases to the router without callback-driven setup loops',()=>{
     expect(tactical).toContain('onPhaseChange');
     expect(tactical).toContain("onPhaseChange?.('active')");
     expect(tactical).toContain("onPhaseChange?.('result')");
+    expect(tactical).toContain('onPhaseChangeRef.current');
   });
 });


### PR DESCRIPTION
Promote V8 Mobile Router from integration/v3 to production main.

Source PR: #199
Source GREEN: CI #1944 — 465/465 test files, 1816/1816 tests, npm audit 0, TypeScript/Vite production build GREEN.

Includes full-screen semantic mobile routing, routed feature/category screens, guarded active-play navigation, scroll-safe shell, and Tactical phase stabilization.