### PR TITLE
[V14 Detail Completion R2] Guided Play & Tactical Result Readability

### DIFF
--- a/docs/plans/2026-08-29-v14-detail-completion-r2.md
+++ b/docs/plans/2026-08-29-v14-detail-completion-r2.md
@@ -1,0 +1,68 @@
+# V14 Detail Completion R2 — Guided Play & Tactical/Result Readability
+
+Date: 2026-08-29
+Baseline: integration/v3@96f30977482bbab01179f105158241a77c5abeaf
+Branch: work/v14-detail-completion-r2
+
+## Goal
+
+Finish the highest-value remaining guided-play and tactical result readability gaps without changing combat rules, rewards, expedition progression, save schema, or introducing new UI frameworks.
+
+## Architecture
+
+Keep `TacticalBattleScreen` as the presentation/input boundary and preserve the existing tactical engine, AI, ultimate resolver, session callbacks, and `ActionResultSummary` ownership. Improvements are semantic/presentation-only: expose selected/current state to assistive technology, make battle-result actions readable in the Korean UI, and preserve the existing exit/retry callback priority. Use existing mobile tokens and compact-height/reduced-motion rules rather than adding a parallel layout system.
+
+## Files
+
+- Create: `src/v14-detail-completion-r2-regression.test.ts`
+- Modify: `src/TacticalBattleScreen.tsx`
+- Modify only if evidence requires: `src/tactical-battle.css`
+
+## Task 1 — RED: tactical state and result contracts
+
+1. Add a source regression test requiring:
+   - current timeline actor exposes `aria-current`
+   - selected tactical cards and bond ultimates expose `aria-pressed`
+   - AUTO exposes `aria-pressed={auto}`
+   - result overlay is modal via `aria-modal="true"`
+   - result actions use Korean labels (`홈으로 돌아가기`, `다시 도전`) instead of literal `EXIT` / `RETRY`
+   - callback behavior remains `onExit ?? onRetry` for the primary continuation and `onRetry` for the optional second action
+2. Open a draft PR so GitHub Actions runs the test.
+3. Verify the new contract fails before production code changes.
+
+## Task 2 — GREEN: minimal tactical presentation implementation
+
+1. Add `aria-pressed={auto}` to AUTO.
+2. Mark the active timeline item with `aria-current="true"`.
+3. Add `aria-pressed` to bond ultimate buttons and tactical hand cards based on existing selected state.
+4. Add `aria-modal="true"` to the result dialog.
+5. Keep callback ordering unchanged while replacing English result CTA labels with Korean:
+   - primary when exit exists: `홈으로 돌아가기`
+   - primary when only retry exists: `다시 도전`
+   - secondary retry when both exist: `다시 도전`
+6. Keep result/combat progression logic untouched.
+7. Re-run CI and confirm the RED contract turns GREEN.
+
+## Task 3 — Mobile/readability verification
+
+1. Inspect compact-height and <=430px tactical CSS for overlap or unreachable result actions.
+2. Modify CSS only if source evidence shows a concrete regression.
+3. Preserve reduced-motion behavior and existing intentional arena/feed scrolling zones.
+
+## Task 4 — Release gate
+
+1. Full `npm run test` and `npm run build` through GitHub Actions.
+2. Verify Vercel preview status when available.
+3. Merge the feature PR into `integration/v3` only after GREEN.
+4. Open integration→main release PR and verify release-gate CI.
+5. Merge to main, then freshly verify main CI and production Vercel deployment.
+6. Compare `integration/v3` and `main`; expected code-tree difference after release is zero, with main ahead only by the release merge commit.
+
+## Non-goals
+
+- No tactical balance changes.
+- No AP/MP/card/AI/ultimate rule changes.
+- No reward or expedition progression changes.
+- No save schema changes.
+- No new animation framework.
+- No speculative Outing/Story edits without a source-backed defect.

