### PR TITLE
[V14 Scene Interaction UX] Environmental affordances

### DIFF
--- a/src/scene/InteractiveObject.test.tsx
+++ b/src/scene/InteractiveObject.test.tsx
@@ -1,0 +1,36 @@
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe,expect,it,vi} from 'vitest';
+import InteractiveObject from './InteractiveObject';
+import type {ResolvedSceneInteraction,SceneAnchor} from './scene-types';
+
+const anchor:SceneAnchor={id:'trace',x:56,y:63};
+
+function interaction(overrides:Partial<ResolvedSceneInteraction>={}):ResolvedSceneInteraction{
+  return {
+    id:'trace',label:'빛나는 흔적 조사',mode:'explore',anchorId:'trace',enabled:true,hint:'new',
+    ...overrides,
+  };
+}
+
+describe('V14 environmental scene interaction object',()=>{
+  it('renders an icon marker, readable label, and compact hint badge from existing interaction metadata',()=>{
+    const html=renderToStaticMarkup(<InteractiveObject interaction={interaction()} anchor={anchor} onInteraction={vi.fn()}/>);
+    expect(html).toContain('v14-scene-object__marker');
+    expect(html).toContain('data-icon-token="compass"');
+    expect(html).toContain('data-family="discovery"');
+    expect(html).toContain('data-emphasis="new"');
+    expect(html).toContain('v14-scene-object__label');
+    expect(html).toContain('v14-scene-object__badge');
+    expect(html).toContain('NEW');
+  });
+
+  it('preserves the existing accessible name and disabled interaction behavior',()=>{
+    const enabled=renderToStaticMarkup(<InteractiveObject interaction={interaction({hint:'required'})} anchor={anchor} onInteraction={vi.fn()}/>);
+    const disabled=renderToStaticMarkup(<InteractiveObject interaction={interaction({enabled:false,hint:'required'})} anchor={anchor} onInteraction={vi.fn()}/>);
+    expect(enabled).toContain('aria-label="빛나는 흔적 조사"');
+    expect(enabled).toContain('>필수<');
+    expect(disabled).toContain('disabled=""');
+    expect(disabled).toContain('aria-disabled="true"');
+    expect(disabled).toContain('data-emphasis="disabled"');
+  });
+});

--- a/src/scene/InteractiveObject.test.tsx
+++ b/src/scene/InteractiveObject.test.tsx
@@ -33,4 +33,13 @@ describe('V14 environmental scene interaction object',()=>{
     expect(disabled).toContain('aria-disabled="true"');
     expect(disabled).toContain('data-emphasis="disabled"');
   });
+
+  it('aligns edge anchors inward so action labels do not clip outside the scene',()=>{
+    const left=renderToStaticMarkup(<InteractiveObject interaction={interaction()} anchor={{id:'exit',x:8,y:60}} onInteraction={vi.fn()}/>);
+    const center=renderToStaticMarkup(<InteractiveObject interaction={interaction()} anchor={anchor} onInteraction={vi.fn()}/>);
+    const right=renderToStaticMarkup(<InteractiveObject interaction={interaction()} anchor={{id:'rift',x:88,y:31}} onInteraction={vi.fn()}/>);
+    expect(left).toContain('data-edge="left"');
+    expect(center).toContain('data-edge="center"');
+    expect(right).toContain('data-edge="right"');
+  });
 });

--- a/src/scene/InteractiveObject.tsx
+++ b/src/scene/InteractiveObject.tsx
@@ -1,4 +1,5 @@
 import type {CSSProperties} from 'react';
