### PR TITLE
[V14 Scene Action Feedback] Runtime status lane

### DIFF
--- a/src/scene/SceneStage.tsx
+++ b/src/scene/SceneStage.tsx
@@ -2,6 +2,7 @@ import {type CSSProperties,useEffect} from 'react';
 import CharacterActor from './CharacterActor';
 import InteractiveObject from './InteractiveObject';
 import SceneDirector,{type SceneDirectorController} from './SceneDirector';
+import {sceneActionFeedback,type SceneActionFeedback} from './scene-action-feedback';
 import {resolveSceneFeedbackVisual} from './scene-asset-registry';
 import {resolveSceneRecipe} from './scene-recipe';
 import type {SceneRuntimePhase} from './scene-runtime';
@@ -20,6 +21,7 @@ type SceneStageFrameProps=Props&{
   runtimeActorPose?:string;
   runtimeActorMotion?:string;
   runtimePhase?:SceneRuntimePhase;
+  actionFeedback?:SceneActionFeedback|null;
 };
 
 function poseForInteraction(interaction:ResolvedSceneInteraction|undefined,phase:SceneRuntimePhase):string|undefined{
@@ -52,7 +54,7 @@ function currentWorldFacts(scene:ResolvedScene):string[]{
 }
 
 function SceneStageFrame({
-  scene,onInteraction,runtimeActorAnchorId,runtimeActorPose,runtimeActorMotion,runtimePhase='idle',
+  scene,onInteraction,runtimeActorAnchorId,runtimeActorPose,runtimeActorMotion,runtimePhase='idle',actionFeedback,
 }:SceneStageFrameProps){
   const anchors=new Map<string,SceneAnchor>(scene.anchors.map(anchor=>[anchor.id,anchor]));
   const resolvedRunaAnchor=scene.cast.find(actor=>actor.actorId==='runa')?.anchorId;
@@ -136,6 +138,17 @@ function SceneStageFrame({
         '--scene-y':`${feedbackAnchor.y}%`,
       } as CSSProperties}
     />:null}
+    {actionFeedback?<div
+      className="v14-scene-action-feedback"
+      data-feedback-tone={actionFeedback.tone}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-busy={actionFeedback.busy}
+    >
+      <i className="v14-scene-action-feedback__indicator" aria-hidden="true"/>
+      <span>{actionFeedback.message}</span>
+    </div>:null}
     <div className="v14-scene-interactions">
       {scene.interactions.map(interaction=>{
         const anchorId=interaction.id==='runa'?(runtimeActorAnchorId??resolvedRunaAnchor??interaction.anchorId):interaction.anchorId;
@@ -152,6 +165,7 @@ function DirectedSceneStage({scene,controller}:{scene:ResolvedScene;controller:S
   const runtimeActorAnchorId=phase==='idle'?undefined:interaction?.anchorId;
   const runtimeActorPose=poseForInteraction(interaction,phase);
   const runtimeActorMotion=motionForPhase(phase);
+  const actionFeedback=sceneActionFeedback(interaction,phase);
 
   useEffect(()=>{
     if(phase==='idle') return;
@@ -168,6 +182,7 @@ function DirectedSceneStage({scene,controller}:{scene:ResolvedScene;controller:S
     runtimeActorPose={runtimeActorPose}
     runtimeActorMotion={runtimeActorMotion}
     runtimePhase={phase}
+    actionFeedback={actionFeedback}
   />;
 }
 

--- a/src/scene/scene-action-feedback.test.tsx
+++ b/src/scene/scene-action-feedback.test.tsx
@@ -1,8 +1,6 @@
-import {act,fireEvent,render,screen} from '@testing-library/react';
-import {afterEach,describe,expect,it,vi} from 'vitest';
-import SceneStage from './SceneStage';
+import {readFileSync} from 'node:fs';
+import {describe,expect,it} from 'vitest';
 import {sceneActionFeedback} from './scene-action-feedback';
-import {resolveScene} from './scene-resolver';
 import type {ResolvedSceneInteraction} from './scene-types';
 
 const restInteraction={
@@ -14,15 +12,19 @@ const restInteraction={
   hint:'accessible-idle',
 } satisfies ResolvedSceneInteraction;
 
-afterEach(()=>{
-  vi.useRealTimers();
-});
+const stageSource=readFileSync(new URL('./SceneStage.tsx',import.meta.url),'utf8');
+const interactionCss=readFileSync(new URL('./scene-interaction.css',import.meta.url),'utf8');
 
 describe('V14 scene action feedback',()=>{
   it('turns runtime phases into concise progress and result copy without game-state coupling',()=>{
     expect(sceneActionFeedback(restInteraction,'idle')).toBeNull();
     expect(sceneActionFeedback(restInteraction,'approaching')).toEqual({
       message:'잠깐 쉬기 · 이동 중',
+      tone:'info',
+      busy:true,
+    });
+    expect(sceneActionFeedback(restInteraction,'acting')).toEqual({
+      message:'잠깐 쉬기 · 진행 중',
       tone:'info',
       busy:true,
     });
@@ -38,25 +40,20 @@ describe('V14 scene action feedback',()=>{
     });
   });
 
-  it('shows the active action as an accessible live status through the shared SceneStage',()=>{
-    vi.useFakeTimers();
-    const onInteraction=vi.fn();
-    const scene=resolveScene({year:1,month:4,week:1,location:'home'});
-    render(<SceneStage scene={scene} onInteraction={onInteraction}/>);
+  it('connects feedback to the shared stage with accessible live semantics',()=>{
+    expect(stageSource).toContain('sceneActionFeedback(');
+    expect(stageSource).toContain('v14-scene-action-feedback');
+    expect(stageSource).toContain('role="status"');
+    expect(stageSource).toContain('aria-live="polite"');
+    expect(stageSource).toContain('aria-atomic="true"');
+    expect(stageSource).toContain('aria-busy={actionFeedback.busy}');
+  });
 
-    fireEvent.click(screen.getByRole('button',{name:'잠깐 쉬기'}));
-    expect(screen.getByRole('status')).toHaveTextContent('잠깐 쉬기 · 이동 중');
-    expect(screen.getByRole('status')).toHaveAttribute('aria-live','polite');
-    expect(screen.getByRole('status')).toHaveAttribute('aria-busy','true');
-
-    act(()=>vi.advanceTimersByTime(220));
-    expect(screen.getByRole('status')).toHaveTextContent('잠깐 쉬기 · 진행 중');
-
-    act(()=>vi.advanceTimersByTime(180));
-    expect(onInteraction).toHaveBeenCalledTimes(1);
-
-    act(()=>vi.advanceTimersByTime(40));
-    expect(screen.getByRole('status')).toHaveTextContent('잠깐 쉬기 · 휴식 선택을 확인했어요.');
-    expect(screen.getByRole('status')).toHaveAttribute('aria-busy','false');
+  it('keeps feedback readable and compact across scene layouts',()=>{
+    expect(interactionCss).toContain('.v14-scene-action-feedback');
+    expect(interactionCss).toContain('data-feedback-tone="success"');
+    expect(interactionCss).toContain('@media(max-width:430px)');
+    expect(interactionCss).toContain('@media(max-height:640px)');
+    expect(interactionCss).toContain('env(safe-area-inset-bottom)');
   });
 });

--- a/src/scene/scene-action-feedback.test.tsx
+++ b/src/scene/scene-action-feedback.test.tsx
@@ -1,0 +1,62 @@
+import {act,fireEvent,render,screen} from '@testing-library/react';
+import {afterEach,describe,expect,it,vi} from 'vitest';
+import SceneStage from './SceneStage';
+import {sceneActionFeedback} from './scene-action-feedback';
+import {resolveScene} from './scene-resolver';
+import type {ResolvedSceneInteraction} from './scene-types';
+
+const restInteraction={
+  id:'bed',
+  label:'잠깐 쉬기',
+  mode:'rest',
+  anchorId:'bed',
+  enabled:true,
+  hint:'accessible-idle',
+} satisfies ResolvedSceneInteraction;
+
+afterEach(()=>{
+  vi.useRealTimers();
+});
+
+describe('V14 scene action feedback',()=>{
+  it('turns runtime phases into concise progress and result copy without game-state coupling',()=>{
+    expect(sceneActionFeedback(restInteraction,'idle')).toBeNull();
+    expect(sceneActionFeedback(restInteraction,'approaching')).toEqual({
+      message:'잠깐 쉬기 · 이동 중',
+      tone:'info',
+      busy:true,
+    });
+    expect(sceneActionFeedback(restInteraction,'committing')).toEqual({
+      message:'잠깐 쉬기 · 반영 중',
+      tone:'info',
+      busy:true,
+    });
+    expect(sceneActionFeedback(restInteraction,'presenting')).toEqual({
+      message:'잠깐 쉬기 · 휴식 선택을 확인했어요.',
+      tone:'success',
+      busy:false,
+    });
+  });
+
+  it('shows the active action as an accessible live status through the shared SceneStage',()=>{
+    vi.useFakeTimers();
+    const onInteraction=vi.fn();
+    const scene=resolveScene({year:1,month:4,week:1,location:'home'});
+    render(<SceneStage scene={scene} onInteraction={onInteraction}/>);
+
+    fireEvent.click(screen.getByRole('button',{name:'잠깐 쉬기'}));
+    expect(screen.getByRole('status')).toHaveTextContent('잠깐 쉬기 · 이동 중');
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live','polite');
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy','true');
+
+    act(()=>vi.advanceTimersByTime(220));
+    expect(screen.getByRole('status')).toHaveTextContent('잠깐 쉬기 · 진행 중');
+
+    act(()=>vi.advanceTimersByTime(180));
+    expect(onInteraction).toHaveBeenCalledTimes(1);
+
+    act(()=>vi.advanceTimersByTime(40));
+    expect(screen.getByRole('status')).toHaveTextContent('잠깐 쉬기 · 휴식 선택을 확인했어요.');
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy','false');
+  });
+});

--- a/src/scene/scene-action-feedback.ts
+++ b/src/scene/scene-action-feedback.ts
@@ -1,0 +1,36 @@
+import type {SceneRuntimePhase} from './scene-runtime';
+import type {InteractionMode,ResolvedSceneInteraction} from './scene-types';
+
+export type SceneActionFeedbackTone='info'|'success';
+
+export interface SceneActionFeedback{
+  message:string;
+  tone:SceneActionFeedbackTone;
+  busy:boolean;
+}
+
+const resultMessage:Record<InteractionMode,string>={
+  dialogue:'대화를 열었어요.',
+  inspect:'확인했어요.',
+  collect:'수집 결과를 확인했어요.',
+  travel:'이동을 시작했어요.',
+  rest:'휴식 선택을 확인했어요.',
+  shop:'상점을 열었어요.',
+  training:'훈련을 시작했어요.',
+  choice:'선택을 반영했어요.',
+  minigame:'활동을 시작했어요.',
+  explore:'탐험 선택을 반영했어요.',
+  battle:'전투를 시작했어요.',
+  reward:'보상을 확인했어요.',
+};
+
+export function sceneActionFeedback(
+  interaction:ResolvedSceneInteraction|undefined,
+  phase:SceneRuntimePhase,
+):SceneActionFeedback|null{
+  if(!interaction||phase==='idle') return null;
+  if(phase==='approaching') return {message:`${interaction.label} · 이동 중`,tone:'info',busy:true};
+  if(phase==='acting') return {message:`${interaction.label} · 진행 중`,tone:'info',busy:true};
+  if(phase==='committing') return {message:`${interaction.label} · 반영 중`,tone:'info',busy:true};
+  return {message:`${interaction.label} · ${resultMessage[interaction.mode]}`,tone:'success',busy:false};
+}

--- a/src/scene/scene-interaction.css
+++ b/src/scene/scene-interaction.css
@@ -136,6 +136,52 @@
 .v14-scene-stage[data-interaction-skin="expedition-tactical"] .v14-scene-object__marker,
 .v14-scene-stage[data-interaction-skin="expedition-debrief"] .v14-scene-object__marker{border-radius:7px;background:linear-gradient(180deg,rgba(74,63,50,.97),rgba(37,37,37,.98));box-shadow:0 4px 0 rgba(28,28,27,.38),0 8px 16px rgba(0,0,0,.3)}
 
+.v14-scene-action-feedback{
+  position:absolute;
+  left:50%;
+  bottom:max(13%,calc(env(safe-area-inset-bottom) + 18px));
+  z-index:52;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+  width:max-content;
+  max-width:min(86%,420px);
+  min-height:34px;
+  padding:7px 12px;
+  transform:translateX(-50%);
+  border:1px solid rgba(213,226,241,.58);
+  border-radius:999px;
+  background:rgba(14,22,34,.9);
+  box-shadow:0 7px 20px rgba(0,0,0,.32);
+  color:#f5f8fc;
+  font-size:12px;
+  font-weight:800;
+  line-height:1.25;
+  text-align:center;
+  word-break:keep-all;
+  overflow-wrap:anywhere;
+  pointer-events:none;
+  backdrop-filter:blur(8px);
+}
+.v14-scene-action-feedback__indicator{
+  flex:0 0 auto;
+  width:7px;
+  height:7px;
+  border-radius:50%;
+  background:#b9d8f4;
+  box-shadow:0 0 0 3px rgba(132,184,228,.16);
+}
+.v14-scene-action-feedback[data-feedback-tone="success"]{
+  border-color:rgba(171,229,187,.68);
+  background:rgba(20,52,39,.92);
+  color:#effff3;
+}
+.v14-scene-action-feedback[data-feedback-tone="success"] .v14-scene-action-feedback__indicator{
+  background:#9ce0af;
+  box-shadow:0 0 0 3px rgba(102,196,129,.18);
+}
+
 .lh-living-scene .v14-scene-object__label{font-size:10px;max-width:118px;padding:4px 6px}
 
 @keyframes v14-scene-affordance-pulse{0%,100%{filter:brightness(1)}50%{filter:brightness(1.11)}}
@@ -149,12 +195,14 @@
   .v14-scene-object__marker::before{font-size:18px}
   .v14-scene-object__label{top:calc(100% + 3px);max-width:min(34vw,132px);padding:4px 6px;font-size:10px}
   .v14-scene-object__badge{right:-8px;top:-7px;min-width:24px;padding:2px 4px;font-size:8px}
+  .v14-scene-action-feedback{bottom:max(11%,calc(env(safe-area-inset-bottom) + 14px));max-width:88%;min-height:32px;padding:6px 10px;font-size:11px}
   .lh-living-scene .v14-scene-object__label{max-width:94px;font-size:9px}
 }
 
 @media(max-height:640px){
   .v14-scene-object__label{top:calc(100% + 2px);max-width:122px;padding:3px 5px;font-size:9px}
   .v14-scene-object__badge{top:-6px}
+  .v14-scene-action-feedback{bottom:max(9%,calc(env(safe-area-inset-bottom) + 10px));max-width:82%;min-height:28px;padding:5px 9px;font-size:10px}
 }
 
 @media(prefers-reduced-motion:reduce){


### PR DESCRIPTION
## V14 Scene Action Feedback UX

### Goal
Make every shared SceneStage interaction immediately legible while its existing runtime moves through approach → action → commit → presentation.

### Scope
- add a presentation-only action feedback model derived from existing interaction metadata + SceneRuntime phase
- expose concise Korean progress/result copy in an accessible live status
- preserve existing SceneDirector commit ownership and game callbacks
- preserve visual phase feedback; no rewards, progression, economy, save schema, or route rules change
- keep shared/mobile behavior data-driven and low-maintenance

### TDD
RED head `f3cb75ed956490897b9de6d22586b51f1189047f` intentionally requires the missing feedback helper + SceneStage live status before implementation.