--- a/src/TacticalBattleScreen.tsx
+++ b/src/TacticalBattleScreen.tsx
@@ -108,24 +108,24 @@ export function TacticalBattleScreen({session,auto,speed,party=EMPTY_PARTY,bondL
   };
 
   return <section className="tactical-screen" aria-label="Tactical battle">
-    <header><strong>3 VS 3</strong><span>ROUND {v.round}</span><button onClick={onToggleAuto}>{v.autoLabel}</button><button onClick={onToggleSpeed}>{v.speedLabel}</button></header>
-    <div className="tactical-timeline">{v.timeline.map(id=><span key={id} className={id===v.activeActorId?'active':''}>{id}</span>)}</div>
+    <header><strong>3 VS 3</strong><span>ROUND {v.round}</span><button onClick={onToggleAuto} aria-pressed={auto}>{v.autoLabel}</button><button onClick={onToggleSpeed}>{v.speedLabel}</button></header>
+    <div className="tactical-timeline">{v.timeline.map(id=><span key={id} aria-current={id===v.activeActorId?'true':undefined} className={id===v.activeActorId?'active':''}>{id}</span>)}</div>
     <div className="tactical-field">
       <div className="tactical-team enemies">{v.enemies.map(u=>{const targetable=validTargetIds.includes(u.id);return <article key={u.id} role="button" tabIndex={targetable?0:-1} aria-disabled={!targetable} aria-label={`${u.id} ${u.alive?'target':'down'}`} onKeyDown={event=>targetKeyDown(event,u.id)} onClick={()=>chooseTarget(u.id)} className={`unit ${u.position} ${u.active?'active':''} ${targetable?'targetable':''} ${!u.alive?'down':''}`}><b>{u.id}</b><progress max={u.maxHp} value={u.hp}/><small>HP {u.hp}/{u.maxHp} · SH {u.shield}</small><small>AP {u.ap}/{u.maxAp} · MP {u.mp}/{u.maxMp}</small>{u.statuses.length?<em>{u.statuses.join(' · ')}</em>:null}</article>})}</div>
       <div className="tactical-team allies">{v.allies.map(u=>{const targetable=validTargetIds.includes(u.id);return <article key={u.id} role="button" tabIndex={targetable?0:-1} aria-disabled={!targetable} aria-label={`${u.id} ${u.alive?'target':'down'}`} onKeyDown={event=>targetKeyDown(event,u.id)} onClick={()=>chooseTarget(u.id)} className={`unit ${u.position} ${u.active?'active':''} ${targetable?'targetable':''} ${!u.alive?'down':''}`}><b>{u.id}</b><progress max={u.maxHp} value={u.hp}/><small>HP {u.hp}/{u.maxHp} · SH {u.shield}</small><small>AP {u.ap}/{u.maxAp} · MP {u.mp}/{u.maxMp}</small>{u.statuses.length?<em>{u.statuses.join(' · ')}</em>:null}</article>})}</div>
     </div>
     <div className="tactical-log" role="status" aria-live="polite" aria-label="Battle log">{log.length?log.map((line,index)=><span key={`${line}-${index}`}>{line}</span>):<span>{activeRaw?.side==='ally'?'카드 1장을 선택하세요.':'적의 행동을 기다리는 중...'}</span>}</div>
-    {ultimateViews.length?<div className="tactical-ultimates" aria-label="Bond Lv5 합동기">{ultimateViews.map(ultimate=><button key={ultimate.companionId} className={selectedUltimate===ultimate.companionId?'selected':''} disabled={!ultimate.available||activeRaw?.id!=='runa'||auto||Boolean(v.result)} onClick={()=>chooseUltimate(ultimate.companionId)}><b>{ultimate.label}</b><small>MP {ultimate.mpCost} · BOND 5</small></button>)}</div>:null}
-    <footer className="tactical-hand" aria-label="4장 전술 카드">{v.hand.map((id,index)=>{const action=v.actions.find(item=>item.id===id);return <button key={`${id}-${index}`} className={selectedAction===id?'selected':''} disabled={!action||activeRaw?.side!=='ally'||auto||Boolean(v.result)} onClick={()=>chooseAction(id)}><b>{id.toUpperCase()}</b>{action?<small>AP {action.apCost}{action.mpCost?` · MP ${action.mpCost}`:''}</small>:<small>사용 불가</small>}</button>})}</footer>
-    {v.result?<div className="tactical-result" role="dialog" aria-label="전투 결과">
+    {ultimateViews.length?<div className="tactical-ultimates" aria-label="Bond Lv5 합동기">{ultimateViews.map(ultimate=><button key={ultimate.companionId} aria-pressed={selectedUltimate===ultimate.companionId} className={selectedUltimate===ultimate.companionId?'selected':''} disabled={!ultimate.available||activeRaw?.id!=='runa'||auto||Boolean(v.result)} onClick={()=>chooseUltimate(ultimate.companionId)}><b>{ultimate.label}</b><small>MP {ultimate.mpCost} · BOND 5</small></button>)}</div>:null}
+    <footer className="tactical-hand" aria-label="4장 전술 카드">{v.hand.map((id,index)=>{const action=v.actions.find(item=>item.id===id);return <button key={`${id}-${index}`} aria-pressed={selectedAction===id} className={selectedAction===id?'selected':''} disabled={!action||activeRaw?.side!=='ally'||auto||Boolean(v.result)} onClick={()=>chooseAction(id)}><b>{id.toUpperCase()}</b>{action?<small>AP {action.apCost}{action.mpCost?` · MP ${action.mpCost}`:''}</small>:<small>사용 불가</small>}</button>})}</footer>
+    {v.result?<div className="tactical-result" role="dialog" aria-modal="true" aria-label="전투 결과">
       {onExit||onRetry?<>
         <ActionResultSummary
           title={v.result==='victory'?'VICTORY':'DEFEAT'}
           message={`ROUND ${v.round}`}
-          continuationLabel={onExit?'EXIT':'RETRY'}
+          continuationLabel={onExit?'홈으로 돌아가기':'다시 도전'}
           onContinue={onExit??onRetry!}
         />
-        {onExit&&onRetry?<button className="tactical-result-retry" onClick={onRetry}>RETRY</button>:null}
+        {onExit&&onRetry?<button className="tactical-result-retry" onClick={onRetry}>다시 도전</button>:null}
       </>:<><strong>{v.result==='victory'?'VICTORY':'DEFEAT'}</strong><span>ROUND {v.round}</span></>}
     </div>:null}
   </section>

--- a/src/v10-action-result.test.tsx
+++ b/src/v10-action-result.test.tsx
@@ -34,7 +34,8 @@ describe('V10 action result feedback',()=>{
   it('routes Tactical terminal feedback through the shared result summary while preserving retry',()=>{
     expect(tacticalSource).toContain("from './ActionResultSummary'");
     expect(tacticalSource).toContain('<ActionResultSummary');
-    expect(tacticalSource).toContain('RETRY');
+    expect(tacticalSource).toContain("continuationLabel={onExit?'홈으로 돌아가기':'다시 도전'}");
+    expect(tacticalSource).toContain('>다시 도전</button>');
     expect(tacticalSource).toContain('onRetry');
     expect(tacticalSource).toContain('onExit');
   });

--- a/src/v14-detail-completion-r2-regression.test.ts
+++ b/src/v14-detail-completion-r2-regression.test.ts
@@ -1,0 +1,27 @@
+import {readFileSync} from 'node:fs';
+import {describe,expect,it} from 'vitest';
+
+const tactical=readFileSync(new URL('./TacticalBattleScreen.tsx',import.meta.url),'utf8');
+
+describe('V14 Detail Completion R2 — tactical guided play',()=>{
+  it('exposes active and selected tactical state semantically',()=>{
+    expect(tactical).toContain('aria-pressed={auto}');
+    expect(tactical).toContain("aria-current={id===v.activeActorId?'true':undefined}");
+    expect(tactical).toContain('aria-pressed={selectedUltimate===ultimate.companionId}');
+    expect(tactical).toContain('aria-pressed={selectedAction===id}');
+  });
+
+  it('presents battle results as a modal with Korean next actions',()=>{
+    expect(tactical).toContain('className="tactical-result" role="dialog" aria-modal="true" aria-label="전투 결과"');
+    expect(tactical).toContain("continuationLabel={onExit?'홈으로 돌아가기':'다시 도전'}");
+    expect(tactical).toContain('>다시 도전</button>');
+    expect(tactical).not.toContain("continuationLabel={onExit?'EXIT':'RETRY'}");
+    expect(tactical).not.toContain('>RETRY</button>');
+  });
+
+  it('keeps the existing exit and retry callback behavior unchanged',()=>{
+    expect(tactical).toContain('onContinue={onExit??onRetry!}');
+    expect(tactical).toContain('onExit&&onRetry?<button');
+    expect(tactical).toContain('onClick={onRetry}');
+  });
+});


### PR DESCRIPTION
## Scope

- Tactical active/selected state semantics
- Korean battle result actions without changing callback behavior
- Result dialog accessibility
- Mobile/readability verification

## TDD / verification

- RED contract commit `576f4c26373484e9a3c8013c310eaffda50680e0` → CI #2300 failed at `npm run test` as expected before implementation.
- Implementation commit `fbfb3db48ea9070bcd85595872e66a1d84ee63ae` exposed one stale V10 source contract that still required the literal English `RETRY`; the new R2 regression itself was GREEN.
- Contract-alignment commit `f9ed8d407ef6803e1dec169706ba3edbd55a0c8a` updates that old assertion to the new Korean actions while preserving `onRetry` / `onExit` behavior.
- CI #2302 SUCCESS: clean install, dependency audit evidence, full `npm run test`, and `npm run build` all passed.
- Review threads: none.

## Deployment note

Vercel has hit the account free deployment-rate limit (`api-deployments-free-per-day`, retry in 24 hours). This is external to repository test/build health; the branch previously received a Ready preview before the later deployment attempt was rate-limited.

## Non-goals

No combat balance, AP/MP/card/AI/ultimate rule, reward, expedition progression, save-schema, or speculative Outing/Story changes.