+import {resolveSceneInteractionPresentation} from './scene-interaction-presentation';
 import type {ResolvedSceneInteraction,SceneAnchor} from './scene-types';
 
 type Props={
@@ -12,6 +13,7 @@ export default function InteractiveObject({interaction,anchor,onInteraction}:Pro
     '--scene-x':`${anchor.x}%`,
     '--scene-y':`${anchor.y}%`,
   } as CSSProperties;
+  const presentation=resolveSceneInteractionPresentation(interaction);
   const hinted=interaction.hint!=='none';
   return <button
     type="button"
@@ -21,11 +23,15 @@ export default function InteractiveObject({interaction,anchor,onInteraction}:Pro
     data-anchor-id={anchor.id}
     data-mode={interaction.mode}
     data-hint={interaction.hint}
+    data-family={presentation.family}
+    data-emphasis={presentation.emphasis}
     aria-label={interaction.label}
     disabled={!interaction.enabled}
     aria-disabled={!interaction.enabled}
     onClick={()=>onInteraction(interaction)}
   >
-    <span>{interaction.label}</span>
+    <i className="v14-scene-object__marker" data-icon-token={presentation.iconToken} aria-hidden="true"/>
+    <span className="v14-scene-object__label">{interaction.label}</span>
+    {presentation.hintLabel?<small className="v14-scene-object__badge" aria-hidden="true">{presentation.hintLabel}</small>:null}
   </button>;
 }

--- a/src/scene/InteractiveObject.tsx
+++ b/src/scene/InteractiveObject.tsx
@@ -8,6 +8,12 @@ type Props={
   onInteraction:(interaction:ResolvedSceneInteraction)=>void;
 };
 
+function edgeForAnchor(anchor:SceneAnchor):'left'|'center'|'right'{
+  if(anchor.x<=18)return 'left';
+  if(anchor.x>=82)return 'right';
+  return 'center';
+}
+
 export default function InteractiveObject({interaction,anchor,onInteraction}:Props){
   const style={
     '--scene-x':`${anchor.x}%`,
@@ -25,6 +31,7 @@ export default function InteractiveObject({interaction,anchor,onInteraction}:Pro
     data-hint={interaction.hint}
     data-family={presentation.family}
     data-emphasis={presentation.emphasis}
+    data-edge={edgeForAnchor(anchor)}
     aria-label={interaction.label}
     disabled={!interaction.enabled}
     aria-disabled={!interaction.enabled}

--- a/src/scene/SceneStage.tsx
+++ b/src/scene/SceneStage.tsx
@@ -8,6 +8,7 @@ import type {SceneRuntimePhase} from './scene-runtime';
 import type {ResolvedScene,ResolvedSceneInteraction,SceneAnchor} from './scene-types';
 import './scene.css';
 import './scene-recipe.css';
+import './scene-interaction.css';
 
 type Props={
   scene:ResolvedScene;

--- a/src/scene/scene-interaction-presentation.test.ts
+++ b/src/scene/scene-interaction-presentation.test.ts
@@ -1,0 +1,53 @@
+import {describe,expect,it} from 'vitest';
+import {INTERACTION_MODES,type ResolvedSceneInteraction} from './scene-interaction-presentation';
+import {resolveSceneInteractionPresentation} from './scene-interaction-presentation';
+
+const expectedIcons={
+  dialogue:'speech',
+  inspect:'inspect',
+  collect:'collect',
+  travel:'travel',
+  rest:'rest',
+  shop:'shop',
+  training:'target',
+  choice:'choice',
+  minigame:'spark',
+  explore:'compass',
+  battle:'battle',
+  reward:'reward',
+} as const;
+
+function interaction(overrides:Partial<ResolvedSceneInteraction>={}):ResolvedSceneInteraction{
+  return {
+    id:'sample',label:'행동',mode:'inspect',anchorId:'sample',enabled:true,hint:'none',
+    ...overrides,
+  };
+}
+
+describe('V14 scene interaction presentation',()=>{
+  it('gives every interaction mode a stable environmental icon token',()=>{
+    expect(INTERACTION_MODES).toEqual(Object.keys(expectedIcons));
+    for(const mode of INTERACTION_MODES){
+      expect(resolveSceneInteractionPresentation(interaction({mode})).iconToken).toBe(expectedIcons[mode]);
+    }
+  });
+
+  it('groups modes into readable action families without changing their game mode',()=>{
+    expect(resolveSceneInteractionPresentation(interaction({mode:'dialogue'})).family).toBe('social');
+    expect(resolveSceneInteractionPresentation(interaction({mode:'inspect'})).family).toBe('discovery');
+    expect(resolveSceneInteractionPresentation(interaction({mode:'explore'})).family).toBe('discovery');
+    expect(resolveSceneInteractionPresentation(interaction({mode:'collect'})).family).toBe('gather');
+    expect(resolveSceneInteractionPresentation(interaction({mode:'travel'})).family).toBe('movement');
+    expect(resolveSceneInteractionPresentation(interaction({mode:'training'})).family).toBe('challenge');
+    expect(resolveSceneInteractionPresentation(interaction({mode:'battle'})).family).toBe('challenge');
+    expect(resolveSceneInteractionPresentation(interaction({mode:'reward'})).family).toBe('reward');
+  });
+
+  it('turns existing hint state into a compact visible priority badge',()=>{
+    expect(resolveSceneInteractionPresentation(interaction({hint:'required'}))).toMatchObject({emphasis:'required',hintLabel:'필수'});
+    expect(resolveSceneInteractionPresentation(interaction({hint:'new'}))).toMatchObject({emphasis:'new',hintLabel:'NEW'});
+    expect(resolveSceneInteractionPresentation(interaction({hint:'accessible-idle'}))).toMatchObject({emphasis:'recommended',hintLabel:'추천'});
+    expect(resolveSceneInteractionPresentation(interaction({hint:'none'}))).toMatchObject({emphasis:'normal',hintLabel:null});
+    expect(resolveSceneInteractionPresentation(interaction({enabled:false,hint:'required'}))).toMatchObject({emphasis:'disabled'});
+  });
+});

--- a/src/scene/scene-interaction-presentation.test.ts
+++ b/src/scene/scene-interaction-presentation.test.ts
@@ -1,6 +1,6 @@
 import {describe,expect,it} from 'vitest';
-import {INTERACTION_MODES,type ResolvedSceneInteraction} from './scene-interaction-presentation';
-import {resolveSceneInteractionPresentation} from './scene-interaction-presentation';
+import {INTERACTION_MODES,resolveSceneInteractionPresentation} from './scene-interaction-presentation';
+import type {ResolvedSceneInteraction} from './scene-types';
 
 const expectedIcons={
   dialogue:'speech',

--- a/src/scene/scene-interaction-presentation.ts
+++ b/src/scene/scene-interaction-presentation.ts
@@ -1,0 +1,43 @@
+import type {InteractionMode,ResolvedSceneInteraction} from './scene-types';
+
+export const INTERACTION_MODES=[
+  'dialogue','inspect','collect','travel','rest','shop',
+  'training','choice','minigame','explore','battle','reward',
+] as const satisfies readonly InteractionMode[];
+
+export type SceneInteractionFamily='social'|'discovery'|'gather'|'movement'|'recovery'|'commerce'|'challenge'|'decision'|'reward';
+export type SceneInteractionEmphasis='normal'|'required'|'new'|'recommended'|'disabled';
+
+export interface SceneInteractionPresentation{
+  iconToken:'speech'|'inspect'|'collect'|'travel'|'rest'|'shop'|'target'|'choice'|'spark'|'compass'|'battle'|'reward';
+  family:SceneInteractionFamily;
+  emphasis:SceneInteractionEmphasis;
+  hintLabel:string|null;
+}
+
+const modePresentation:Record<InteractionMode,Pick<SceneInteractionPresentation,'iconToken'|'family'>>={
+  dialogue:{iconToken:'speech',family:'social'},
+  inspect:{iconToken:'inspect',family:'discovery'},
+  collect:{iconToken:'collect',family:'gather'},
+  travel:{iconToken:'travel',family:'movement'},
+  rest:{iconToken:'rest',family:'recovery'},
+  shop:{iconToken:'shop',family:'commerce'},
+  training:{iconToken:'target',family:'challenge'},
+  choice:{iconToken:'choice',family:'decision'},
+  minigame:{iconToken:'spark',family:'challenge'},
+  explore:{iconToken:'compass',family:'discovery'},
+  battle:{iconToken:'battle',family:'challenge'},
+  reward:{iconToken:'reward',family:'reward'},
+};
+
+function hintPresentation(interaction:ResolvedSceneInteraction):Pick<SceneInteractionPresentation,'emphasis'|'hintLabel'>{
+  if(!interaction.enabled)return {emphasis:'disabled',hintLabel:null};
+  if(interaction.hint==='required')return {emphasis:'required',hintLabel:'필수'};
+  if(interaction.hint==='new')return {emphasis:'new',hintLabel:'NEW'};
+  if(interaction.hint==='accessible-idle')return {emphasis:'recommended',hintLabel:'추천'};
+  return {emphasis:'normal',hintLabel:null};
+}
+
+export function resolveSceneInteractionPresentation(interaction:ResolvedSceneInteraction):SceneInteractionPresentation{
+  return {...modePresentation[interaction.mode],...hintPresentation(interaction)};
+}

--- a/src/scene/scene-interaction-style.test.ts
+++ b/src/scene/scene-interaction-style.test.ts
@@ -1,0 +1,38 @@
+import {readFileSync} from 'node:fs';
+import {describe,expect,it} from 'vitest';
+
+const css=readFileSync(new URL('./scene-interaction.css',import.meta.url),'utf8');
+const stageSource=readFileSync(new URL('./SceneStage.tsx',import.meta.url),'utf8');
+
+describe('V14 scene interaction environmental affordance styles',()=>{
+  it('loads the dedicated interaction presentation layer after shared scene styles',()=>{
+    expect(stageSource).toContain("import './scene-interaction.css';");
+    expect(css).toContain('.v14-scene-object__marker');
+    expect(css).toContain('.v14-scene-object__label');
+    expect(css).toContain('.v14-scene-object__badge');
+  });
+
+  it('draws a distinct marker for every interaction icon token',()=>{
+    for(const token of ['speech','inspect','collect','travel','rest','shop','target','choice','spark','compass','battle','reward']){
+      expect(css).toContain(`data-icon-token="${token}"`);
+    }
+  });
+
+  it('keeps required, new, recommended, disabled and keyboard focus states visually distinct',()=>{
+    for(const emphasis of ['required','new','recommended','disabled']){
+      expect(css).toContain(`data-emphasis="${emphasis}"`);
+    }
+    expect(css).toContain(':focus-visible');
+  });
+
+  it('keeps scene material identity and compact mobile targets',()=>{
+    expect(css).toContain('data-interaction-skin="rune-socket"');
+    expect(css).toContain('data-interaction-skin="botany-tag"');
+    expect(css).toContain('data-interaction-skin="street-sign"');
+    expect(css).toContain('min-width:44px');
+    expect(css).toContain('min-height:44px');
+    expect(css).toContain('@media(max-width:430px)');
+    expect(css).toContain('@media(max-height:640px)');
+    expect(css).toContain('@media(prefers-reduced-motion:reduce)');
+  });
+});

--- a/src/scene/scene-interaction.css
+++ b/src/scene/scene-interaction.css
@@ -1,0 +1,165 @@
+.v14-scene-stage .v14-scene-interactions .v14-scene-object{
+  width:44px;
+  height:44px;
+  min-width:44px;
+  min-height:44px;
+  max-width:none;
+  padding:0;
+  border:0;
+  border-radius:50%;
+  background:transparent;
+  box-shadow:none;
+  backdrop-filter:none;
+  overflow:visible;
+  color:#fff;
+  isolation:isolate;
+  --interaction-accent:rgba(201,220,238,.9);
+  --interaction-glow:rgba(128,172,210,.24);
+}
+
+.v14-scene-object[data-family="social"]{--interaction-accent:rgba(222,190,255,.95);--interaction-glow:rgba(160,101,215,.28)}
+.v14-scene-object[data-family="discovery"]{--interaction-accent:rgba(170,229,238,.95);--interaction-glow:rgba(66,166,184,.26)}
+.v14-scene-object[data-family="gather"]{--interaction-accent:rgba(172,236,181,.96);--interaction-glow:rgba(67,157,91,.26)}
+.v14-scene-object[data-family="movement"]{--interaction-accent:rgba(161,205,255,.96);--interaction-glow:rgba(72,135,210,.27)}
+.v14-scene-object[data-family="recovery"]{--interaction-accent:rgba(193,207,255,.95);--interaction-glow:rgba(104,121,197,.25)}
+.v14-scene-object[data-family="commerce"]{--interaction-accent:rgba(255,207,173,.96);--interaction-glow:rgba(189,112,70,.27)}
+.v14-scene-object[data-family="challenge"]{--interaction-accent:rgba(255,213,133,.97);--interaction-glow:rgba(208,143,52,.29)}
+.v14-scene-object[data-family="decision"]{--interaction-accent:rgba(220,199,255,.96);--interaction-glow:rgba(139,104,210,.27)}
+.v14-scene-object[data-family="reward"]{--interaction-accent:rgba(255,229,139,.98);--interaction-glow:rgba(230,176,55,.3)}
+.v14-scene-object[data-mode="battle"]{--interaction-accent:rgba(255,151,151,.98);--interaction-glow:rgba(221,73,81,.34)}
+
+.v14-scene-object__marker{
+  position:absolute;
+  inset:0;
+  display:grid;
+  place-items:center;
+  border:2px solid var(--interaction-accent);
+  border-radius:50%;
+  background:radial-gradient(circle at 35% 28%,rgba(255,255,255,.18),rgba(18,27,39,.9) 58%,rgba(12,18,29,.96));
+  box-shadow:0 0 0 4px var(--interaction-glow),0 7px 16px rgba(0,0,0,.34);
+  color:#fff;
+  pointer-events:none;
+  transition:transform .16s ease,filter .16s ease,box-shadow .16s ease;
+}
+
+.v14-scene-object__marker::before{
+  display:block;
+  font-size:21px;
+  font-weight:800;
+  line-height:1;
+  text-shadow:0 1px 5px rgba(0,0,0,.45);
+}
+.v14-scene-object__marker[data-icon-token="speech"]::before{content:"···";letter-spacing:-1px;transform:translateY(-2px)}
+.v14-scene-object__marker[data-icon-token="inspect"]::before{content:"⌕";font-size:25px}
+.v14-scene-object__marker[data-icon-token="collect"]::before{content:"✦"}
+.v14-scene-object__marker[data-icon-token="travel"]::before{content:"➜";font-size:22px}
+.v14-scene-object__marker[data-icon-token="rest"]::before{content:"☾";font-size:24px}
+.v14-scene-object__marker[data-icon-token="shop"]::before{content:"▣";font-size:19px}
+.v14-scene-object__marker[data-icon-token="target"]::before{content:"◎";font-size:23px}
+.v14-scene-object__marker[data-icon-token="choice"]::before{content:"↗";font-size:21px}
+.v14-scene-object__marker[data-icon-token="spark"]::before{content:"✧";font-size:24px}
+.v14-scene-object__marker[data-icon-token="compass"]::before{content:"◇";font-size:22px;transform:rotate(45deg)}
+.v14-scene-object__marker[data-icon-token="battle"]::before{content:"⚔";font-size:19px}
+.v14-scene-object__marker[data-icon-token="reward"]::before{content:"★";font-size:19px}
+
+.v14-scene-object__label{
+  position:absolute;
+  left:50%;
+  top:calc(100% + 5px);
+  width:max-content;
+  max-width:min(38vw,174px);
+  transform:translateX(-50%);
+  padding:5px 8px;
+  border:1px solid color-mix(in srgb,var(--interaction-accent) 52%,transparent);
+  border-radius:9px;
+  background:rgba(14,21,32,.9);
+  box-shadow:0 5px 12px rgba(0,0,0,.28);
+  color:#fff;
+  font-size:11px;
+  font-weight:700;
+  line-height:1.22;
+  white-space:normal;
+  word-break:keep-all;
+  overflow-wrap:anywhere;
+  text-align:center;
+  pointer-events:none;
+  z-index:2;
+}
+.v14-scene-object[data-edge="left"] .v14-scene-object__label{left:0;transform:none;text-align:left}
+.v14-scene-object[data-edge="right"] .v14-scene-object__label{left:auto;right:0;transform:none;text-align:right}
+
+.v14-scene-object__badge{
+  position:absolute;
+  z-index:4;
+  right:-12px;
+  top:-10px;
+  min-width:28px;
+  padding:3px 5px;
+  border:1px solid rgba(255,255,255,.78);
+  border-radius:999px;
+  background:#263448;
+  color:#fff;
+  font-size:9px;
+  font-weight:900;
+  line-height:1;
+  letter-spacing:.04em;
+  box-shadow:0 3px 9px rgba(0,0,0,.3);
+  pointer-events:none;
+}
+.v14-scene-object[data-emphasis="required"] .v14-scene-object__badge{background:#a33f48}
+.v14-scene-object[data-emphasis="new"] .v14-scene-object__badge{background:#9a6b16;color:#fff7d5}
+.v14-scene-object[data-emphasis="recommended"] .v14-scene-object__badge{background:#2f668f}
+.v14-scene-object[data-emphasis="required"] .v14-scene-object__marker,
+.v14-scene-object[data-emphasis="new"] .v14-scene-object__marker,
+.v14-scene-object[data-emphasis="recommended"] .v14-scene-object__marker{
+  box-shadow:0 0 0 5px var(--interaction-glow),0 0 20px var(--interaction-glow),0 8px 18px rgba(0,0,0,.35);
+}
+.v14-scene-object[data-emphasis="disabled"]{opacity:.44;cursor:not-allowed}
+.v14-scene-object[data-emphasis="disabled"] .v14-scene-object__marker{filter:saturate(.35)}
+
+.v14-scene-object:hover:not(:disabled) .v14-scene-object__marker{transform:translateY(-2px) scale(1.05);filter:brightness(1.12)}
+.v14-scene-object:hover:not(:disabled) .v14-scene-object__label{background:rgba(19,29,44,.96)}
+.v14-scene-object:focus-visible{outline:0;filter:none}
+.v14-scene-object:focus-visible .v14-scene-object__marker{box-shadow:0 0 0 3px #172131,0 0 0 6px #ffe29a,0 8px 18px rgba(0,0,0,.36);filter:brightness(1.1)}
+.v14-scene-object:focus-visible .v14-scene-object__label{border-color:#ffe29a}
+
+.v14-scene-stage[data-interaction-skin="contextual-room"] .v14-scene-object__marker{border-radius:12px;background:linear-gradient(145deg,rgba(129,86,55,.96),rgba(65,47,39,.98))}
+.v14-scene-stage[data-interaction-skin="target-hud"] .v14-scene-object__marker{border-radius:8px;background:linear-gradient(180deg,rgba(86,61,30,.96),rgba(42,35,27,.98));box-shadow:inset 0 0 0 2px rgba(255,255,255,.06),0 0 0 4px var(--interaction-glow),0 7px 16px rgba(0,0,0,.34)}
+.v14-scene-stage[data-interaction-skin="rune-socket"] .v14-scene-object__marker{border:2px solid rgba(211,196,255,.9);background:radial-gradient(circle,rgba(117,79,193,.96),rgba(41,31,75,.98));box-shadow:0 0 0 5px rgba(158,126,255,.16),0 0 22px rgba(132,99,255,.34)}
+.v14-scene-stage[data-interaction-skin="botany-tag"] .v14-scene-object__marker{border-radius:6px 13px 6px 13px;border-color:rgba(113,91,60,.72);background:linear-gradient(180deg,rgba(246,236,193,.98),rgba(210,194,142,.98));color:#35472e;text-shadow:none}
+.v14-scene-stage[data-interaction-skin="exploration-marker"] .v14-scene-object__marker{border-radius:6px 15px 6px 15px;background:linear-gradient(155deg,rgba(46,91,57,.97),rgba(24,55,37,.98))}
+.v14-scene-stage[data-interaction-skin="street-sign"] .v14-scene-object__marker{border-radius:4px;border-color:rgba(238,198,145,.82);background:linear-gradient(180deg,rgba(135,77,46,.98),rgba(76,47,38,.98));box-shadow:0 4px 0 rgba(55,39,34,.42),0 8px 15px rgba(0,0,0,.28)}
+.v14-scene-stage[data-interaction-skin="quiet-ripple"] .v14-scene-object__marker{border-color:rgba(220,243,255,.72);background:radial-gradient(circle,rgba(72,136,164,.86),rgba(33,76,105,.92));box-shadow:0 0 0 6px rgba(193,230,247,.1),0 0 18px rgba(158,220,245,.2)}
+.v14-scene-stage[data-interaction-skin="inscription-seal"] .v14-scene-object__marker{border:3px double rgba(219,212,193,.8);border-radius:10px;background:linear-gradient(180deg,rgba(76,70,76,.97),rgba(41,39,49,.98))}
+.v14-scene-stage[data-interaction-skin="expedition-command"] .v14-scene-object__marker,
+.v14-scene-stage[data-interaction-skin="expedition-preparation"] .v14-scene-object__marker,
+.v14-scene-stage[data-interaction-skin="expedition-tactical"] .v14-scene-object__marker,
+.v14-scene-stage[data-interaction-skin="expedition-debrief"] .v14-scene-object__marker{border-radius:7px;background:linear-gradient(180deg,rgba(74,63,50,.97),rgba(37,37,37,.98));box-shadow:0 4px 0 rgba(28,28,27,.38),0 8px 16px rgba(0,0,0,.3)}
+
+.lh-living-scene .v14-scene-object__label{font-size:10px;max-width:118px;padding:4px 6px}
+
+@keyframes v14-scene-affordance-pulse{0%,100%{filter:brightness(1)}50%{filter:brightness(1.11)}}
+.v14-scene-stage .v14-scene-object[data-emphasis="required"],
+.v14-scene-stage .v14-scene-object[data-emphasis="new"],
+.v14-scene-stage .v14-scene-object[data-emphasis="recommended"]{animation:v14-scene-affordance-pulse 1.8s ease-in-out infinite}
+
+@media(max-width:430px){
+  .v14-scene-stage .v14-scene-interactions .v14-scene-object{width:44px;height:44px;min-width:44px;min-height:44px}
+  .v14-scene-object__marker{inset:3px;border-width:2px}
+  .v14-scene-object__marker::before{font-size:18px}
+  .v14-scene-object__label{top:calc(100% + 3px);max-width:min(34vw,132px);padding:4px 6px;font-size:10px}
+  .v14-scene-object__badge{right:-8px;top:-7px;min-width:24px;padding:2px 4px;font-size:8px}
+  .lh-living-scene .v14-scene-object__label{max-width:94px;font-size:9px}
+}
+
+@media(max-height:640px){
+  .v14-scene-object__label{top:calc(100% + 2px);max-width:122px;padding:3px 5px;font-size:9px}
+  .v14-scene-object__badge{top:-6px}
+}
+
+@media(prefers-reduced-motion:reduce){
+  .v14-scene-object__marker{transition:none}
+  .v14-scene-stage .v14-scene-object[data-emphasis="required"],
+  .v14-scene-stage .v14-scene-object[data-emphasis="new"],
+  .v14-scene-stage .v14-scene-object[data-emphasis="recommended"]{animation:none}
+}


### PR DESCRIPTION
## V14 Scene Interaction UX — Environmental Affordances

### Scope
- replace generic floating scene pills with environmental 44px interaction markers while preserving the existing button/click/intent/runtime path
- add a stable presentation token for every existing `InteractionMode`
- group actions into visual families without changing their underlying game mode
- surface existing hint metadata as compact priority badges: `필수`, `NEW`, `추천`
- preserve `aria-label`, `aria-disabled`, disabled behavior, keyboard focus visibility, and reduced-motion handling
- automatically align edge-anchored labels inward so left/right scene actions do not clip outside the viewport
- adapt marker material to existing scene interaction skins such as rune socket, botany tag, street sign, shrine seal, and expedition command/tactical skins
- keep compact handling for 430px width and 640px short-height layouts

### TDD evidence
- initial RED contract → CI #2340 FAILED at `npm run test` as expected before the presentation helper/component implementation
- dedicated styling RED contract `ef1d8596f6e9462448bb9bc67e256e8415d43e76` → CI #2343 FAILED at `npm run test` with build skipped as expected
- final exact head `9a8c4e5ddb5cd23f8d5238ad41278a8f29f80a4a`

### Verification
Latest CI #2347:
- 549 / 549 test files passed
- 2,132 / 2,132 tests passed
- `tsc -b && vite build` passed
- npm audit: 0 vulnerabilities

### Non-goals
No SceneDirector/runtime rules, intents, rewards, progression, economy, route behavior, or save-schema changes.